### PR TITLE
Use dev branch for dev scaffolding

### DIFF
--- a/cli/src/create/mod.rs
+++ b/cli/src/create/mod.rs
@@ -299,18 +299,25 @@ pub struct ProjectDependencies {
 }
 
 pub enum SwiftDependency {
-    Git { version: Option<String> },
+    Git {
+        version: Option<String>,
+        branch: Option<String>,
+    },
 }
 
 #[allow(clippy::const_is_empty)]
 pub fn resolve_dependencies(dev: bool) -> Result<ProjectDependencies> {
     if dev {
-        let rust_toml = r#"waterui = { git = "https://github.com/water-rs/waterui" }
-waterui-ffi = { git = "https://github.com/water-rs/waterui" }"#
-            .to_string();
+        let rust_toml =
+            r#"waterui = { git = "https://github.com/water-rs/waterui", branch = "dev" }
+waterui-ffi = { git = "https://github.com/water-rs/waterui", branch = "dev" }"#
+                .to_string();
         return Ok(ProjectDependencies {
             rust_toml,
-            swift: SwiftDependency::Git { version: None },
+            swift: SwiftDependency::Git {
+                version: None,
+                branch: Some("dev".to_string()),
+            },
         });
     }
 
@@ -339,6 +346,7 @@ waterui-ffi = "{}""#,
         rust_toml,
         swift: SwiftDependency::Git {
             version: swift_version,
+            branch: None,
         },
     })
 }

--- a/cli/src/create/swift.rs
+++ b/cli/src/create/swift.rs
@@ -25,11 +25,15 @@ pub fn create_xcode_project(
     context.insert("BUNDLE_IDENTIFIER", bundle_identifier.to_string());
     context.insert("CRATE_NAME", crate_name.to_string());
 
-    let SwiftDependency::Git { version } = swift_dependency;
+    let SwiftDependency::Git { version, branch } = swift_dependency;
 
     let requirement = if let Some(version) = version {
         format!(
             "requirement = {{ \n\t\t\t\tkind = upToNextMajorVersion;\n\t\t\t\tminimumVersion = \"{version}\";\n\t\t\t\t}}"
+        )
+    } else if let Some(branch) = branch {
+        format!(
+            "requirement = {{\n\t\t\t\tkind = branch;\n\t\t\t\tbranch = \"{branch}\";\n\t\t\t}};"
         )
     } else {
         "requirement = {\n\t\t\t\tkind = branch;\n\t\t\t\tbranch = \"main\";\n\t\t\t};".to_string()


### PR DESCRIPTION
## Summary
- update the create command to scaffold dev projects from the `dev` branch of the WaterUI repositories
- extend Swift dependency handling so development scaffolds track a custom branch

## Testing
- cargo fmt
- cargo clippy --all-targets
- cargo test --all *(fails: existing doctest compilation errors in README and widget documentation)*
