### PR TITLE
Fix Android submodule release cleanliness

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -21,7 +21,7 @@ android-kotlin-version = "2.0.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
 apple-backend-commit = "f4f1b2ef6622a10bfb6575ed723dfc2489f609dd"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
-android-backend-commit = "0f06ff8dd62bfb67f085808e00a3ee8c61277bd1"
+android-backend-commit = "d9a3eebfc693e835cee90e5500793b732eaa7850"
 
 [[bin]]
 name = "water"


### PR DESCRIPTION
Fix the release-plz blocker after the minimal release workflow repair.\n\nRoot cause:\n- backends/android tracked .idea/workspace.xml while .gitignore ignores .idea/.\n- release-plz rejects release updates when a submodule contains tracked ignored files.\n\nFix:\n- Remove the tracked IDE workspace file in android-backend.\n- Update the superproject Android submodule pointer.\n\nVerification:\n- Fresh recursive clone of remote dev succeeds.\n- git -C backends/android ls-files -ci --exclude-standard is empty on the fresh clone.\n\nRelease design note:\n- Merging this to main should let the existing workflow_run Release job run release-plz.\n- The intended release flow is still release-plz creating/updating a release PR from main changes; actual publishing remains gated on the reviewed release PR being merged.