### PR TITLE
Fix release checkout for release-plz

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_branch }}
+          ref: main
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,13 +14,13 @@ jobs:
   release-plz:
     name: Release
     runs-on: ubuntu-latest
-    if: github.event.workflow_run.conclusion == 'success'
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.head_branch == 'main'
     outputs:
       cli_tag: ${{ steps.cli_tag.outputs.cli_tag }}
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.workflow_run.head_sha }}
+          ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable


### PR DESCRIPTION
Keep release-plz on the real main branch checkout instead of detached HEAD or the repository default branch.\n\n- Run Release only for successful CI workflow_run events whose head branch is main.\n- Checkout main explicitly so release-plz can resolve branch/upstream.\n- Preserve the intended release model: normal main merges create a release PR; actual publishing still requires the reviewed release PR to be merged.\n- No extra release verification scripts or workflow-side package logic added.\n\nVerification:\n- Parsed release.yml locally with Ruby YAML parser.