### PR TITLE
Require release PR before publishing

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,6 +3,7 @@ pr_draft = false
 pr_labels = ["release"]
 git_release_name = "{{ package }}-v{{ version }}"
 publish = true
+release_always = false
 git_tag_enable = true
 changelog_update = true
 


### PR DESCRIPTION
This keeps the existing minimal Release workflow and fixes the publish gate through release-plz config instead of workflow scripting.

Verification:
- python3 tomllib parsed release-plz.toml successfully
- git diff --check passed
- release-plz release --dry-run --config release-plz.toml reported: skipping release: current commit is not from a release PR, with no releases

Policy:
- Ordinary main merges should create/update the release PR path, not publish directly.
- Publishing remains automatic only after an approved release PR is merged.
- No GitHub Actions workflow files are changed in this PR.

Context:
- The previous Release run showed that the action without this guard can continue into release publishing after release-pr handling. This PR uses release-plz native configuration to restore the intended approval gate.