### PR TITLE
Scaffold dispatcher-driven web backend skeleton

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,10 +2,10 @@
 [workspace]
 members = [
     "core",
-    "kit", 
+    "kit",
     "components/*",
     "utils/*",
-    # "backends/web",
+    "backends/web",
     "render_utils",
     # "plugins/i18n", We need more thoughtful design about i18n...
     "window",

--- a/backends/web/Cargo.toml
+++ b/backends/web/Cargo.toml
@@ -1,0 +1,38 @@
+[package]
+name = "waterui-web"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "Web/WASM backend for the WaterUI framework"
+rust-version.workspace = true
+
+[lib]
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+waterui-core.workspace = true
+waterui-render-utils.workspace = true
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen = "0.2"
+wasm-bindgen-futures = "0.4"
+web-sys = { version = "0.3", features = [
+    "console",
+    "Document",
+    "Element",
+    "Event",
+    "EventTarget",
+    "HtmlButtonElement",
+    "HtmlElement",
+    "Node",
+    "Window"
+] }
+js-sys = "0.3"
+
+[features]
+default = []
+
+[lints]
+workspace = true

--- a/backends/web/IMPLEMENTATION_STATUS.md
+++ b/backends/web/IMPLEMENTATION_STATUS.md
@@ -1,0 +1,75 @@
+# Web Backend Implementation Status
+
+This document tracks how the experimental web backend maps the Rust APIs exported by
+WaterUI onto browser primitives. Status values:
+
+- **✅ complete** – Behaviour matches the Rust contract in day-to-day scenarios.
+- **⚠️ partial** – Some scaffolding exists, but important behaviour is stubbed or missing.
+- **❌ missing** – No meaningful implementation yet.
+
+> File references use the sources under `backends/web/src` unless noted otherwise.
+
+## Core Infrastructure
+
+| Rust Feature | Web Status | Notes |
+| --- | --- | --- |
+| Workspace registration / cargo integration | ✅ complete | `Cargo.toml` exposes the crate with optional `wasm32` tooling. |
+| DOM bootstrap (`waterui_app` equivalent) | ⚠️ partial | `WebApp` locates a root element, injects default styles, and mounts a surface, but dispatcher handlers still terminate in `todo!()`. |
+| Environment lifecycle (`Environment` ownership) | ⚠️ partial | `WebApp` owns an `Environment`, yet no browser-specific resources are attached or torn down. |
+| `AnyView` rendering entry point | ❌ missing | `WebRenderer::render` forwards to a dispatcher whose first handler still calls `todo!("Render text views")`. |
+| Fine-grained reactivity dispatcher | ⚠️ partial | The dispatcher from `waterui_render_utils` is registered, but only a text route stub exists. |
+
+## Layout
+
+| Rust Feature | Web Status | Notes |
+| --- | --- | --- |
+| Container/layout trait bridging | ❌ missing | No DOM translation for layout trait objects yet. |
+| Scroll/stack/grid helpers | ❌ missing | Awaiting dispatcher registrations. |
+| Spacer / padding utilities | ❌ missing | Not connected to DOM elements. |
+
+## Text & Styling
+
+| Rust Feature | Web Status | Notes |
+| --- | --- | --- |
+| Plain text (`waterui_text`) | ❌ missing | Dispatcher TODO prevents text nodes from being created. |
+| Styled strings | ❌ missing | No mapping for `StyledStr` runs. |
+| Theming / palette bindings | ❌ missing | Styling limited to embedded CSS with no reactive updates. |
+
+## Controls
+
+| Rust Feature | Web Status | Notes |
+| --- | --- | --- |
+| Button (`waterui_button`) | ❌ missing | No DOM translation has been implemented; dispatcher registration remains a `todo!()`. |
+| Input controls (text field, toggle, slider, etc.) | ❌ missing | No DOM widgets registered. |
+| Collection / dynamic views | ❌ missing | Dispatcher has no array or dynamic handlers. |
+
+## Navigation & Presentation
+
+| Rust Feature | Web Status | Notes |
+| --- | --- | --- |
+| Navigation stack / links | ❌ missing | No browser navigation integration. |
+| Overlays / dialogs | ❌ missing | Awaiting design. |
+| Alerts / sheets | ❌ missing | Not implemented. |
+
+## Media & Graphics
+
+| Rust Feature | Web Status | Notes |
+| --- | --- | --- |
+| Color view (`waterui_color`) | ❌ missing | CSS variables not wired. |
+| Image / video surfaces | ❌ missing | No HTML media elements registered. |
+| Canvas / drawing APIs | ❌ missing | No `canvas` integration. |
+
+## Miscellaneous
+
+| Rust Feature | Web Status | Notes |
+| --- | --- | --- |
+| Asset pipeline (CSS/JS bundling) | ⚠️ partial | `styles/default.css` is embedded at compile time; external asset story undefined. |
+| Testing (`wasm-bindgen-test`) | ❌ missing | No automated tests configured. |
+| Error reporting / logging | ⚠️ partial | `WebError` captures basic DOM failures, but there is no logging bridge. |
+
+## Summary
+
+The web backend currently provides mounting scaffolding, DOM helpers, and a dispatcher
+hook, but all real rendering work is still TODO. The next milestones involve teaching the
+dispatcher how to translate core views (text, button, layout containers) into real DOM
+nodes and wiring browser events into WaterUI's fine-grained reactivity model.

--- a/backends/web/README.md
+++ b/backends/web/README.md
@@ -1,0 +1,67 @@
+# WaterUI Web Backend
+
+This crate hosts the experimental WebAssembly backend for WaterUI. The goal is to provide a
+browser-native renderer that consumes `waterui-core` view trees and produces HTML + CSS updates.
+The current implementation focuses on scaffolding:
+
+- ✅ Rust crate configured for `wasm32-unknown-unknown`
+- ✅ DOM bootstrapping with automatic stylesheet injection
+- ✅ Pretty default styling using standard web components (buttons, headings, paragraphs)
+- ✅ `WebApp` entry point mirrored after the Swift backend's modular design
+- 🔄 TODO: dispatcher registrations that translate `AnyView` nodes into DOM elements (current handlers end with `todo!()`)
+- 🔄 TODO: event propagation and reactive state reconciliation
+
+## Building
+
+Ensure the `wasm32-unknown-unknown` target is installed:
+
+```bash
+rustup target add wasm32-unknown-unknown
+```
+
+You can build the crate directly using Cargo:
+
+```bash
+cargo build -p waterui-web --target wasm32-unknown-unknown
+```
+
+For browser integration with bundlers, `wasm-pack` offers a convenient workflow:
+
+```bash
+wasm-pack build backends/web --target web
+```
+
+## Usage
+
+The generated WASM module exposes a `WebApp` type. From JavaScript you can mount the application
+like so:
+
+```javascript
+import init, { WebApp } from "./pkg/waterui_web.js";
+
+async function bootstrap() {
+  await init();
+  const app = new WebApp();
+  await app.wasm_mount();
+}
+
+bootstrap();
+```
+
+By default the renderer will create a host `<div>` when no root id is supplied. To mount into an
+existing element, call `WebAppBuilder::new().with_root_id("app-root")` from Rust before exporting
+the instance.
+
+## Project Layout
+
+- `src/app.rs`: Entry point and builder responsible for managing the `Environment` and renderer.
+- `src/dom.rs`: Thin wrappers around `web_sys` to simplify DOM mutation and stylesheet injection.
+- `src/renderer.rs`: Dispatcher-driven rendering surface that currently ends with explicit
+  `todo!()` placeholders for each view type.
+- `styles/default.css`: Standalone stylesheet bundled via `include_str!` and injected during
+  mounting to provide a pleasant baseline for native web controls.
+- `IMPLEMENTATION_STATUS.md`: Detailed tracker mirroring other backends and documenting which
+  dispatcher routes still need to be implemented.
+
+Please update this document as the backend evolves (e.g., once the dispatcher can render core
+widgets and browser events feed back into WaterUI's fine-grained reactivity).

--- a/backends/web/src/app.rs
+++ b/backends/web/src/app.rs
@@ -1,0 +1,125 @@
+use waterui_core::{AnyView, Environment};
+
+use crate::{dom::DomRoot, error::WebError, renderer::WebRenderer};
+
+/// Builder for [`WebApp`].
+#[derive(Debug, Default, Clone)]
+pub struct WebAppBuilder {
+    root_id: Option<String>,
+    inject_default_styles: bool,
+}
+
+impl WebAppBuilder {
+    /// Creates a new builder with default configuration.
+    #[must_use]
+    pub const fn new() -> Self {
+        Self {
+            root_id: None,
+            inject_default_styles: true,
+        }
+    }
+
+    /// Sets the DOM element identifier that should host the application.
+    #[must_use]
+    pub fn with_root_id(mut self, id: impl Into<String>) -> Self {
+        self.root_id = Some(id.into());
+        self
+    }
+
+    /// Controls whether the backend injects the default WaterUI stylesheet.
+    #[must_use]
+    pub fn inject_default_styles(mut self, inject: bool) -> Self {
+        self.inject_default_styles = inject;
+        self
+    }
+
+    /// Finalises the builder and creates a [`WebApp`].
+    pub fn build(self) -> Result<WebApp, WebError> {
+        WebApp::new_with_options(self)
+    }
+}
+
+impl From<WebAppBuilder> for WebApp {
+    fn from(value: WebAppBuilder) -> Self {
+        value
+            .build()
+            .expect("WebAppBuilder::build should succeed when used in wasm32 targets")
+    }
+}
+
+/// Entry point for running WaterUI inside the browser.
+#[derive(Debug)]
+pub struct WebApp {
+    environment: Environment,
+    renderer: WebRenderer,
+}
+
+impl WebApp {
+    /// Creates a new [`WebApp`] using the default configuration.
+    pub fn new() -> Result<Self, WebError> {
+        Self::new_with_options(WebAppBuilder::new())
+    }
+
+    fn new_with_options(builder: WebAppBuilder) -> Result<Self, WebError> {
+        let dom_root = DomRoot::new(builder.root_id.as_deref(), builder.inject_default_styles)?;
+        let renderer = WebRenderer::new(dom_root);
+        Ok(Self {
+            environment: Environment::new(),
+            renderer,
+        })
+    }
+
+    /// Provides mutable access to the renderer state for advanced integrations.
+    #[must_use]
+    pub fn renderer_mut(&mut self) -> &mut WebRenderer {
+        &mut self.renderer
+    }
+
+    /// Provides access to the renderer state.
+    #[must_use]
+    pub fn renderer(&self) -> &WebRenderer {
+        &self.renderer
+    }
+
+    /// Returns a mutable reference to the underlying [`Environment`].
+    #[must_use]
+    pub fn environment_mut(&mut self) -> &mut Environment {
+        &mut self.environment
+    }
+
+    /// Returns an immutable reference to the environment.
+    #[must_use]
+    pub fn environment(&self) -> &Environment {
+        &self.environment
+    }
+
+    /// Mounts the application into the DOM, rendering a placeholder interface.
+    pub fn mount(&mut self) -> Result<(), WebError> {
+        self.renderer.mount()
+    }
+
+    /// Renders an [`AnyView`] tree. The current implementation shows a placeholder UI
+    /// until the dispatcher wiring for core components is completed.
+    pub fn render(&mut self, view: AnyView) -> Result<(), WebError> {
+        self.renderer.render(&self.environment, view)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::prelude::*;
+
+#[cfg(target_arch = "wasm32")]
+#[wasm_bindgen]
+impl WebApp {
+    /// Convenience constructor exposed to JavaScript callers.
+    #[wasm_bindgen(constructor)]
+    pub fn wasm_new() -> Result<WebApp, JsValue> {
+        Self::new().map_err(JsValue::from)
+    }
+
+    /// Mounts the application from JavaScript without requiring manual error handling.
+    #[wasm_bindgen]
+    pub fn wasm_mount(&mut self) -> Result<(), JsValue> {
+        self.mount().map_err(JsValue::from)
+    }
+}

--- a/backends/web/src/dom.rs
+++ b/backends/web/src/dom.rs
@@ -1,0 +1,154 @@
+use crate::error::WebError;
+
+#[cfg(target_arch = "wasm32")]
+use std::sync::OnceLock;
+
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen::{JsCast, JsValue};
+
+#[cfg(target_arch = "wasm32")]
+use web_sys::{Document, Element, HtmlElement, Window};
+
+#[cfg(not(target_arch = "wasm32"))]
+/// Placeholder DOM root for non-wasm targets.
+#[derive(Debug, Clone)]
+pub struct DomRoot;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone)]
+pub struct DomRoot {
+    document: Document,
+    element: Element,
+}
+
+impl DomRoot {
+    /// Creates a [`DomRoot`] pointing at the provided element id.
+    pub fn new(root_id: Option<&str>, inject_styles: bool) -> Result<Self, WebError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let _ = root_id;
+            let _ = inject_styles;
+            return Err(WebError::Unsupported);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            let window: Window = web_sys::window().ok_or(WebError::DomUnavailable)?;
+            let document: Document = window.document().ok_or(WebError::DomUnavailable)?;
+
+            if inject_styles {
+                inject_stylesheet(&document)?;
+            }
+
+            let element = if let Some(id) = root_id {
+                document
+                    .get_element_by_id(id)
+                    .ok_or_else(|| WebError::RootNotFound(id.to_string()))?
+            } else {
+                let body = document.body().ok_or(WebError::DomUnavailable)?;
+                let host = document.create_element("div")?;
+                host.set_id("waterui-web-root");
+                body.append_child(&host)?;
+                host
+            };
+
+            Ok(Self { document, element })
+        }
+    }
+
+    /// Returns the DOM element representing the mounting point.
+    #[must_use]
+    pub fn element(&self) -> &Element {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            panic!("DomRoot::element is only available on wasm32 targets");
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            &self.element
+        }
+    }
+
+    /// Returns the owning document.
+    #[must_use]
+    pub fn document(&self) -> &Document {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            panic!("DomRoot::document is only available on wasm32 targets");
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            &self.document
+        }
+    }
+
+    /// Clears the mounting element.
+    pub fn clear(&self) -> Result<(), WebError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            return Err(WebError::Unsupported);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            while let Some(child) = self.element.first_child() {
+                self.element.remove_child(&child)?;
+            }
+            Ok(())
+        }
+    }
+
+    /// Sets the CSS class name for the root element.
+    pub fn set_class_name(&self, class_name: &str) -> Result<(), WebError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let _ = class_name;
+            return Err(WebError::Unsupported);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.element.set_class_name(class_name);
+            Ok(())
+        }
+    }
+
+    /// Converts the element into an [`HtmlElement`].
+    #[cfg(target_arch = "wasm32")]
+    pub fn as_html_element(&self) -> Result<HtmlElement, WebError> {
+        self.element
+            .clone()
+            .dyn_into::<HtmlElement>()
+            .map_err(WebError::from)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn inject_stylesheet(document: &Document) -> Result<(), WebError> {
+    static STYLE_CACHE: OnceLock<()> = OnceLock::new();
+
+    if document.get_element_by_id("waterui-web-styles").is_some() {
+        return Ok(());
+    }
+
+    STYLE_CACHE
+        .get_or_try_init(|| {
+            let style = document.create_element("style")?;
+            style.set_id("waterui-web-styles");
+            style.set_attribute("data-waterui", "true")?;
+            style.set_inner_html(include_str!("../styles/default.css"));
+
+            if let Some(head) = document.head() {
+                head.append_child(&style)?;
+            } else if let Some(body) = document.body() {
+                body.prepend_with_node_1(&style)?;
+            } else {
+                return Err(WebError::DomUnavailable);
+            }
+
+            Ok(())
+        })
+        .map(|_| ())
+}

--- a/backends/web/src/error.rs
+++ b/backends/web/src/error.rs
@@ -1,0 +1,52 @@
+use core::fmt;
+
+/// Error type produced by the web backend.
+#[derive(Debug, Clone)]
+pub enum WebError {
+    /// The DOM APIs are not accessible (e.g., when executed outside of a browser).
+    DomUnavailable,
+    /// The requested mounting node cannot be located.
+    RootNotFound(String),
+    /// The feature is currently unsupported on the active target.
+    Unsupported,
+    /// Wrapper around JavaScript exceptions.
+    Js(String),
+}
+
+impl fmt::Display for WebError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::DomUnavailable => write!(f, "DOM is not available"),
+            Self::RootNotFound(id) => write!(f, "Failed to find DOM element with id `{id}`"),
+            Self::Unsupported => write!(f, "WaterUI web backend requires the wasm32 target"),
+            Self::Js(msg) => write!(f, "JavaScript error: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for WebError {}
+
+#[cfg(target_arch = "wasm32")]
+impl From<wasm_bindgen::JsValue> for WebError {
+    fn from(value: wasm_bindgen::JsValue) -> Self {
+        if let Some(string) = value.as_string() {
+            Self::Js(string)
+        } else {
+            Self::Js(format!("{value:?}"))
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+impl From<WebError> for wasm_bindgen::JsValue {
+    fn from(value: WebError) -> Self {
+        match value {
+            WebError::Js(msg) => Self::from(msg),
+            WebError::DomUnavailable => Self::from("DOM is not available"),
+            WebError::RootNotFound(id) => {
+                Self::from(format!("Failed to find DOM element with id `{id}`"))
+            }
+            WebError::Unsupported => Self::from("WaterUI web backend requires the wasm32 target"),
+        }
+    }
+}

--- a/backends/web/src/lib.rs
+++ b/backends/web/src/lib.rs
@@ -1,0 +1,23 @@
+#![warn(missing_docs)]
+#![warn(clippy::pedantic)]
+#![allow(clippy::module_name_repetitions)]
+
+//! Web/WASM backend for the WaterUI framework.
+//!
+//! This crate hosts the browser renderer prototype. It provides a high-level [`WebApp`]
+//! entry point that is responsible for bootstrapping the DOM, injecting the default
+//! WaterUI styles, and rendering [`waterui_core::View`] trees into HTML nodes.
+//!
+//! The current implementation focuses on the plumbing required to run inside
+//! `wasm32-unknown-unknown` targets. Rendering logic is intentionally minimal and
+//! routes every view through a dispatcher that currently terminates with
+//! `todo!()` placeholders.
+
+mod app;
+mod dom;
+mod error;
+mod renderer;
+
+pub use app::{WebApp, WebAppBuilder};
+pub use error::WebError;
+pub use renderer::{WebRenderer, WebRendererState};

--- a/backends/web/src/renderer.rs
+++ b/backends/web/src/renderer.rs
@@ -1,0 +1,137 @@
+use crate::{dom::DomRoot, error::WebError};
+use waterui_core::{AnyView, Environment};
+
+#[cfg(target_arch = "wasm32")]
+use waterui_core::Str;
+
+#[cfg(target_arch = "wasm32")]
+use waterui_render_utils::ViewDispatcher;
+
+#[cfg(target_arch = "wasm32")]
+use web_sys::{Document, Element};
+
+/// Internal state machine for the web renderer.
+#[derive(Debug, Default, Clone, Copy)]
+pub enum WebRendererState {
+    /// The renderer has been created but not mounted to the DOM yet.
+    #[default]
+    Initialising,
+    /// The renderer has mounted its root container into the DOM.
+    Mounted,
+}
+
+/// Responsible for routing WaterUI views through the dispatcher and producing DOM updates.
+#[derive(Debug)]
+pub struct WebRenderer {
+    root: DomRoot,
+    state: WebRendererState,
+    #[cfg(target_arch = "wasm32")]
+    dispatcher: ViewDispatcher<DispatcherState, RenderContext, Result<(), WebError>>,
+}
+
+impl WebRenderer {
+    /// Creates a new renderer instance bound to the provided DOM root.
+    #[must_use]
+    pub fn new(root: DomRoot) -> Self {
+        Self {
+            root,
+            state: WebRendererState::Initialising,
+            #[cfg(target_arch = "wasm32")]
+            dispatcher: initialise_dispatcher(),
+        }
+    }
+
+    /// Returns the current renderer state.
+    #[must_use]
+    pub const fn state(&self) -> WebRendererState {
+        self.state
+    }
+
+    /// Mounts the renderer, preparing the DOM for updates.
+    pub fn mount(&mut self) -> Result<(), WebError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let _ = self;
+            return Err(WebError::Unsupported);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.root.set_class_name("waterui-web-root")?;
+            self.root.clear()?;
+            self.state = WebRendererState::Mounted;
+            Ok(())
+        }
+    }
+
+    /// Renders the provided [`AnyView`]. The current implementation paints a placeholder UI
+    /// until the dispatcher learns how to translate core views into DOM nodes.
+    pub fn render(&mut self, _environment: &Environment, view: AnyView) -> Result<(), WebError> {
+        #[cfg(not(target_arch = "wasm32"))]
+        {
+            let _ = _environment;
+            let _ = view;
+            return Err(WebError::Unsupported);
+        }
+
+        #[cfg(target_arch = "wasm32")]
+        {
+            self.root.set_class_name("waterui-web-root")?;
+            self.root.clear()?;
+
+            let document = self.root.document();
+
+            let surface = document.create_element("section")?;
+            surface.set_class_name("waterui-surface");
+            self.root.element().append_child(&surface)?;
+
+            let context = RenderContext::new(document.clone(), surface);
+            self.dispatcher.dispatch_any(view, _environment, context)
+        }
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Default)]
+struct DispatcherState;
+
+#[cfg(target_arch = "wasm32")]
+#[derive(Debug, Clone)]
+struct RenderContext {
+    document: Document,
+    parent: Element,
+}
+
+#[cfg(target_arch = "wasm32")]
+impl RenderContext {
+    fn new(document: Document, parent: Element) -> Self {
+        Self { document, parent }
+    }
+
+    #[allow(dead_code)]
+    fn document(&self) -> &Document {
+        &self.document
+    }
+
+    #[allow(dead_code)]
+    fn parent(&self) -> &Element {
+        &self.parent
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn initialise_dispatcher() -> ViewDispatcher<DispatcherState, RenderContext, Result<(), WebError>> {
+    let mut dispatcher = ViewDispatcher::default();
+    dispatcher.register(|state, context, view: Str, _env| {
+        let _ = state;
+        let _ = context;
+        let _ = view;
+        todo!("Render text views into DOM nodes");
+    });
+    dispatcher.register(|state, context, _view: (), _env| {
+        let _ = state;
+        let _ = context;
+        todo!("Render unit views into DOM nodes");
+    });
+    dispatcher
+}

--- a/backends/web/styles/default.css
+++ b/backends/web/styles/default.css
@@ -1,0 +1,78 @@
+:root {
+    color-scheme: light dark;
+    font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+    background-color: #f5f7fb;
+    color: #101828;
+}
+
+body {
+    margin: 0;
+    min-height: 100vh;
+    background: linear-gradient(180deg, rgba(15, 76, 129, 0.08) 0%, rgba(15, 76, 129, 0.02) 100%);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.waterui-web-root {
+    width: 100%;
+    max-width: 960px;
+    padding: 48px;
+    box-sizing: border-box;
+}
+
+.waterui-surface,
+.waterui-demo {
+    background-color: rgba(255, 255, 255, 0.85);
+    border-radius: 24px;
+    box-shadow: 0 24px 48px rgba(15, 76, 129, 0.12);
+    padding: 40px;
+    backdrop-filter: blur(12px);
+}
+
+.waterui-heading,
+.waterui-demo__title {
+    margin: 0 0 16px;
+    font-size: 2.25rem;
+    font-weight: 700;
+    letter-spacing: -0.02em;
+}
+
+.waterui-body,
+.waterui-demo__description {
+    margin: 0 0 24px;
+    font-size: 1rem;
+    line-height: 1.6;
+    color: rgba(16, 24, 40, 0.72);
+}
+
+.waterui-button {
+    appearance: none;
+    border: none;
+    border-radius: 999px;
+    padding: 14px 28px;
+    font-size: 1rem;
+    font-weight: 600;
+    color: white;
+    background: linear-gradient(135deg, #2563eb 0%, #4f46e5 100%);
+    box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
+    cursor: pointer;
+    transition: transform 120ms ease, box-shadow 120ms ease;
+}
+
+.waterui-button:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 18px 32px rgba(37, 99, 235, 0.3);
+}
+
+.waterui-button:active {
+    transform: translateY(0);
+    box-shadow: 0 6px 18px rgba(37, 99, 235, 0.2);
+}
+
+.waterui-demo__status {
+    display: inline-block;
+    margin-left: 16px;
+    font-size: 0.95rem;
+    color: rgba(16, 24, 40, 0.7);
+}


### PR DESCRIPTION
## Summary
- add the experimental `waterui-web` crate with the `WebApp` entry point, DOM helpers, error type, and dispatcher-driven renderer that currently ends in `todo!()` stubs
- embed a default stylesheet, implementation status tracker, and README guidance so the WASM backend mirrors the other platforms' documentation patterns
- document the project layout in the web backend README to orient contributors toward the renderer, DOM utilities, and status tracker

## Testing
- cargo check
