### PR TITLE
Add chart components built on canvas

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ waterui-media = { version = "0.1.0", path = "components/media" }
 waterui-form = { version = "0.1.0", path = "components/form" }
 waterui-form-derive = { version = "0.1.0", path = "components/form/derive" }
 waterui-graphics = { version = "0.1.0", path = "components/graphics" }
+waterui-chart = { version = "0.1.0", path = "components/chart" }
 waterui-ffi = { version = "0.1.0", path = "ffi" }
 waterui-layout = { version = "0.1.0", path = "components/layout" }
 waterui-navigation = { version = "0.1.0", path = "components/navigation" }
@@ -91,6 +92,7 @@ waterui-media.workspace = true
 waterui-navigation.workspace = true
 waterui-color.workspace = true
 waterui-form.workspace = true
+waterui-chart.workspace = true
 executor-core.workspace = true
 serde = { workspace = true, features = ["derive"], optional = true }
 log.workspace = true

--- a/components/chart/Cargo.toml
+++ b/components/chart/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "waterui-chart"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+readme.workspace = true
+repository.workspace = true
+description = "Chart components for WaterUI"
+keywords = ["chart", "graphics", "ui", "waterui"]
+categories = ["gui"]
+
+[dependencies]
+waterui-core.workspace = true
+waterui-graphics.workspace = true
+waterui-color.workspace = true
+
+[lints]
+workspace = true

