### PR TITLE
Refactor CLI toolchain checks and interactive doctor

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -36,6 +36,7 @@ tokio = { version = "1.41.1", features = ["rt", "net", "sync", "macros"] }
 hyper = { version = "1.4.1", features = ["http1", "server"] }
 hyper-util = { version = "0.1.5", features = ["server", "tokio"] }
 hyper-staticfile = "0.10.0"
+indexmap = "2.6.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 which = "8.0.0"

--- a/cli/src/doctor.rs
+++ b/cli/src/doctor.rs
@@ -1,11 +1,11 @@
 use clap::Args;
-use color_eyre::eyre::{Result, eyre};
+use color_eyre::eyre::Result;
 use console::style;
 use core::time::Duration;
 use dialoguer::Confirm;
 use indicatif::{ProgressBar, ProgressStyle};
-use std::collections::HashSet;
-use std::process::Command;
+
+use crate::toolchain::{self, CheckMode, CheckTarget, FixMode, Section};
 
 #[derive(Args, Debug, Default)]
 pub struct DoctorArgs {
@@ -26,44 +26,27 @@ pub fn run(args: DoctorArgs) -> Result<()> {
     pb.set_message(style("Preparing environment checks…").dim().to_string());
     pb.tick();
 
-    let include_swift = cfg!(target_os = "macos");
-    let total = 2 + usize::from(include_swift);
+    let targets = doctor_targets();
+    let total = targets.len();
     let mut sections = Vec::new();
     let mut fixes = Vec::new();
-    let mut step = 1;
 
-    pb.set_message(progress_label(step, total, "Rust toolchain"));
-    pb.tick();
-    let rust = check_rust();
-    announce_section(&pb, step, total, rust.section());
-    let (rust_section, mut rust_fixes) = rust.into_parts();
-    sections.push(rust_section);
-    fixes.append(&mut rust_fixes);
-    step += 1;
-
-    if include_swift {
-        pb.set_message(progress_label(step, total, "Swift toolchain"));
+    for (index, target) in targets.iter().enumerate() {
+        let step = index + 1;
+        pb.set_message(progress_label(step, total, target.label()));
         pb.tick();
-        if let Some(swift) = check_swift() {
-            announce_section(&pb, step, total, swift.section());
-            let (swift_section, mut swift_fixes) = swift.into_parts();
-            sections.push(swift_section);
-            fixes.append(&mut swift_fixes);
-        }
-        step += 1;
-    }
 
-    pb.set_message(progress_label(step, total, "Android tooling"));
-    pb.tick();
-    let android = check_android();
-    announce_section(&pb, step, total, android.section());
-    let (android_section, mut android_fixes) = android.into_parts();
-    sections.push(android_section);
-    fixes.append(&mut android_fixes);
+        if let Some(outcome) = toolchain::perform_check(CheckMode::Full, *target) {
+            announce_section(&pb, step, total, outcome.section());
+            let (section, mut section_fixes) = outcome.into_parts();
+            sections.push(section);
+            fixes.append(&mut section_fixes);
+        }
+    }
 
     pb.finish_and_clear();
 
-    let has_failures = sections.iter().any(|section| section.has_failure());
+    let has_failures = sections.iter().any(Section::has_failure);
 
     println!("{}", style("WaterUI doctor report").bold().underlined());
     for (index, section) in sections.iter().enumerate() {
@@ -82,18 +65,52 @@ pub fn run(args: DoctorArgs) -> Result<()> {
         style("Resolve ⚠ or ✘ entries to keep your toolchain healthy.").dim()
     );
 
-    if has_failures && !args.fix {
+    let mut fix_mode = None;
+
+    if has_failures {
+        let requested = if args.fix {
+            true
+        } else {
+            println!();
+            Confirm::new()
+                .with_prompt("Critical issues detected. Apply automatic fixes now?")
+                .default(true)
+                .interact()?
+        };
+
+        if requested {
+            fix_mode = Some(if args.fix {
+                FixMode::Automatic
+            } else {
+                FixMode::Interactive
+            });
+        } else if !args.fix {
+            println!(
+                "{}",
+                style("Tip: run `water doctor --fix` to attempt automatic repairs.").yellow()
+            );
+        }
+    } else if args.fix {
         println!(
             "{}",
-            style("Tip: run `water doctor --fix` to attempt automatic repairs.").yellow()
+            style("All required checks already pass. Nothing to fix.").green()
         );
     }
 
-    if args.fix {
-        apply_fixes(fixes)?;
+    if let Some(mode) = fix_mode {
+        toolchain::apply_fixes(fixes, mode)?;
     }
 
     Ok(())
+}
+
+fn doctor_targets() -> Vec<CheckTarget> {
+    let mut targets = vec![CheckTarget::Rust];
+    if cfg!(target_os = "macos") {
+        targets.push(CheckTarget::Swift);
+    }
+    targets.push(CheckTarget::Android);
+    targets
 }
 
 fn announce_section(pb: &ProgressBar, step: usize, total: usize, section: &Section) {
@@ -111,803 +128,4 @@ fn progress_label(step: usize, total: usize, message: &str) -> String {
         style(format!("[{step}/{total}]")).dim(),
         style(message).bold()
     )
-}
-
-fn check_rust() -> SectionOutcome {
-    let mut outcome = SectionOutcome::new("Rust toolchain");
-
-    outcome.push_outcome(check_command(
-        "cargo",
-        "Install Rust from https://rustup.rs",
-    ));
-    outcome.push_outcome(check_command(
-        "rustup",
-        "Install Rust from https://rustup.rs",
-    ));
-
-    if which::which("rustup").is_ok() {
-        outcome.push(Row::info("Installed Rust targets"));
-
-        let output = Command::new("rustup")
-            .args(["target", "list", "--installed"])
-            .output();
-
-        match output {
-            Ok(output) => {
-                let installed_targets = String::from_utf8_lossy(&output.stdout);
-
-                if cfg!(target_os = "macos") {
-                    outcome.push(Row::info("Apple platforms").with_indent(1));
-                    if cfg!(target_arch = "aarch64") {
-                        let required = [
-                            (
-                                "aarch64-apple-darwin",
-                                "Required for macOS builds on Apple Silicon",
-                            ),
-                            (
-                                "aarch64-apple-ios-sim",
-                                "Required for Apple Silicon iOS Simulator",
-                            ),
-                        ];
-                        for (target, note) in required {
-                            outcome.push_outcome(target_row(
-                                &installed_targets,
-                                target,
-                                TargetKind::Required { note: Some(note) },
-                            ));
-                        }
-                        let optional = [
-                            ("aarch64-apple-ios", "for deploying to physical iOS devices"),
-                            (
-                                "x86_64-apple-darwin",
-                                "for building macOS binaries for Intel Macs",
-                            ),
-                            ("x86_64-apple-ios", "for Intel-based iOS Simulator support"),
-                        ];
-                        for (target, reason) in optional {
-                            outcome.push_outcome(target_row(
-                                &installed_targets,
-                                target,
-                                TargetKind::Optional(reason),
-                            ));
-                        }
-                    } else if cfg!(target_arch = "x86_64") {
-                        let required = [
-                            ("x86_64-apple-darwin", "Required for macOS builds on Intel"),
-                            ("x86_64-apple-ios", "Required for Intel iOS Simulator"),
-                        ];
-                        for (target, note) in required {
-                            outcome.push_outcome(target_row(
-                                &installed_targets,
-                                target,
-                                TargetKind::Required { note: Some(note) },
-                            ));
-                        }
-                        let optional = [
-                            (
-                                "aarch64-apple-darwin",
-                                "for building macOS binaries for Apple Silicon",
-                            ),
-                            (
-                                "aarch64-apple-ios",
-                                "for deploying to Apple Silicon iOS devices",
-                            ),
-                            (
-                                "aarch64-apple-ios-sim",
-                                "for Apple Silicon iOS Simulator compatibility",
-                            ),
-                        ];
-                        for (target, reason) in optional {
-                            outcome.push_outcome(target_row(
-                                &installed_targets,
-                                target,
-                                TargetKind::Optional(reason),
-                            ));
-                        }
-                    }
-                }
-
-                outcome.push(Row::info("Android targets").with_indent(1));
-                if cfg!(target_arch = "aarch64") {
-                    outcome.push_outcome(target_row(
-                        &installed_targets,
-                        "aarch64-linux-android",
-                        TargetKind::Required {
-                            note: Some("Required for Android emulator on Apple Silicon"),
-                        },
-                    ));
-                    let optional = [
-                        ("armv7-linux-androideabi", "for legacy Android (armv7)"),
-                        ("i686-linux-android", "for Android x86 emulators"),
-                        ("x86_64-linux-android", "for Android x86_64 emulators"),
-                    ];
-                    for (target, reason) in optional {
-                        outcome.push_outcome(target_row(
-                            &installed_targets,
-                            target,
-                            TargetKind::Optional(reason),
-                        ));
-                    }
-                } else if cfg!(target_arch = "x86_64") {
-                    outcome.push_outcome(target_row(
-                        &installed_targets,
-                        "x86_64-linux-android",
-                        TargetKind::Required {
-                            note: Some("Required for Android emulator on Intel"),
-                        },
-                    ));
-                    let optional = [
-                        ("aarch64-linux-android", "for Android devices (arm64)"),
-                        ("armv7-linux-androideabi", "for legacy Android (armv7)"),
-                        ("i686-linux-android", "for Android x86 emulators"),
-                    ];
-                    for (target, reason) in optional {
-                        outcome.push_outcome(target_row(
-                            &installed_targets,
-                            target,
-                            TargetKind::Optional(reason),
-                        ));
-                    }
-                } else {
-                    let optional = [
-                        ("aarch64-linux-android", "for Android devices (arm64)"),
-                        ("armv7-linux-androideabi", "for legacy Android (armv7)"),
-                        ("i686-linux-android", "for Android x86 emulators"),
-                        ("x86_64-linux-android", "for Android x86_64 emulators"),
-                    ];
-                    for (target, reason) in optional {
-                        outcome.push_outcome(target_row(
-                            &installed_targets,
-                            target,
-                            TargetKind::Optional(reason),
-                        ));
-                    }
-                }
-            }
-            Err(err) => outcome.push(
-                Row::warn("Could not query installed Rust targets")
-                    .with_detail(format!("rustup target list --installed failed: {err}")),
-            ),
-        }
-    }
-
-    outcome.push_outcome(check_sccache_tool());
-    if let Some(mold) = check_mold_tool() {
-        outcome.push_outcome(mold);
-    }
-
-    outcome
-}
-
-pub fn check_android_prerequisites() -> Result<Vec<RowOutcome>> {
-    let mut outcomes = vec![
-        // Check for adb
-        check_command("adb", "Install Android SDK Platform-Tools and add to PATH."),
-        // Check for emulator
-        check_command(
-            "emulator",
-            "Install Android SDK command-line tools and add to PATH.",
-        ),
-    ];
-
-    // Check environment variables
-    outcomes.push(check_env_var(
-        "ANDROID_HOME",
-        "Set ANDROID_HOME to your Android SDK path.",
-    ));
-    outcomes.push(check_env_var(
-        "ANDROID_NDK_HOME",
-        "Set ANDROID_NDK_HOME to your Android NDK path.",
-    ));
-    outcomes.push(check_env_var(
-        "JAVA_HOME",
-        "Set JAVA_HOME to your JDK path (Java 17 or newer recommended).",
-    ));
-
-    // Check Java version (this part is a bit more complex as it involves running a command)
-    let java_version_cmd = if let Ok(java_home) = std::env::var("JAVA_HOME") {
-        let java_exe = std::path::Path::new(&java_home).join("bin/java");
-        if java_exe.exists() {
-            Some(Command::new(java_exe))
-        } else {
-            None
-        }
-    } else if which::which("java").is_ok() {
-        Some(Command::new("java"))
-    } else {
-        None
-    };
-
-    if let Some(mut cmd) = java_version_cmd {
-        let output = cmd.arg("-version").output();
-        match output {
-            Ok(output) => {
-                let version_info = String::from_utf8_lossy(&output.stderr);
-                if let Some(line) = version_info.lines().next() {
-                    outcomes.push(RowOutcome::new(
-                        Row::pass("Java detected").with_detail(line.trim().to_string()),
-                    ));
-                } else {
-                    outcomes.push(RowOutcome::new(Row::warn(
-                        "Could not determine Java version",
-                    )));
-                }
-            }
-            Err(err) => outcomes.push(RowOutcome::new(
-                Row::warn("Failed to read Java version")
-                    .with_detail(format!("java -version failed: {err}")),
-            )),
-        }
-    } else {
-        outcomes.push(RowOutcome::new(Row::fail(
-            "Java not found in JAVA_HOME or PATH",
-        )));
-    }
-
-    // Check for aarch64-linux-android target if on aarch64 host
-    if which::which("rustup").is_ok() {
-        let output = Command::new("rustup")
-            .args(["target", "list", "--installed"])
-            .output()?; // Use ? here to propagate errors from rustup command
-
-        let installed_targets = String::from_utf8_lossy(&output.stdout);
-
-        if cfg!(target_arch = "aarch64") {
-            outcomes.push(target_row(
-                &installed_targets,
-                "aarch64-linux-android",
-                TargetKind::Required {
-                    note: Some("Required for Android emulator on Apple Silicon"),
-                },
-            ));
-        }
-    } else {
-        outcomes.push(RowOutcome::new(Row::warn(
-            "rustup not found, cannot check Rust targets.",
-        )));
-    }
-
-    Ok(outcomes)
-}
-
-fn check_swift() -> Option<SectionOutcome> {
-    if cfg!(not(target_os = "macos")) {
-        return None;
-    }
-
-    let mut outcome = SectionOutcome::new("Swift (macOS)");
-    outcome.push_outcome(check_command(
-        "xcodebuild",
-        "Install Xcode and command line tools (xcode-select --install)",
-    ));
-    outcome.push_outcome(check_command(
-        "xcrun",
-        "Install Xcode and command line tools (xcode-select --install)",
-    ));
-    Some(outcome)
-}
-
-fn check_android() -> SectionOutcome {
-    let mut outcome = SectionOutcome::new("Android tooling");
-    let prerequisites = match check_android_prerequisites() {
-        Ok(outcomes) => outcomes,
-        Err(err) => {
-            outcome.push(
-                Row::fail("Failed to run Android prerequisites check").with_detail(err.to_string()),
-            );
-            return outcome;
-        }
-    };
-
-    for row_outcome in prerequisites {
-        outcome.push_outcome(row_outcome);
-    }
-
-    outcome
-}
-
-fn check_command(name: &str, help: &str) -> RowOutcome {
-    match which::which(name) {
-        Ok(path) => RowOutcome::new(
-            Row::pass(format!("Found `{name}`")).with_detail(path.display().to_string()),
-        ),
-        Err(_) => RowOutcome::new(Row::fail(format!("`{name}` not found")).with_detail(help)),
-    }
-}
-
-fn check_sccache_tool() -> RowOutcome {
-    match which::which("sccache") {
-        Ok(path) => RowOutcome::new(
-            Row::pass("`sccache` build cache available")
-                .with_indent(1)
-                .with_detail(path.display().to_string()),
-        ),
-        Err(_) => {
-            let detail =
-                "Install sccache to cache Rust compilation outputs. Run `cargo install sccache`.";
-            let row = Row::warn("`sccache` not installed")
-                .with_indent(1)
-                .with_detail(detail);
-            RowOutcome::with_fix(
-                row,
-                FixSuggestion::new(
-                    "tool-sccache".into(),
-                    "Install sccache build cache".into(),
-                    vec!["cargo".into(), "install".into(), "sccache".into()],
-                ),
-            )
-        }
-    }
-}
-
-fn check_mold_tool() -> Option<RowOutcome> {
-    if !cfg!(target_os = "linux") {
-        return None;
-    }
-
-    match which::which("mold") {
-        Ok(path) => Some(RowOutcome::new(
-            Row::pass("`mold` linker available")
-                .with_indent(1)
-                .with_detail(path.display().to_string()),
-        )),
-        Err(_) => {
-            let mut detail = String::from("Install mold to speed up Rust linking on Linux.");
-            if let Some((fix, hint)) = mold_fix_suggestion() {
-                if !hint.is_empty() {
-                    detail.push(' ');
-                    detail.push_str(&hint);
-                }
-                Some(RowOutcome::with_fix(
-                    Row::warn("`mold` linker not installed")
-                        .with_indent(1)
-                        .with_detail(detail),
-                    fix,
-                ))
-            } else {
-                detail
-                    .push_str(" See https://github.com/rui314/mold for installation instructions.");
-                Some(RowOutcome::new(
-                    Row::warn("`mold` linker not installed")
-                        .with_indent(1)
-                        .with_detail(detail),
-                ))
-            }
-        }
-    }
-}
-
-fn mold_fix_suggestion() -> Option<(FixSuggestion, String)> {
-    if cfg!(not(any(target_os = "linux", target_os = "macos"))) {
-        return None;
-    }
-    if which::which("apt-get").is_ok() {
-        let mut command = Vec::new();
-        if which::which("sudo").is_ok() {
-            command.push("sudo".into());
-        }
-        command.extend(
-            ["apt-get", "install", "-y", "mold"]
-                .into_iter()
-                .map(String::from),
-        );
-        let preview = command.join(" ");
-        let description = "Install mold linker via apt".to_string();
-        let fix = FixSuggestion::new("tool-mold".into(), description, command);
-        return Some((fix, format!("Try `{preview}`.")));
-    }
-
-    if which::which("dnf").is_ok() {
-        let mut command = Vec::new();
-        if which::which("sudo").is_ok() {
-            command.push("sudo".into());
-        }
-        command.extend(
-            ["dnf", "install", "-y", "mold"]
-                .into_iter()
-                .map(String::from),
-        );
-        let preview = command.join(" ");
-        let description = "Install mold linker via dnf".to_string();
-        let fix = FixSuggestion::new("tool-mold".into(), description, command);
-        return Some((fix, format!("Try `{preview}`.")));
-    }
-
-    if which::which("pacman").is_ok() {
-        let mut command = Vec::new();
-        if which::which("sudo").is_ok() {
-            command.push("sudo".into());
-        }
-        command.extend(
-            ["pacman", "-S", "--noconfirm", "mold"]
-                .into_iter()
-                .map(String::from),
-        );
-        let preview = command.join(" ");
-        let description = "Install mold linker via pacman".to_string();
-        let fix = FixSuggestion::new("tool-mold".into(), description, command);
-        return Some((fix, format!("Try `{preview}`.")));
-    }
-
-    if which::which("brew").is_ok() {
-        let mut command = Vec::new();
-        if which::which("sudo").is_ok() {
-            command.push("sudo".into());
-        }
-        command.extend(["brew", "install", "mold"].into_iter().map(String::from));
-        let preview = command.join(" ");
-        let description = "Install mold linker via Homebrew".to_string();
-        let fix = FixSuggestion::new("tool-mold".into(), description, command);
-        return Some((fix, format!("Try `{preview}`.")));
-    }
-
-    None
-}
-
-fn check_env_var(name: &str, help: &str) -> RowOutcome {
-    match std::env::var(name) {
-        Ok(value) => {
-            RowOutcome::new(Row::pass(format!("Environment `{name}` set")).with_detail(value))
-        }
-        Err(_) => {
-            let row = Row::fail(format!("Environment `{name}` missing")).with_detail(help);
-            let fix = FixSuggestion::new(
-                format!("env-var-{}", name.to_lowercase()),
-                format!("Set {} environment variable", name),
-                vec![format!("export {}=\"/path/to/your/android-ndk\"", name)], // Placeholder command
-            );
-            RowOutcome::with_fix(row, fix)
-        }
-    }
-}
-
-fn target_row(installed: &str, target: &str, kind: TargetKind) -> RowOutcome {
-    let present = installed.contains(target);
-    match kind {
-        TargetKind::Required { note } => {
-            if present {
-                RowOutcome::new(Row::pass(format!("Rust target `{target}`")).with_indent(2))
-            } else {
-                let mut detail = format!("Run `rustup target add {target}`");
-                let description = if let Some(note) = note {
-                    detail = format!("{note}. {detail}");
-                    format!("Install Rust target `{target}` ({note})")
-                } else {
-                    format!("Install Rust target `{target}`")
-                };
-                let row = Row::fail(format!("Rust target `{target}` missing"))
-                    .with_detail(detail)
-                    .with_indent(2);
-                RowOutcome::with_fix(
-                    row,
-                    FixSuggestion::new(
-                        format!("rust-target-{target}"),
-                        description,
-                        vec![
-                            "rustup".into(),
-                            "target".into(),
-                            "add".into(),
-                            target.to_string(),
-                        ],
-                    ),
-                )
-            }
-        }
-        TargetKind::Optional(reason) => {
-            if present {
-                RowOutcome::new(
-                    Row::pass(format!("Rust target `{target}`"))
-                        .with_detail(format!("Optional {reason}"))
-                        .with_indent(2),
-                )
-            } else {
-                RowOutcome::new(
-                    Row::warn(format!("Rust target `{target}` not installed"))
-                        .with_detail(format!(
-                            "Optional {reason}. Run `rustup target add {target}` if needed."
-                        ))
-                        .with_indent(2),
-                )
-            }
-        }
-    }
-}
-
-enum TargetKind {
-    Required { note: Option<&'static str> },
-    Optional(&'static str),
-}
-
-#[derive(Clone, Copy)]
-pub enum Status {
-    Pass,
-    Warn,
-    Fail,
-    Info,
-}
-
-pub struct Row {
-    pub status: Status,
-    message: String,
-    detail: Option<String>,
-    indent: usize,
-}
-
-pub struct RowOutcome {
-    pub row: Row,
-    fix: Option<FixSuggestion>,
-}
-
-impl RowOutcome {
-    fn new(row: Row) -> Self {
-        Self { row, fix: None }
-    }
-
-    fn with_fix(row: Row, fix: FixSuggestion) -> Self {
-        Self {
-            row,
-            fix: Some(fix),
-        }
-    }
-}
-
-impl Row {
-    fn pass(message: impl Into<String>) -> Self {
-        Self::new(Status::Pass, message)
-    }
-
-    fn warn(message: impl Into<String>) -> Self {
-        Self::new(Status::Warn, message)
-    }
-
-    fn fail(message: impl Into<String>) -> Self {
-        Self::new(Status::Fail, message)
-    }
-
-    fn info(message: impl Into<String>) -> Self {
-        Self::new(Status::Info, message)
-    }
-
-    fn new(status: Status, message: impl Into<String>) -> Self {
-        Self {
-            status,
-            message: message.into(),
-            detail: None,
-            indent: 0,
-        }
-    }
-
-    fn with_detail(mut self, detail: impl Into<String>) -> Self {
-        self.detail = Some(detail.into());
-        self
-    }
-
-    fn with_indent(mut self, indent: usize) -> Self {
-        self.indent = indent;
-        self
-    }
-
-    pub fn render(&self) -> Vec<String> {
-        let mut lines = Vec::new();
-        let indent = "  ".repeat(self.indent + 1);
-        let icon = match self.status {
-            Status::Pass => format!("{}", style("✔").green()),
-            Status::Warn => format!("{}", style("⚠").yellow()),
-            Status::Fail => format!("{}", style("✘").red()),
-            Status::Info => format!("{}", style("•").cyan()),
-        };
-        lines.push(format!("{indent}{icon} {}", self.message));
-        if let Some(detail) = &self.detail {
-            let detail_indent = "  ".repeat(self.indent + 2);
-            lines.push(format!("{}{}", detail_indent, style(detail).dim()));
-        }
-        lines
-    }
-
-    fn status(&self) -> Status {
-        self.status
-    }
-}
-
-struct Section {
-    title: String,
-    rows: Vec<Row>,
-}
-
-impl Section {
-    fn new(title: impl Into<String>) -> Self {
-        Self {
-            title: title.into(),
-            rows: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, row: Row) {
-        self.rows.push(row);
-    }
-
-    fn render(&self) -> Vec<String> {
-        let mut lines = Vec::new();
-        lines.push(format!(
-            "{} {}",
-            style("◈").cyan(),
-            style(&self.title).bold()
-        ));
-        for row in &self.rows {
-            lines.extend(row.render());
-        }
-        lines
-    }
-
-    fn summary_line(&self) -> String {
-        let icon = match self.overall_status() {
-            Status::Pass => style("✔").green(),
-            Status::Warn => style("⚠").yellow(),
-            Status::Fail => style("✘").red(),
-            Status::Info => style("•").cyan(),
-        };
-        format!("{} {}", icon, style(&self.title).bold())
-    }
-
-    fn overall_status(&self) -> Status {
-        if self
-            .rows
-            .iter()
-            .any(|row| matches!(row.status(), Status::Fail))
-        {
-            Status::Fail
-        } else if self
-            .rows
-            .iter()
-            .any(|row| matches!(row.status(), Status::Warn))
-        {
-            Status::Warn
-        } else if self
-            .rows
-            .iter()
-            .any(|row| matches!(row.status(), Status::Pass))
-        {
-            Status::Pass
-        } else {
-            Status::Info
-        }
-    }
-
-    fn has_failure(&self) -> bool {
-        self.rows
-            .iter()
-            .any(|row| matches!(row.status(), Status::Fail))
-    }
-}
-
-struct SectionOutcome {
-    section: Section,
-    fixes: Vec<FixSuggestion>,
-}
-
-impl SectionOutcome {
-    fn new(title: impl Into<String>) -> Self {
-        Self {
-            section: Section::new(title),
-            fixes: Vec::new(),
-        }
-    }
-
-    fn push(&mut self, row: Row) {
-        self.section.push(row);
-    }
-
-    fn push_outcome(&mut self, outcome: RowOutcome) {
-        if let Some(fix) = outcome.fix {
-            self.fixes.push(fix);
-        }
-        self.section.push(outcome.row);
-    }
-
-    fn section(&self) -> &Section {
-        &self.section
-    }
-
-    fn into_parts(self) -> (Section, Vec<FixSuggestion>) {
-        (self.section, self.fixes)
-    }
-}
-
-#[derive(Clone)]
-struct FixSuggestion {
-    id: String,
-    description: String,
-    command: Vec<String>,
-}
-
-impl FixSuggestion {
-    fn new(id: String, description: String, command: Vec<String>) -> Self {
-        Self {
-            id,
-            description,
-            command,
-        }
-    }
-
-    fn command_preview(&self) -> String {
-        self.command.join(" ")
-    }
-}
-
-fn apply_fixes(fixes: Vec<FixSuggestion>) -> Result<()> {
-    let mut seen = HashSet::new();
-    let mut unique = Vec::new();
-    for fix in fixes {
-        if seen.insert(fix.id.clone()) {
-            unique.push(fix);
-        }
-    }
-
-    if unique.is_empty() {
-        println!(
-            "{}",
-            style("All required checks are already satisfied.").green()
-        );
-        return Ok(());
-    }
-
-    println!();
-    println!("{}", style("Attempting to fix required issues").bold());
-
-    for fix in unique {
-        println!("\n{} {}", style("•").cyan(), style(&fix.description).bold());
-        println!("    {}", style(fix.command_preview()).dim());
-
-        let apply = Confirm::new()
-            .with_prompt("Apply this fix?")
-            .default(true)
-            .interact()
-            .map_err(|err| {
-                eyre!(
-                    "Unable to prompt for confirmation (is this running in an interactive terminal?): {err}"
-                )
-            })?;
-
-        if !apply {
-            println!("    {}", style("Skipped.").yellow());
-            continue;
-        }
-
-        if fix.command.is_empty() {
-            println!(
-                "    {}",
-                style("No command associated with this fix. Skipping.").yellow()
-            );
-            continue;
-        }
-
-        let mut command = Command::new(&fix.command[0]);
-        if fix.command.len() > 1 {
-            command.args(&fix.command[1..]);
-        }
-
-        match command.status() {
-            Ok(status) if status.success() => {
-                println!("    {}", style("Completed successfully.").green());
-            }
-            Ok(status) => {
-                let code = status
-                    .code()
-                    .map(|c| c.to_string())
-                    .unwrap_or_else(|| "signal".to_string());
-                println!(
-                    "    {}",
-                    style(format!("Command exited with status {code}.")).red()
-                );
-            }
-            Err(err) => {
-                println!(
-                    "    {}",
-                    style(format!("Failed to execute command: {err}")).red()
-                );
-            }
-        }
-    }
-
-    Ok(())
 }

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -9,6 +9,7 @@ mod doctor;
 mod output;
 mod package;
 mod run;
+mod toolchain;
 mod util;
 
 use clap::{Parser, Subcommand};

--- a/cli/src/run.rs
+++ b/cli/src/run.rs
@@ -14,7 +14,7 @@ use std::{
     time::{Duration, Instant},
 };
 
-use crate::doctor;
+use crate::toolchain::{self, CheckMode, CheckTarget};
 use clap::{Args, ValueEnum};
 use color_eyre::eyre::{Context, Result, bail, eyre};
 use dialoguer::{Select, theme::ColorfulTheme};
@@ -215,6 +215,25 @@ fn platform_from_device(device: &DeviceInfo) -> Result<Platform> {
     }
 }
 
+fn toolchain_targets_for_platform(platform: Platform) -> Vec<CheckTarget> {
+    let mut targets = vec![CheckTarget::Rust];
+    if matches!(
+        platform,
+        Platform::Macos
+            | Platform::Ios
+            | Platform::Ipados
+            | Platform::Watchos
+            | Platform::Tvos
+            | Platform::Visionos
+    ) {
+        targets.push(CheckTarget::Swift);
+    }
+    if platform == Platform::Android {
+        targets.push(CheckTarget::Android);
+    }
+    targets
+}
+
 fn run_platform(
     platform: Platform,
     device: Option<String>,
@@ -223,6 +242,9 @@ fn run_platform(
     release: bool,
     no_watch: bool,
 ) -> Result<()> {
+    toolchain::ensure_ready(CheckMode::Quick, &toolchain_targets_for_platform(platform))
+        .with_context(|| format!("Toolchain not ready for {:?}", platform))?;
+
     if platform == Platform::Web {
         run_web(project_dir, config, release, no_watch)?;
         return Ok(());
@@ -287,22 +309,6 @@ fn run_platform(
             }
         }
         Platform::Android => {
-            let android_prerequisites = doctor::check_android_prerequisites()?;
-            let mut has_failures = false;
-            for outcome in &android_prerequisites {
-                for line in outcome.row.render() {
-                    eprintln!("{}", line);
-                }
-                if matches!(outcome.row.status, doctor::Status::Fail) {
-                    has_failures = true;
-                }
-            }
-            if has_failures {
-                bail!(
-                    "Android environment is not set up correctly. Run `water doctor --fix` to resolve issues."
-                );
-            }
-
             if let Some(android_config) = &config.backends.android {
                 let selection = match device {
                     Some(name) => Some(resolve_android_device(&name)?),

--- a/cli/src/toolchain/mod.rs
+++ b/cli/src/toolchain/mod.rs
@@ -1,0 +1,1140 @@
+use std::{
+    env, fs,
+    path::{Path, PathBuf},
+    process::Command,
+};
+
+use color_eyre::eyre::{Context, Result, eyre};
+use console::style;
+use indexmap::IndexSet;
+use which::which;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckMode {
+    Full,
+    Quick,
+}
+
+impl CheckMode {
+    fn is_full(self) -> bool {
+        matches!(self, CheckMode::Full)
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum CheckTarget {
+    Rust,
+    Swift,
+    Android,
+}
+
+impl CheckTarget {
+    pub fn label(self) -> &'static str {
+        match self {
+            CheckTarget::Rust => "Rust toolchain",
+            CheckTarget::Swift => "Swift toolchain",
+            CheckTarget::Android => "Android tooling",
+        }
+    }
+}
+
+pub struct ToolchainReport {
+    pub sections: Vec<Section>,
+}
+
+impl ToolchainReport {
+    pub fn has_failures(&self) -> bool {
+        self.sections.iter().any(Section::has_failure)
+    }
+
+    pub fn failure_summaries(&self) -> Vec<String> {
+        self.sections
+            .iter()
+            .flat_map(Section::failure_summaries)
+            .collect()
+    }
+}
+
+pub fn run_checks(mode: CheckMode, targets: &[CheckTarget]) -> ToolchainReport {
+    let mut sections = Vec::new();
+
+    for &target in targets {
+        if let Some(outcome) = perform_check(mode, target) {
+            let (section, _) = outcome.into_parts();
+            sections.push(section);
+        }
+    }
+
+    ToolchainReport { sections }
+}
+
+pub fn ensure_ready(mode: CheckMode, targets: &[CheckTarget]) -> Result<()> {
+    let report = run_checks(mode, targets);
+    if !report.has_failures() {
+        return Ok(());
+    }
+
+    let mut message = String::from("Required toolchain components are missing:");
+    for failure in report.failure_summaries() {
+        message.push_str("\n  - ");
+        message.push_str(&failure);
+    }
+    message.push_str("\nRun `water doctor` for a full report.");
+
+    Err(eyre!(message))
+}
+
+pub fn perform_check(mode: CheckMode, target: CheckTarget) -> Option<SectionOutcome> {
+    match target {
+        CheckTarget::Rust => Some(check_rust(mode)),
+        CheckTarget::Swift => {
+            if cfg!(target_os = "macos") {
+                Some(check_swift())
+            } else {
+                None
+            }
+        }
+        CheckTarget::Android => Some(check_android(mode)),
+    }
+}
+
+pub fn apply_fixes(fixes: Vec<FixSuggestion>, mode: FixMode) -> Result<()> {
+    let mut seen = IndexSet::new();
+    let mut unique = Vec::new();
+    for fix in fixes {
+        if seen.insert(fix.id.clone()) {
+            unique.push(fix);
+        }
+    }
+
+    if unique.is_empty() {
+        println!(
+            "{}",
+            style("All required checks are already satisfied.").green()
+        );
+        return Ok(());
+    }
+
+    println!();
+    println!("{}", style("Attempting to fix required issues").bold());
+
+    for fix in unique {
+        println!(
+            "\n{} {}",
+            style("•").cyan(),
+            style(fix.description()).bold()
+        );
+        println!("    {}", style(fix.command_preview()).dim());
+
+        if !mode.should_apply_fix()? {
+            println!("    {}", style("Skipped.").yellow());
+            continue;
+        }
+
+        if fix.command.is_empty() {
+            println!(
+                "    {}",
+                style("No command associated with this fix. Skipping.").yellow()
+            );
+            continue;
+        }
+
+        let mut command = Command::new(&fix.command[0]);
+        if fix.command.len() > 1 {
+            command.args(&fix.command[1..]);
+        }
+
+        match command.status() {
+            Ok(status) if status.success() => {
+                println!("    {}", style("Completed successfully.").green());
+            }
+            Ok(status) => {
+                let code = status
+                    .code()
+                    .map(|c| c.to_string())
+                    .unwrap_or_else(|| "signal".to_string());
+                println!(
+                    "    {}",
+                    style(format!("Command exited with status {code}.")).red()
+                );
+            }
+            Err(err) => {
+                println!(
+                    "    {}",
+                    style(format!("Failed to execute command: {err}")).red()
+                );
+            }
+        }
+    }
+
+    Ok(())
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FixMode {
+    Automatic,
+    Interactive,
+}
+
+impl FixMode {
+    fn should_apply_fix(self) -> Result<bool> {
+        match self {
+            FixMode::Automatic => Ok(true),
+            FixMode::Interactive => {
+                use dialoguer::Confirm;
+                Confirm::new()
+                    .with_prompt("Apply this fix?")
+                    .default(true)
+                    .interact()
+                    .map_err(|err| {
+                        eyre!(
+                            "Unable to prompt for confirmation (is this running in an interactive terminal?): {err}"
+                        )
+                    })
+            }
+        }
+    }
+}
+
+pub struct SectionOutcome {
+    section: Section,
+    fixes: Vec<FixSuggestion>,
+}
+
+impl SectionOutcome {
+    fn new(title: impl Into<String>) -> Self {
+        Self {
+            section: Section::new(title),
+            fixes: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, row: Row) {
+        self.section.push(row);
+    }
+
+    fn push_outcome(&mut self, outcome: RowOutcome) {
+        if let Some(fix) = outcome.fix {
+            self.fixes.push(fix);
+        }
+        self.section.push(outcome.row);
+    }
+
+    pub fn section(&self) -> &Section {
+        &self.section
+    }
+
+    pub fn into_parts(self) -> (Section, Vec<FixSuggestion>) {
+        (self.section, self.fixes)
+    }
+}
+
+#[derive(Clone)]
+pub struct FixSuggestion {
+    pub id: String,
+    description: String,
+    command: Vec<String>,
+}
+
+impl FixSuggestion {
+    pub fn new(id: String, description: String, command: Vec<String>) -> Self {
+        Self {
+            id,
+            description,
+            command,
+        }
+    }
+
+    pub fn description(&self) -> &str {
+        &self.description
+    }
+
+    pub fn command_preview(&self) -> String {
+        self.command.join(" ")
+    }
+}
+
+#[derive(Clone, Copy)]
+pub enum Status {
+    Pass,
+    Warn,
+    Fail,
+    Info,
+}
+
+pub struct Row {
+    pub status: Status,
+    message: String,
+    detail: Option<String>,
+    indent: usize,
+}
+
+pub struct RowOutcome {
+    pub row: Row,
+    pub fix: Option<FixSuggestion>,
+}
+
+impl RowOutcome {
+    fn new(row: Row) -> Self {
+        Self { row, fix: None }
+    }
+
+    fn with_fix(row: Row, fix: FixSuggestion) -> Self {
+        Self {
+            row,
+            fix: Some(fix),
+        }
+    }
+}
+
+impl Row {
+    fn pass(message: impl Into<String>) -> Self {
+        Self::new(Status::Pass, message)
+    }
+
+    fn warn(message: impl Into<String>) -> Self {
+        Self::new(Status::Warn, message)
+    }
+
+    fn fail(message: impl Into<String>) -> Self {
+        Self::new(Status::Fail, message)
+    }
+
+    fn info(message: impl Into<String>) -> Self {
+        Self::new(Status::Info, message)
+    }
+
+    fn new(status: Status, message: impl Into<String>) -> Self {
+        Self {
+            status,
+            message: message.into(),
+            detail: None,
+            indent: 0,
+        }
+    }
+
+    pub fn with_detail(mut self, detail: impl Into<String>) -> Self {
+        self.detail = Some(detail.into());
+        self
+    }
+
+    pub fn with_indent(mut self, indent: usize) -> Self {
+        self.indent = indent;
+        self
+    }
+
+    pub fn render(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        let indent = "  ".repeat(self.indent + 1);
+        let icon = match self.status {
+            Status::Pass => format!("{}", style("✔").green()),
+            Status::Warn => format!("{}", style("⚠").yellow()),
+            Status::Fail => format!("{}", style("✘").red()),
+            Status::Info => format!("{}", style("•").cyan()),
+        };
+        lines.push(format!("{indent}{icon} {}", self.message));
+        if let Some(detail) = &self.detail {
+            let detail_indent = "  ".repeat(self.indent + 2);
+            lines.push(format!("{}{}", detail_indent, style(detail).dim()));
+        }
+        lines
+    }
+
+    pub fn status(&self) -> Status {
+        self.status
+    }
+
+    fn summary(&self, title: &str) -> String {
+        format!("{title}: {}", self.message)
+    }
+}
+
+pub struct Section {
+    title: String,
+    rows: Vec<Row>,
+}
+
+impl Section {
+    fn new(title: impl Into<String>) -> Self {
+        Self {
+            title: title.into(),
+            rows: Vec::new(),
+        }
+    }
+
+    fn push(&mut self, row: Row) {
+        self.rows.push(row);
+    }
+
+    pub fn render(&self) -> Vec<String> {
+        let mut lines = Vec::new();
+        lines.push(format!(
+            "{} {}",
+            style("◈").cyan(),
+            style(&self.title).bold()
+        ));
+        for row in &self.rows {
+            lines.extend(row.render());
+        }
+        lines
+    }
+
+    pub fn summary_line(&self) -> String {
+        let icon = match self.overall_status() {
+            Status::Pass => style("✔").green(),
+            Status::Warn => style("⚠").yellow(),
+            Status::Fail => style("✘").red(),
+            Status::Info => style("•").cyan(),
+        };
+        format!("{} {}", icon, style(&self.title).bold())
+    }
+
+    pub fn overall_status(&self) -> Status {
+        if self
+            .rows
+            .iter()
+            .any(|row| matches!(row.status(), Status::Fail))
+        {
+            Status::Fail
+        } else if self
+            .rows
+            .iter()
+            .any(|row| matches!(row.status(), Status::Warn))
+        {
+            Status::Warn
+        } else if self
+            .rows
+            .iter()
+            .any(|row| matches!(row.status(), Status::Pass))
+        {
+            Status::Pass
+        } else {
+            Status::Info
+        }
+    }
+
+    pub fn has_failure(&self) -> bool {
+        self.rows
+            .iter()
+            .any(|row| matches!(row.status(), Status::Fail))
+    }
+
+    fn failure_summaries(&self) -> Vec<String> {
+        self.rows
+            .iter()
+            .filter(|row| matches!(row.status(), Status::Fail))
+            .map(|row| row.summary(&self.title))
+            .collect()
+    }
+}
+
+fn check_rust(mode: CheckMode) -> SectionOutcome {
+    let mut outcome = SectionOutcome::new("Rust toolchain");
+
+    outcome.push_outcome(check_command(
+        "cargo",
+        "Install Rust from https://rustup.rs",
+    ));
+    outcome.push_outcome(check_command(
+        "rustup",
+        "Install Rust from https://rustup.rs",
+    ));
+
+    if mode.is_full() {
+        extend_rust_details(&mut outcome);
+    }
+
+    outcome
+}
+
+fn extend_rust_details(outcome: &mut SectionOutcome) {
+    outcome.push_outcome(RowOutcome::new(Row::info("Installed Rust targets")));
+
+    if which("rustup").is_ok() {
+        match Command::new("rustup")
+            .args(["target", "list", "--installed"])
+            .output()
+        {
+            Ok(output) => {
+                let installed_targets = String::from_utf8_lossy(&output.stdout);
+                collect_rust_targets(&installed_targets, outcome);
+            }
+            Err(err) => outcome.push_outcome(RowOutcome::new(
+                Row::warn("Could not query installed Rust targets")
+                    .with_detail(format!("rustup target list --installed failed: {err}")),
+            )),
+        }
+    }
+
+    outcome.push_outcome(check_sccache_tool());
+    if let Some(mold) = check_mold_tool() {
+        outcome.push_outcome(mold);
+    }
+}
+
+fn collect_rust_targets(installed_targets: &str, outcome: &mut SectionOutcome) {
+    let (required, optional) = if cfg!(target_os = "macos") {
+        if cfg!(target_arch = "aarch64") {
+            (
+                vec![
+                    (
+                        "aarch64-apple-darwin",
+                        Some("Required for macOS builds on Apple Silicon"),
+                    ),
+                    (
+                        "aarch64-apple-ios-sim",
+                        Some("Required for Apple Silicon iOS Simulator"),
+                    ),
+                ],
+                vec![
+                    ("aarch64-apple-ios", "for deploying to physical iOS devices"),
+                    ("armv7-apple-ios", "for legacy 32-bit iOS devices"),
+                    ("x86_64-apple-darwin", "for Rosetta macOS builds"),
+                    ("x86_64-apple-ios", "for Intel iOS Simulator"),
+                ],
+            )
+        } else {
+            (
+                vec![
+                    (
+                        "x86_64-apple-darwin",
+                        Some("Required for macOS builds on Intel"),
+                    ),
+                    (
+                        "aarch64-apple-ios-sim",
+                        Some("Required for Apple Silicon iOS Simulator"),
+                    ),
+                ],
+                vec![
+                    ("aarch64-apple-ios", "for Apple Silicon devices"),
+                    ("armv7-apple-ios", "for legacy 32-bit iOS devices"),
+                    ("x86_64-apple-ios", "for Intel iOS Simulator"),
+                ],
+            )
+        }
+    } else if cfg!(target_os = "windows") {
+        (
+            vec![(
+                "aarch64-pc-windows-msvc",
+                Some("Required for Windows on ARM"),
+            )],
+            vec![
+                ("x86_64-pc-windows-gnu", "for MinGW environments"),
+                ("i686-pc-windows-msvc", "for 32-bit Windows"),
+            ],
+        )
+    } else {
+        (
+            vec![(
+                "x86_64-unknown-linux-gnu",
+                Some("Required for native Linux builds"),
+            )],
+            vec![
+                (
+                    "aarch64-unknown-linux-gnu",
+                    "for cross-compiling to ARM64 Linux",
+                ),
+                ("armv7-unknown-linux-gnueabihf", "for ARMv7 Linux"),
+            ],
+        )
+    };
+
+    if !required.is_empty() {
+        outcome.push(Row::info("Required targets").with_indent(1));
+        for (target, note) in required {
+            outcome.push_outcome(target_row(
+                installed_targets,
+                target,
+                TargetKind::Required { note },
+            ));
+        }
+    }
+
+    if !optional.is_empty() {
+        outcome.push(Row::info("Optional targets").with_indent(1));
+        for (target, reason) in optional {
+            outcome.push_outcome(target_row(
+                installed_targets,
+                target,
+                TargetKind::Optional(reason),
+            ));
+        }
+    }
+}
+
+fn check_swift() -> SectionOutcome {
+    let mut outcome = SectionOutcome::new("Swift (macOS)");
+    outcome.push_outcome(check_command(
+        "xcodebuild",
+        "Install Xcode and command line tools (xcode-select --install)",
+    ));
+    outcome.push_outcome(check_command(
+        "xcrun",
+        "Install Xcode and command line tools (xcode-select --install)",
+    ));
+    outcome
+}
+
+fn check_android(mode: CheckMode) -> SectionOutcome {
+    let mut outcome = SectionOutcome::new("Android tooling");
+    let prerequisites = match check_android_prerequisites(mode) {
+        Ok(outcomes) => outcomes,
+        Err(err) => {
+            outcome.push(
+                Row::fail("Failed to run Android prerequisites check").with_detail(err.to_string()),
+            );
+            return outcome;
+        }
+    };
+
+    for row_outcome in prerequisites {
+        outcome.push_outcome(row_outcome);
+    }
+
+    outcome
+}
+
+fn check_command(name: &str, help: &str) -> RowOutcome {
+    match which(name) {
+        Ok(path) => RowOutcome::new(
+            Row::pass(format!("Found `{name}`")).with_detail(path.display().to_string()),
+        ),
+        Err(_) => RowOutcome::new(Row::fail(format!("`{name}` not found")).with_detail(help)),
+    }
+}
+
+fn check_sccache_tool() -> RowOutcome {
+    match which("sccache") {
+        Ok(path) => RowOutcome::new(
+            Row::pass("`sccache` build cache available")
+                .with_indent(1)
+                .with_detail(path.display().to_string()),
+        ),
+        Err(_) => {
+            let detail =
+                "Install sccache to cache Rust compilation outputs. Run `cargo install sccache`.";
+            let row = Row::warn("`sccache` not installed")
+                .with_indent(1)
+                .with_detail(detail);
+            RowOutcome::with_fix(
+                row,
+                FixSuggestion::new(
+                    "tool-sccache".into(),
+                    "Install sccache build cache".into(),
+                    vec!["cargo".into(), "install".into(), "sccache".into()],
+                ),
+            )
+        }
+    }
+}
+
+fn check_mold_tool() -> Option<RowOutcome> {
+    if !cfg!(target_os = "linux") {
+        return None;
+    }
+
+    match which("mold") {
+        Ok(path) => Some(RowOutcome::new(
+            Row::pass("`mold` linker available")
+                .with_indent(1)
+                .with_detail(path.display().to_string()),
+        )),
+        Err(_) => {
+            let mut detail = String::from("Install mold to speed up Rust linking on Linux.");
+            if let Some((fix, hint)) = mold_fix_suggestion() {
+                if !hint.is_empty() {
+                    detail.push(' ');
+                    detail.push_str(&hint);
+                }
+                Some(RowOutcome::with_fix(
+                    Row::warn("`mold` linker not installed")
+                        .with_indent(1)
+                        .with_detail(detail),
+                    fix,
+                ))
+            } else {
+                detail
+                    .push_str(" See https://github.com/rui314/mold for installation instructions.");
+                Some(RowOutcome::new(
+                    Row::warn("`mold` linker not installed")
+                        .with_indent(1)
+                        .with_detail(detail),
+                ))
+            }
+        }
+    }
+}
+
+fn mold_fix_suggestion() -> Option<(FixSuggestion, String)> {
+    if cfg!(not(any(target_os = "linux", target_os = "macos"))) {
+        return None;
+    }
+    if which("apt-get").is_ok() {
+        let mut command = Vec::new();
+        if which("sudo").is_ok() {
+            command.push("sudo".into());
+        }
+        command.extend(
+            ["apt-get", "install", "-y", "mold"]
+                .into_iter()
+                .map(String::from),
+        );
+        let preview = command.join(" ");
+        let description = "Install mold linker via apt".to_string();
+        let fix = FixSuggestion::new("tool-mold".into(), description, command);
+        return Some((fix, format!("Try `{preview}`.")));
+    }
+
+    if which("dnf").is_ok() {
+        let mut command = Vec::new();
+        if which("sudo").is_ok() {
+            command.push("sudo".into());
+        }
+        command.extend(
+            ["dnf", "install", "-y", "mold"]
+                .into_iter()
+                .map(String::from),
+        );
+        let preview = command.join(" ");
+        let description = "Install mold linker via dnf".to_string();
+        let fix = FixSuggestion::new("tool-mold".into(), description, command);
+        return Some((fix, format!("Try `{preview}`.")));
+    }
+
+    if which("pacman").is_ok() {
+        let mut command = Vec::new();
+        if which("sudo").is_ok() {
+            command.push("sudo".into());
+        }
+        command.extend(
+            ["pacman", "-S", "--noconfirm", "mold"]
+                .into_iter()
+                .map(String::from),
+        );
+        let preview = command.join(" ");
+        let description = "Install mold linker via pacman".to_string();
+        let fix = FixSuggestion::new("tool-mold".into(), description, command);
+        return Some((fix, format!("Try `{preview}`.")));
+    }
+
+    if which("brew").is_ok() {
+        let mut command = Vec::new();
+        if which("sudo").is_ok() {
+            command.push("sudo".into());
+        }
+        command.extend(["brew", "install", "mold"].into_iter().map(String::from));
+        let preview = command.join(" ");
+        let description = "Install mold linker via Homebrew".to_string();
+        let fix = FixSuggestion::new("tool-mold".into(), description, command);
+        return Some((fix, format!("Try `{preview}`.")));
+    }
+
+    None
+}
+
+fn check_android_prerequisites(_mode: CheckMode) -> Result<Vec<RowOutcome>> {
+    let mut outcomes = vec![
+        check_command("adb", "Install Android SDK Platform-Tools and add to PATH."),
+        check_command(
+            "emulator",
+            "Install Android SDK command-line tools and add to PATH.",
+        ),
+    ];
+
+    outcomes.push(check_java_environment());
+
+    let env_status = evaluate_android_env();
+    outcomes.extend(env_status.rows);
+
+    if let Some(root) = env_status.root.clone() {
+        let sdk = AndroidSdk::new(root);
+        outcomes.extend(sdk.check_components()?);
+    }
+
+    if which("rustup").is_ok() {
+        let output = Command::new("rustup")
+            .args(["target", "list", "--installed"])
+            .output()
+            .context("failed to query installed rust targets")?;
+
+        let installed_targets = String::from_utf8_lossy(&output.stdout);
+
+        if cfg!(target_arch = "aarch64") {
+            outcomes.push(target_row(
+                &installed_targets,
+                "aarch64-linux-android",
+                TargetKind::Required {
+                    note: Some("Required for Android emulator on Apple Silicon"),
+                },
+            ));
+        }
+    } else {
+        outcomes.push(RowOutcome::new(Row::warn(
+            "rustup not found, cannot check Rust targets.",
+        )));
+    }
+
+    Ok(outcomes)
+}
+
+fn check_java_environment() -> RowOutcome {
+    let java_env = env::var("JAVA_HOME").ok();
+    let java_version_cmd = if let Some(java_home) = java_env.clone() {
+        let java_exe = Path::new(&java_home).join("bin/java");
+        if java_exe.exists() {
+            Some(Command::new(java_exe))
+        } else {
+            None
+        }
+    } else if which("java").is_ok() {
+        Some(Command::new("java"))
+    } else {
+        None
+    };
+
+    if let Some(mut cmd) = java_version_cmd {
+        match cmd.arg("-version").output() {
+            Ok(output) => {
+                let version_info = String::from_utf8_lossy(&output.stderr);
+                if let Some(line) = version_info.lines().next() {
+                    RowOutcome::new(Row::pass("Java detected").with_detail(line.trim().to_string()))
+                } else {
+                    RowOutcome::new(Row::warn("Could not determine Java version"))
+                }
+            }
+            Err(err) => RowOutcome::new(
+                Row::warn("Failed to read Java version")
+                    .with_detail(format!("java -version failed: {err}")),
+            ),
+        }
+    } else {
+        RowOutcome::new(Row::fail("Java not found in JAVA_HOME or PATH"))
+    }
+}
+
+struct AndroidEnvStatus {
+    root: Option<PathBuf>,
+    rows: Vec<RowOutcome>,
+}
+
+fn evaluate_android_env() -> AndroidEnvStatus {
+    let mut rows = Vec::new();
+
+    let root = check_env_path(
+        &mut rows,
+        "ANDROID_SDK_ROOT",
+        true,
+        "Set ANDROID_SDK_ROOT to the root of your Android SDK installation.",
+    )
+    .or_else(|| {
+        check_env_path(
+            &mut rows,
+            "ANDROID_HOME",
+            false,
+            "Set ANDROID_HOME to the root of your Android SDK installation.",
+        )
+    });
+
+    let _ndk = check_env_path(
+        &mut rows,
+        "ANDROID_NDK_HOME",
+        false,
+        "Set ANDROID_NDK_HOME to the Android NDK directory (usually inside the SDK's ndk folder).",
+    );
+
+    AndroidEnvStatus { root, rows }
+}
+
+fn check_env_path(
+    rows: &mut Vec<RowOutcome>,
+    name: &str,
+    required: bool,
+    help: &str,
+) -> Option<PathBuf> {
+    match env::var(name) {
+        Ok(value) if !value.trim().is_empty() => {
+            let path = PathBuf::from(&value);
+            if path.exists() {
+                rows.push(RowOutcome::new(
+                    Row::pass(format!("Environment `{name}` set")).with_detail(value.clone()),
+                ));
+                Some(path)
+            } else {
+                rows.push(RowOutcome::new(
+                    Row::fail(format!("Environment `{name}` points to a missing path"))
+                        .with_detail(format!("{} does not exist", value)),
+                ));
+                None
+            }
+        }
+        _ => {
+            let row = if required {
+                Row::fail(format!("Environment `{name}` missing"))
+            } else {
+                Row::warn(format!("Environment `{name}` missing"))
+            }
+            .with_detail(help);
+            rows.push(RowOutcome::new(row));
+            None
+        }
+    }
+}
+
+struct AndroidSdk {
+    root: PathBuf,
+    sdkmanager: Option<PathBuf>,
+}
+
+impl AndroidSdk {
+    fn new(root: PathBuf) -> Self {
+        let sdkmanager = locate_sdkmanager(&root);
+        Self { root, sdkmanager }
+    }
+
+    fn check_components(&self) -> Result<Vec<RowOutcome>> {
+        let mut rows = Vec::new();
+
+        if let Some(path) = &self.sdkmanager {
+            rows.push(RowOutcome::new(
+                Row::pass("`sdkmanager` available")
+                    .with_indent(1)
+                    .with_detail(path.display().to_string()),
+            ));
+        } else {
+            rows.push(RowOutcome::new(
+                Row::warn("`sdkmanager` not found")
+                    .with_indent(1)
+                    .with_detail("Install Android command-line tools to obtain sdkmanager."),
+            ));
+        }
+
+        rows.push(self.component_row(
+            "android-platform-tools",
+            "Android Platform Tools",
+            self.root.join("platform-tools"),
+            &["platform-tools"],
+        ));
+
+        rows.push(self.build_tools_row()?);
+        rows.push(self.platforms_row()?);
+        rows.push(self.ndk_row());
+
+        Ok(rows)
+    }
+
+    fn component_row(&self, id: &str, label: &str, path: PathBuf, packages: &[&str]) -> RowOutcome {
+        if path.exists() {
+            RowOutcome::new(
+                Row::pass(format!("{label} installed"))
+                    .with_indent(1)
+                    .with_detail(path.display().to_string()),
+            )
+        } else {
+            let row = Row::fail(format!("{label} missing"))
+                .with_indent(1)
+                .with_detail(format!(
+                    "Install {label} using sdkmanager (package{} {}).",
+                    if packages.len() == 1 { "" } else { "s" },
+                    packages.join(", "),
+                ));
+            if let Some(fix) = self.install_fix(id, format!("Install {label}"), packages) {
+                RowOutcome::with_fix(row, fix)
+            } else {
+                RowOutcome::new(row)
+            }
+        }
+    }
+
+    fn build_tools_row(&self) -> Result<RowOutcome> {
+        let build_tools_dir = self.root.join("build-tools");
+        if !build_tools_dir.exists() {
+            return Ok(self.component_row(
+                "android-build-tools",
+                "Android Build Tools",
+                build_tools_dir,
+                &["build-tools;34.0.0"],
+            ));
+        }
+
+        let has_version = fs::read_dir(&build_tools_dir)?
+            .filter_map(Result::ok)
+            .any(|entry| entry.path().is_dir());
+
+        if has_version {
+            Ok(RowOutcome::new(
+                Row::pass("Android Build Tools installed")
+                    .with_indent(1)
+                    .with_detail(build_tools_dir.display().to_string()),
+            ))
+        } else {
+            Ok(self.component_row(
+                "android-build-tools",
+                "Android Build Tools",
+                build_tools_dir,
+                &["build-tools;34.0.0"],
+            ))
+        }
+    }
+
+    fn platforms_row(&self) -> Result<RowOutcome> {
+        let platforms_dir = self.root.join("platforms");
+        if !platforms_dir.exists() {
+            return Ok(self.component_row(
+                "android-platform",
+                "Android platform SDK",
+                platforms_dir,
+                &["platforms;android-34"],
+            ));
+        }
+
+        let has_platform = fs::read_dir(&platforms_dir)?
+            .filter_map(Result::ok)
+            .any(|entry| entry.path().is_dir());
+
+        if has_platform {
+            Ok(RowOutcome::new(
+                Row::pass("Android platform SDK installed")
+                    .with_indent(1)
+                    .with_detail(platforms_dir.display().to_string()),
+            ))
+        } else {
+            Ok(self.component_row(
+                "android-platform",
+                "Android platform SDK",
+                platforms_dir,
+                &["platforms;android-34"],
+            ))
+        }
+    }
+
+    fn ndk_row(&self) -> RowOutcome {
+        let ndk_dir = self.root.join("ndk");
+        if ndk_dir.exists() {
+            if let Some(first_ndk) = first_child_dir(&ndk_dir) {
+                return RowOutcome::new(
+                    Row::pass("Android NDK installed")
+                        .with_indent(1)
+                        .with_detail(first_ndk.display().to_string()),
+                );
+            }
+        }
+
+        let row = Row::fail("Android NDK not installed")
+            .with_indent(1)
+            .with_detail("Install the Android NDK using sdkmanager.");
+        if let Some(fix) =
+            self.install_fix("android-ndk", "Install Android NDK", &["ndk;26.1.10909125"])
+        {
+            RowOutcome::with_fix(row, fix)
+        } else {
+            RowOutcome::new(row)
+        }
+    }
+
+    fn install_fix(
+        &self,
+        id: &str,
+        description: impl Into<String>,
+        packages: &[&str],
+    ) -> Option<FixSuggestion> {
+        let sdkmanager = self.sdkmanager.as_ref()?;
+        let mut command = Vec::new();
+        command.push(sdkmanager.display().to_string());
+        command.push(format!("--sdk_root={}", self.root.display()));
+        command.push("--install".into());
+        command.extend(packages.iter().map(|pkg| pkg.to_string()));
+        Some(FixSuggestion::new(id.into(), description.into(), command))
+    }
+}
+
+fn first_child_dir(path: &Path) -> Option<PathBuf> {
+    fs::read_dir(path)
+        .ok()?
+        .filter_map(Result::ok)
+        .map(|entry| entry.path())
+        .find(|candidate| candidate.is_dir())
+}
+
+fn locate_sdkmanager(root: &Path) -> Option<PathBuf> {
+    if let Ok(path) = which("sdkmanager") {
+        return Some(path);
+    }
+
+    let candidates: &[&str] = if cfg!(windows) {
+        &[
+            "cmdline-tools/latest/bin/sdkmanager.bat",
+            "cmdline-tools/bin/sdkmanager.bat",
+        ]
+    } else {
+        &[
+            "cmdline-tools/latest/bin/sdkmanager",
+            "cmdline-tools/bin/sdkmanager",
+        ]
+    };
+
+    for candidate in candidates {
+        let full = root.join(candidate);
+        if full.exists() {
+            return Some(full);
+        }
+    }
+
+    None
+}
+
+enum TargetKind {
+    Required { note: Option<&'static str> },
+    Optional(&'static str),
+}
+
+fn target_row(installed: &str, target: &str, kind: TargetKind) -> RowOutcome {
+    let present = installed.contains(target);
+    match kind {
+        TargetKind::Required { note } => {
+            if present {
+                RowOutcome::new(Row::pass(format!("Rust target `{target}`")).with_indent(2))
+            } else {
+                let mut detail = format!("Run `rustup target add {target}`");
+                let description = if let Some(note) = note {
+                    detail = format!("{note}. {detail}");
+                    format!("Install Rust target `{target}` ({note})")
+                } else {
+                    format!("Install Rust target `{target}`")
+                };
+                let row = Row::fail(format!("Rust target `{target}` missing"))
+                    .with_detail(detail)
+                    .with_indent(2);
+                RowOutcome::with_fix(
+                    row,
+                    FixSuggestion::new(
+                        format!("rust-target-{target}"),
+                        description,
+                        vec![
+                            "rustup".into(),
+                            "target".into(),
+                            "add".into(),
+                            target.to_string(),
+                        ],
+                    ),
+                )
+            }
+        }
+        TargetKind::Optional(reason) => {
+            if present {
+                RowOutcome::new(
+                    Row::pass(format!("Rust target `{target}`"))
+                        .with_detail(format!("Optional {reason}"))
+                        .with_indent(2),
+                )
+            } else {
+                RowOutcome::new(
+                    Row::warn(format!("Rust target `{target}` not installed"))
+                        .with_detail(format!(
+                            "Optional {reason}. Run `rustup target add {target}` if needed."
+                        ))
+                        .with_indent(2),
+                )
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated toolchain module that centralises environment checks, reporting, and fix execution
- make `water doctor` interactive with shared toolchain logic and sdkmanager based Android fixes
- validate target toolchains during `water run` using quick checks and add the required dependency wiring

## Testing
- cargo fmt
- cargo clippy -p waterui-cli --all-targets
- cargo test -p waterui-cli