--- a/components/chart/src/bar.rs
+++ b/components/chart/src/bar.rs
@@ -1,0 +1,224 @@
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use waterui_color::{Color, Srgb};
+use waterui_core::{Environment, View};
+use waterui_graphics::{Path, PathBuilder};
+
+use crate::{ChartCanvas, ensure_dimensions, to_arc, usize_to_f32};
+
+/// A bar chart rendered on the `WaterUI` canvas.
+#[derive(Clone)]
+pub struct BarChart {
+    values: Arc<[f32]>,
+    width: f32,
+    height: f32,
+    padding: f32,
+    spacing: f32,
+    fill_color: Srgb,
+    background: Option<Srgb>,
+}
+
+impl core::fmt::Debug for BarChart {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("BarChart")
+            .field("bars", &self.values.len())
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .finish_non_exhaustive()
+    }
+}
+
+impl BarChart {
+    /// Creates a new bar chart from the provided values.
+    pub fn new(values: impl Into<Vec<f32>>) -> Self {
+        let values = values.into();
+        let values = to_arc(values);
+        Self {
+            values,
+            width: 320.0,
+            height: 180.0,
+            padding: 12.0,
+            spacing: 0.2,
+            fill_color: Srgb::new(0.2, 0.6, 0.86),
+            background: None,
+        }
+    }
+
+    /// Sets the chart width.
+    #[must_use]
+    pub fn width(mut self, width: f32) -> Self {
+        ensure_dimensions(width, self.height);
+        self.width = width;
+        self
+    }
+
+    /// Sets the chart height.
+    #[must_use]
+    pub fn height(mut self, height: f32) -> Self {
+        ensure_dimensions(self.width, height);
+        self.height = height;
+        self
+    }
+
+    /// Sets the padding around the chart plot area.
+    #[must_use]
+    pub const fn padding(mut self, padding: f32) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    /// Controls the fraction of each bar reserved as spacing.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the provided spacing lies outside the range [0, 1).
+    #[must_use]
+    pub fn spacing(mut self, spacing: f32) -> Self {
+        assert!(
+            (0.0..1.0).contains(&spacing),
+            "bar spacing must be in [0, 1)"
+        );
+        self.spacing = spacing;
+        self
+    }
+
+    /// Sets the fill color used for each bar.
+    #[must_use]
+    pub const fn fill_color(mut self, color: Srgb) -> Self {
+        self.fill_color = color;
+        self
+    }
+
+    /// Fills the chart background with the provided color.
+    #[must_use]
+    pub const fn background(mut self, color: Srgb) -> Self {
+        self.background = Some(color);
+        self
+    }
+}
+
+impl View for BarChart {
+    fn body(self, _env: &Environment) -> impl View {
+        let Self {
+            values,
+            width,
+            height,
+            padding,
+            spacing,
+            fill_color,
+            background,
+        } = self;
+
+        let fill_color_value = fill_color;
+        ChartCanvas::new(width, height, background).paint(move |ctx| {
+            let rectangles = bar_rectangles(&values, width, height, padding, spacing);
+            let color: Color = fill_color_value.into();
+            for rect in rectangles {
+                ctx.fill(&rect, &color);
+            }
+        })
+    }
+}
+
+/// Builds rectangle paths for each bar value within the chart bounds.
+///
+/// # Panics
+///
+/// Panics if the values slice is empty, all values are identical, or if the
+/// padding consumes the chart dimensions.
+#[must_use]
+pub fn bar_rectangles(
+    values: &[f32],
+    width: f32,
+    height: f32,
+    padding: f32,
+    spacing: f32,
+) -> Vec<Path> {
+    ensure_dimensions(width, height);
+    assert!(!values.is_empty(), "bar chart requires values");
+
+    let (min, max) = values
+        .iter()
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), &v| {
+            (min.min(v), max.max(v))
+        });
+    assert!(max > min, "bar chart expects a non-uniform dataset");
+
+    let plot_width = padding.mul_add(-2.0, width);
+    let plot_height = padding.mul_add(-2.0, height);
+    assert!(
+        plot_width > 0.0 && plot_height > 0.0,
+        "bar chart padding too large"
+    );
+
+    let range = max - min;
+    let zero_offset = if min < 0.0 && max > 0.0 {
+        (-min) / range
+    } else if min >= 0.0 {
+        0.0
+    } else {
+        1.0
+    };
+
+    let zero_y = zero_offset.mul_add(-plot_height, height - padding);
+
+    let bar_count = values.len();
+    let bar_count_f32 = usize_to_f32(bar_count, "bar count");
+    let bar_band = plot_width / bar_count_f32;
+    assert!(
+        (0.0..1.0).contains(&spacing),
+        "bar spacing must be in [0, 1)"
+    );
+    let gap = bar_band * spacing;
+    let bar_width = bar_band - gap;
+
+    let mut rectangles = Vec::with_capacity(bar_count);
+
+    for (index, value) in values.iter().enumerate() {
+        let normalized = (value - min) / range;
+        let value_y = normalized.mul_add(-plot_height, height - padding);
+
+        let index_f = usize_to_f32(index, "bar index");
+        let start_x = index_f.mul_add(bar_band, padding) + (gap / 2.0);
+        let end_x = start_x + bar_width;
+
+        let (top, bottom) = if value_y < zero_y {
+            (value_y, zero_y)
+        } else {
+            (zero_y, value_y)
+        };
+
+        let rect = PathBuilder::new()
+            .move_to([start_x, bottom])
+            .line_to([start_x, top])
+            .line_to([end_x, top])
+            .line_to([end_x, bottom])
+            .close()
+            .build();
+        rectangles.push(rect);
+    }
+
+    rectangles
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waterui_graphics::shape::PathCommand;
+
+    #[test]
+    fn rectangles_cover_positive_values() {
+        let values = vec![1.0, 2.0, 3.0];
+        let rects = bar_rectangles(&values, 120.0, 60.0, 10.0, 0.2);
+        assert_eq!(rects.len(), 3);
+        let first = &rects[0];
+        match first.0[0] {
+            PathCommand::MoveTo([x, y]) => {
+                assert!(x > 10.0);
+                assert!((y - 50.0).abs() < 1.0);
+            }
+            _ => panic!("expected move_to"),
+        }
+    }
+}

--- a/components/chart/src/lib.rs
+++ b/components/chart/src/lib.rs
@@ -1,0 +1,90 @@
+#![doc = "Chart components for `WaterUI` built on top of the graphics canvas."]
+#![allow(clippy::multiple_crate_versions)]
+
+extern crate alloc;
+
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use waterui_color::{Color, Srgb};
+use waterui_graphics::{Canvas, PathBuilder, canvas};
+
+mod line;
+pub use line::{LineChart, line_chart_path};
+
+mod bar;
+pub use bar::{BarChart, bar_rectangles};
+
+/// Shared helpers for chart rendering.
+fn ensure_dimensions(width: f32, height: f32) {
+    assert!(
+        width.is_finite() && width > 0.0,
+        "chart width must be positive"
+    );
+    assert!(
+        height.is_finite() && height > 0.0,
+        "chart height must be positive"
+    );
+}
+
+fn to_arc(values: Vec<f32>) -> Arc<[f32]> {
+    assert!(!values.is_empty(), "chart data cannot be empty");
+    Arc::from(values.into_boxed_slice())
+}
+
+fn usize_to_f32(value: usize, context: &str) -> f32 {
+    const MAX_PRECISE: usize = 1 << 24;
+    assert!(
+        value <= MAX_PRECISE,
+        "{context} {value} exceeds f32 precision budget"
+    );
+    #[allow(clippy::cast_precision_loss)]
+    {
+        value as f32
+    }
+}
+
+struct ChartCanvas {
+    width: f32,
+    height: f32,
+    background: Option<Srgb>,
+}
+
+impl ChartCanvas {
+    fn new(width: f32, height: f32, background: Option<Srgb>) -> Self {
+        ensure_dimensions(width, height);
+        Self {
+            width,
+            height,
+            background,
+        }
+    }
+
+    fn paint(
+        self,
+        draw: impl Fn(&mut waterui_graphics::GraphicsContext<'_>) + Send + Sync + 'static,
+    ) -> Canvas {
+        let Self {
+            width,
+            height,
+            background,
+        } = self;
+
+        canvas(move |ctx| {
+            if let Some(bg) = &background {
+                let bg_color: Color = (*bg).into();
+                let rect = PathBuilder::new()
+                    .move_to([0.0, 0.0])
+                    .line_to([width, 0.0])
+                    .line_to([width, height])
+                    .line_to([0.0, height])
+                    .close()
+                    .build();
+                ctx.fill(&rect, &bg_color);
+            }
+            draw(ctx);
+        })
+        .width(width)
+        .height(height)
+    }
+}

--- a/components/chart/src/line.rs
+++ b/components/chart/src/line.rs
@@ -1,0 +1,197 @@
+use alloc::sync::Arc;
+use alloc::vec::Vec;
+
+use waterui_color::{Color, Srgb};
+use waterui_core::{Environment, View};
+use waterui_graphics::{Path, PathBuilder};
+
+use crate::{ChartCanvas, ensure_dimensions, to_arc, usize_to_f32};
+
+/// A simple line chart rendered using the [`Canvas`](waterui_graphics::Canvas).
+#[derive(Clone)]
+pub struct LineChart {
+    values: Arc<[f32]>,
+    width: f32,
+    height: f32,
+    padding: f32,
+    stroke_color: Srgb,
+    stroke_width: f32,
+    background: Option<Srgb>,
+}
+
+impl core::fmt::Debug for LineChart {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("LineChart")
+            .field("points", &self.values.len())
+            .field("width", &self.width)
+            .field("height", &self.height)
+            .finish_non_exhaustive()
+    }
+}
+
+impl LineChart {
+    /// Creates a new `LineChart` from a list of Y values.
+    ///
+    /// # Panics
+    ///
+    /// Panics if fewer than two data points are provided.
+    pub fn new(values: impl Into<Vec<f32>>) -> Self {
+        let values = values.into();
+        assert!(values.len() > 1, "line chart requires at least two points");
+        let values = to_arc(values);
+        Self {
+            values,
+            width: 320.0,
+            height: 180.0,
+            padding: 12.0,
+            stroke_color: Srgb::new(0.2, 0.6, 0.86),
+            stroke_width: 2.0,
+            background: None,
+        }
+    }
+
+    /// Sets the chart width.
+    #[must_use]
+    pub fn width(mut self, width: f32) -> Self {
+        ensure_dimensions(width, self.height);
+        self.width = width;
+        self
+    }
+
+    /// Sets the chart height.
+    #[must_use]
+    pub fn height(mut self, height: f32) -> Self {
+        ensure_dimensions(self.width, height);
+        self.height = height;
+        self
+    }
+
+    /// Sets the padding applied to the plot area.
+    #[must_use]
+    pub const fn padding(mut self, padding: f32) -> Self {
+        self.padding = padding;
+        self
+    }
+
+    /// Sets the stroke color for the plotted line.
+    #[must_use]
+    pub const fn stroke_color(mut self, color: Srgb) -> Self {
+        self.stroke_color = color;
+        self
+    }
+
+    /// Sets the stroke width for the plotted line.
+    #[must_use]
+    pub const fn stroke_width(mut self, width: f32) -> Self {
+        self.stroke_width = width;
+        self
+    }
+
+    /// Fills the chart background with the provided color.
+    #[must_use]
+    pub const fn background(mut self, color: Srgb) -> Self {
+        self.background = Some(color);
+        self
+    }
+}
+
+impl View for LineChart {
+    fn body(self, _env: &Environment) -> impl View {
+        let Self {
+            values,
+            width,
+            height,
+            padding,
+            stroke_color,
+            stroke_width,
+            background,
+        } = self;
+
+        let stroke_color_value = stroke_color;
+        ChartCanvas::new(width, height, background).paint(move |ctx| {
+            let path = line_chart_path(&values, width, height, padding);
+            let color: Color = stroke_color_value.into();
+            ctx.stroke(&path, &color, stroke_width);
+        })
+    }
+}
+
+/// Constructs a [`Path`] representing the plotted line for the provided values.
+///
+/// # Panics
+///
+/// Panics if fewer than two data points are supplied or if padding consumes the
+/// entire chart size.
+#[must_use]
+pub fn line_chart_path(values: &[f32], width: f32, height: f32, padding: f32) -> Path {
+    ensure_dimensions(width, height);
+    assert!(values.len() > 1, "line chart requires at least two points");
+
+    let (min, max) = values
+        .iter()
+        .fold((f32::INFINITY, f32::NEG_INFINITY), |(min, max), &v| {
+            (min.min(v), max.max(v))
+        });
+
+    let plot_width = padding.mul_add(-2.0, width);
+    let plot_height = padding.mul_add(-2.0, height);
+    assert!(
+        plot_width > 0.0 && plot_height > 0.0,
+        "line chart padding too large"
+    );
+
+    let range = max - min;
+    let mut builder = PathBuilder::new();
+
+    let first_normalized = if range > 0.0 {
+        (values[0] - min) / range
+    } else {
+        0.5
+    };
+    let first_x = padding;
+    let first_y = first_normalized.mul_add(-plot_height, height - padding);
+    builder = builder.move_to([first_x, first_y]);
+
+    let step = plot_width / usize_to_f32(values.len() - 1, "line chart point count");
+
+    for (index, value) in values.iter().enumerate().skip(1) {
+        let normalized = if range > 0.0 {
+            (*value - min) / range
+        } else {
+            0.5
+        };
+        let index_f = usize_to_f32(index, "line chart index");
+        let x = index_f.mul_add(step, padding);
+        let y = normalized.mul_add(-plot_height, height - padding);
+        builder = builder.line_to([x, y]);
+    }
+
+    builder.build()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use waterui_graphics::shape::PathCommand;
+
+    #[test]
+    fn line_path_spans_chart_area() {
+        let values = vec![0.0, 5.0, 10.0];
+        let path = line_chart_path(&values, 100.0, 50.0, 10.0);
+        assert_eq!(path.0.len(), 3);
+        match path.0[0] {
+            PathCommand::MoveTo([x, y]) => {
+                assert!((x - 10.0).abs() < f32::EPSILON);
+                assert!((y - 40.0).abs() < f32::EPSILON);
+            }
+            _ => panic!("expected move_to"),
+        }
+        match path.0[2] {
+            PathCommand::LineTo([x, y]) => {
+                assert!((x - 90.0).abs() < f32::EPSILON);
+                assert!((y - 10.0).abs() < f32::EPSILON);
+            }
+            _ => panic!("expected line_to"),
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ pub mod prelude {
     pub use super::*;
     pub use color::*;
 
+    pub use chart::*;
     pub use component::*;
     pub use form::*;
     pub use layout::*;
@@ -52,6 +53,7 @@ pub mod prelude {
 pub use color::Color;
 #[doc(inline)]
 pub use view::ViewExt;
+pub use waterui_chart as chart;
 pub use waterui_color as color;
 pub use waterui_form as form;
 pub use waterui_layout as layout;


### PR DESCRIPTION
## Summary
- add the new `waterui-chart` crate that renders line and bar charts with the shared canvas machinery
- expose chart helpers for reuse and wire the crate into the workspace and `waterui` re-exports

## Testing
- `cargo clippy -p waterui-chart --all-targets`
- `cargo test -p waterui-chart`
