### PR TITLE
Release baseline after dev merge

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,22 +83,22 @@ nami-core = { version = "0.3.2", path = "vendor/nami/core" }
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 thiserror = "2.0.18"
-waterui-core = { version = "0.2.0", path = "core" }
-waterui-str = { version = "0.2.1", path = "utils/str" }
-waterui-url = { version = "0.2.1", path = "utils/url" }
-waterui-text = { version = "0.2.2", path = "components/text" }
-waterui-media = { version = "0.2.1", path = "components/media" }
+waterui-core = { version = "0.2.1", path = "core" }
+waterui-str = { version = "0.2.2", path = "utils/str" }
+waterui-url = { version = "0.2.2", path = "utils/url" }
+waterui-text = { version = "0.2.3", path = "components/text" }
+waterui-media = { version = "0.2.2", path = "components/media" }
 waterui-image = { version = "0.2.1", path = "components/image" }
 waterui-video = { version = "0.2.1", path = "components/video" }
-waterui-form = { version = "0.2.1", path = "components/form" }
-waterui-controls = { version = "0.2.1", path = "components/controls"}
-waterui-graphics = { version = "0.2.1", path = "components/graphics" }
+waterui-form = { version = "0.2.2", path = "components/form" }
+waterui-controls = { version = "0.2.2", path = "components/controls"}
+waterui-graphics = { version = "0.2.2", path = "components/graphics" }
 waterui-canvas = { version = "0.1.0", path = "components/canvas" }
 waterui-shape = { version = "0.1.0", path = "components/shape" }
 waterui-svg = { version = "0.1.0", path = "components/svg" }
 waterui-ffi = { version = "0.2.1", path = "ffi" }
-waterui-layout = { version = "0.2.2", path = "components/layout" }
-waterui-navigation = { version = "0.2.1", path = "components/navigation" }
+waterui-layout = { version = "0.2.3", path = "components/layout" }
+waterui-navigation = { version = "0.2.2", path = "components/navigation" }
 waterui-webview = { version = "0.2.0", path = "components/webview" }
 waterui-icon = { version = "0.2.0", path = "components/icon" }
 waterui-icons-sf-symbol = { version = "0.1.0", path = "icon-packs/sf-symbol" }
@@ -120,8 +120,8 @@ waterkit-codec = { version = "0.1.0", path = "kit/codec", default-features = fal
 waterkit-video = { version = "0.1.0", path = "kit/video" }
 waterkit-build = { version = "0.1.0", path = "kit/waterkit-build" }
 waterui-backend-core = { version = "0.1.0", path = "backends/core" }
-filtrate = { version = "0.1.0", path = "utils/filtrate" }
-filtrate-core = { version = "0.1.0", path = "utils/filtrate-core" }
+filtrate = { version = "0.1.1", path = "utils/filtrate" }
+filtrate-core = { version = "0.1.1", path = "utils/filtrate-core" }
 waterui-barcode = { version = "0.1.0", path = "components/barcode" }
 waterui-particle = { version = "0.1.0", path = "components/particle" }
 waterui-chart = { version = "0.1.0", path = "components/chart" }
@@ -135,7 +135,7 @@ waterui = { version = "0.2.1", path = "." }
 waterui-build-support = { version = "0.1.0", path = "utils/build-support" }
 hydrolysis-m3 = { version = "0.1.0", path = "backends/hydrolysis-m3" }
 native-executor = { version = "0.7.0" }
-waterui-macros = { version = "0.2.1", path = "macros" }
+waterui-macros = { version = "0.2.2", path = "macros" }
 serde = { version = "1.0", default-features = false, features = ["alloc"] }
 wgpu = "27"
 encase = { version = "0.10", features = ["glam"] }

--- a/backends/core/CHANGELOG.md
+++ b/backends/core/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-backend-core-v0.1.0) - 2026-05-01
+
+### Added
+
+- complete phase 0b and phase 1+2r foundation
+- extract opacity from GPU filter pipeline + zero-alloc ViewDispatcher
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- enhance GTK components and layout integration for WaterUI
+- add GTK4 backend for WaterUI with core infrastructure and initial components
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Checkpoint current WaterUI changes
+- Reduce clippy noise across support crates
+- Fix local state rebuild semantics
+- Add scoped local state for chart composition overlays
+- Auto-install Meson on macOS when cargo build fails
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/backends/gtk/CHANGELOG.md
+++ b/backends/gtk/CHANGELOG.md
@@ -1,0 +1,108 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-gtk-v0.1.0) - 2026-05-01
+
+### Added
+
+- complete navigation parity across backends
+- *(video)* continue player parity work
+- *(particle)* add gpu collision physics
+- align focus state across backends
+- *(graphics)* finalize advanced filter pipeline and core integration
+- *(hydrolysis)* wire reactive rebuild loop through ViewBuilder roots
+- complete phase 0b and phase 1+2r foundation
+- extract opacity from GPU filter pipeline + zero-alloc ViewDispatcher
+- continue deep review fixes and ffi fast-fail cleanup
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(color)* enhance color handling with HDR support and new FFI functions
+- *(color)* enhance color handling with headroom support in conversions
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- enhance navigation controller with FFI support and renderer integration
+- add GTK4 List, Picker, Photo, and SecureField components; update Cargo.toml dependencies
+- enhance GPU support in GTK4 backend with wgpu-hal and glow dependencies
+- add GTK4 Color and LazyContainer components, and update dependencies for GPU support
+- update GTK components to improve layout handling and add padding support
+- add GTK backend support to WaterUI CLI
+- add GPU surface support with wgpu integration for GTK4 backend
+- Implement GTK4 components for WaterUI
+- enhance GTK components and layout integration for WaterUI
+- add GTK4 backend for WaterUI with core infrastructure and initial components
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Mark GTK pkg-config build dependency
+- Fix GTK WebKit link probing
+- Fix CI coverage and preview dylib targets
+- Fix GTK resolved native views and Windows dylib linking
+- Fix CI fontconfig deps and README doctests
+- Clean dev CI and example builds
+- Clean reactive view composition anti-patterns
+- snapshot in-progress canonical changes
+- Implement testing roadmap coverage and CI reporting
+- Refactor split navigation around stable selection ids
+- Checkpoint current WaterUI changes
+- Reduce clippy noise across support crates
+- Implement review fixes and native multi-date picker
+- Refactor asset and icon build helpers
+- Fix local state rebuild semantics
+- Fix async filter setup handling
+- Add semantic chart interaction testing
+- Improve GTK backend completeness and filter support
+- bridge view dimensions across backends
+- checkpoint all in-progress workspace changes
+- checkpoint all in-progress workspace changes
+- commit pending workspace changes on dev
+- *(raw-view)* migrate resolved color to native backends
+- *(gtk)* align gpu surface redraw contract with request_redraw
+- enforce fast-fail rules and remove legacy fallback paths
+- commit full review and inspector/runtime updates
+- Auto-install Meson on macOS when cargo build fails
+- Remove on_demand and add needs_redraw
+- Fix GTK main thread executor and video renderer
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency
+- Linux-only GPU surface + WaterUI layout
+- anyviews watch FFI + preview/gtk/window improvements
+- Update android backend
+- fix axis overlap and enable AA on HDR
+- Add preview system and refactor core APIs
+- Update backend submodules
+- Fix the import of waterui-graphics
+- Refactor color module to use waterui_graphics
+- Remove Hydrolysis backend components and related infrastructure
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/backends/hydrolysis-m3/CHANGELOG.md
+++ b/backends/hydrolysis-m3/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/hydrolysis-m3-v0.1.0) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Fix Hydrolysis and testing strict lints
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean reactive view composition anti-patterns
+- split hydrolysis renderer architecture
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/backends/hydrolysis/CHANGELOG.md
+++ b/backends/hydrolysis/CHANGELOG.md
@@ -1,0 +1,194 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/hydrolysis-v0.1.0) - 2026-05-01
+
+### Added
+
+- deepen semantic label integration
+- add popup menu surfaces to hydrolysis
+- unify label semantics and menu runtimes
+- unify label semantics and menu surfaces
+- *(runtime)* unify gesture semantics and picker backends
+- *(form)* add picker radio group parity
+- *(testing)* add waterui::test macro and a11y-first ui test runtime
+- *(hydrolysis)* finalize accessibility migration and wayland smoke verification
+- *(hydrolysis)* add image accessibility for gpu and scene views
+- *(hydrolysis)* extend list/table and icon accessibility semantics
+- *(hydrolysis)* implement menu picker option selection and Str caching
+- *(a11y)* add hidden/children/state metadata and suppress duplicate child semantics
+- *(hydrolysis)* expand accesskit semantics for text and composite views
+- *(hydrolysis)* wire accesskit accessibility tree and actions
+- *(hydrolysis)* add HydrolysisExt and HydrolysisGpuView wrapper
+- *(hydrolysis)* install offscreen ViewRenderer for environment capture
+- *(scene2d)* add SceneView pipeline and migrate canvas from direct vello
+- *(hydrolysis)* make navigation stack rebuildable with destination builders
+- *(hydrolysis)* add advanced handlers for navigation tabs list table and view effect
+- *(hydrolysis)* implement winit IME event flow for text inputs
+- *(hydrolysis)* add gesture observer tap handling
+- *(hydrolysis)* implement focused and hittable metadata semantics
+- *(hydrolysis)* close input/event loop and add wayland smoke docker runner
+- *(hydrolysis)* implement scroll view state and wheel input routing
+- *(hydrolysis)* add animation controller for toggle and transform metadata
+- *(hydrolysis)* wire reactive rebuild loop through ViewBuilder roots
+- *(hydrolysis)* add native control handlers with shared pointer targets
+- *(hydrolysis)* use parley intrinsic text measurement in layout
+- *(hydrolysis)* route pointer clicks to button actions
+- *(hydrolysis)* register SystemIcon native handler
+- *(hydrolysis)* add GpuSurface native handler
+- *(hydrolysis)* render Str and TextConfig via parley + vello
+- *(hydrolysis)* add native handlers for button and dynamic
+- *(hydrolysis)* switch AppliedFilter compositing to pure GPU path
+- *(hydrolysis)* add core primitive and metadata handlers
+- *(hydrolysis)* add platform abstraction and app runner skeleton
+- *(hydrolysis)* add core renderer and context foundation
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Refactor rendering logic
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(android)* enhance Java environment detection for macOS by including Android Studio's bundled JBR
+- add initial form component file
+- Add watcher functionality for AnyViews and related types
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- *(hydrolysis)* replay cached Dynamic side effects on rebuild
+- *(hydrolysis)* add scroll semantics and remove list/table a11y duplication
+- *(hydrolysis)* support bgra surfaces and stabilize wayland smoke
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+- *(dependencies)* replace log with tracing for improved logging consistency
+
+### Other
+
+- Fix CI dependency and WaterKit lint blockers
+- Fix Hydrolysis and testing strict lints
+- Prepare dev for release automation
+- Allow Hydrolysis testing adapters in test host
+- Fix Hydrolysis CI offscreen test adapter
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Fix Android packaging toolchain resolution
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Add view builder macros and migrate branchy views
+- Tighten reactive text updates and remove redundant AnyView
+- Restore extractor-based testing actions
+- refactor handler state extraction
+- Add date picker testing support
+- split hydrolysis renderer architecture
+- snapshot in-progress canonical changes
+- Implement testing roadmap coverage and CI reporting
+- Fix hydrolysis testing regressions
+- Use hydrolysis headless runtime in testing
+- Refactor split navigation around stable selection ids
+- Checkpoint current WaterUI changes
+- Re-setup hydrolysis gpu surfaces on format changes
+- Fix local state rebuild semantics
+- Persist hydrolysis effect and scene runtimes
+- Persist hydrolysis applied filters
+- Fix async filter setup handling
+- bridge view dimensions across backends
+- rewrite alignment guides as wrapper views
+- add alignment guides and paragraph alignment
+- checkpoint local workspace changes
+- Fix filter setup, sizing, and dynamic-range handling
+- checkpoint all in-progress workspace changes
+- checkpoint all in-progress workspace changes
+- fix probe_accessibility_runtime call path in winit runner
+- prioritize hit targets by paint order over tree depth
+- gate accesskit on runtime bus and fix slider edge drag hitbox
+- lock slider drag and switch caret to fade animation
+- stop rebuild-loop pointer replay and stabilize slider drag
+- handle accessibility root focus without panic
+- prioritize gesture hit targets by depth and order
+- modularize gesture engine and sync layout-coupled input
+- fix logical hit/input coordinates and text input caret state
+- keep pointer input in physical coordinate space
+- fast-fail unsupported accessibility actions
+- map winit pointer coordinates to logical space
+- pin tracing-subscriber dependency locally
+- initialize tracing subscriber from RUST_LOG
+- keep accessibility node ids monotonic across frames
+- remove temporary accesskit action panic
+- debug trap accesskit action delivery
+- drop tracing subscriber bootstrap for runner
+- pin tracing-subscriber dependency locally
+- initialize tracing subscriber from RUST_LOG
+- fast-fail on unmapped accessibility action targets
+- accept accessibility actions from non-root trees
+- restore control hit testing and text input accessibility focus
+- fix text input focus order and render text caret
+- align hit testing order with UIKit depth priority
+- use spring animation for default toggle transitions
+- keep dynamic intrinsic cache across frames
+- fix pointer dispatch and winit scale/input hit mapping
+- fix control hit regions and slider pointer mapping
+- remove progress intrinsic dependency on dynamic labels
+- remove unsynced gpu surface hdr path
+- normalize slider labels before intrinsic measure
+- drop unrelated gpu-surface HDR changes from text fix
+- support waterui_text::Text in intrinsic measurement
+- wire character key presses into text input
+- implement non-tap gesture pipeline on winit
+- add winit input mapping regression tests
+- add render phase diagnostics instrumentation
+- align winit pointer and wheel coordinates with hit-test space
+- implement SubView for HydrolysisGpuView and align async setup
+- add reactive redraw pipeline and unified resource drawing
+- Implement Animatable pipeline and native filtered blur hooks
+- add reactive redraw pipeline and unified resource drawing
+- virtualize lazy container list and table rendering
+- Fix hydrolysis input hit-testing and dynamic intrinsic layout
+- *(hydrolysis)* remove ffmpeg and dav1d deps from wayland smoke image
+- commit pending workspace changes on dev
+- *(str)* migrate chart, drag-drop, and ime paths to Str
+- *(hydrolysis)* move navigation view a11y registration out of render
+- land style/transition/line-limit renderer support
+- complete TextField IME preedit/commit path
+- align list intrinsic with normalized layout path
+- make tabs intrinsic stable across pages
+- replace fixed native intrinsic sizing
+- fix intrinsic text/empty views and native table hook
+- *(hydrolysis)* add HydrolysisExt offscreen regression
+- *(hydrolysis)* format animation and scroll helpers
+- *(hydrolysis)* unify kurbo to single graph instance
+- *(hydrolysis)* migrate to crates.io linebender deps
+- *(hydrolysis)* remove legacy node/render command skeleton
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- Refactor color module to use waterui_graphics
+- Remove Hydrolysis backend components and related infrastructure
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Remove TUI backend and associated files
+- Enhance documentation and improve code clarity across multiple modules
+- Refactor and clean up code across multiple components
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,255 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.4](https://github.com/water-rs/waterui/compare/cli-v0.1.3...cli-v0.1.4) - 2026-05-01
+
+### Added
+
+- unify label semantics and menu runtimes
+- unify label semantics and menu surfaces
+- continue deep review fixes and ffi fast-fail cleanup
+- ship gpu on-demand rendering, animation updates, and cli/runtime sync
+- integrate assets, media, and runtime updates
+- *(cli)* add confirmed recursive clean mode
+- *(preview)* Add water preview command for view rendering
+- Support keyboard command on macOS
+- Implement Audio Visualizer with Microphone Input and CLI Permission Support
+- *(icons)* Refactor icon system with extensible CLI architecture
+- Introduce `waterui-canvas`, `waterui-shape`, and `waterui-svg` crates, refactor graphics components, and integrate Vello for advanced rendering.
+- enhance font management and color handling across platforms
+- font bundling system and download icons at build time
+- enhance error reporting in command execution and add target triple retrieval
+- add Kotlin and Java support to Android toolchain and diagnostics
+- Add support for streaming native platform logs in run options and log streaming
+- add macOS local device gesture support and screenshot functionality
+- Implement screenshot capture functionality for iOS and Android devices
+- *(android)* enhance log streaming to capture panic information
+- Enhance panic handling and logging in macOS device management
+- Enhance macOS crash detection and logging
+- *(cli)* implement crash debugging output and enhance logging
+- *(shape)* Introduce shape system for view clipping and filling
+- add GTK4 Color and LazyContainer components, and update dependencies for GPU support
+- Introduce TargetPlatform enum and migrate backends
+- add GTK backend support to WaterUI CLI
+- Enhance window management and hot reload functionality
+- *(media-picker)* add media picker example with photo, video, and live photo selection
+- Add mac screenshot image and improve markdown example
+- *(cli)* enable hot reload by default for water run
+- Enhance panic logging and error handling in Apple backends
+- enhance logging levels for Apple platforms and improve app structure
+- *(examples)* add gesture and list examples with corresponding templates and assets
+- *(android)* streamline APK installation process and add CMake toolchain wrapper for ABI support
+- *(android)* switch from ComponentActivity to AppCompatActivity and disable Compose
+- *(android)* implement multi-ABI packaging support and optimize build configurations
+- *(android)* add support for multiple architectures and clean jniLibs
+- Rewrite CLI
+- Add project creation with git initialization and new playground example
+- Update dependencies and enhance backend configurations
+- Implement hot reload server and connection handling
+- Enhance Apple platform support with new platform kinds and SDKs
+- Add initial Android and Apple project templates
+- enhance Android and Apple platform support with new configurations and utility functions
+- update platform implementations for Android and Apple, improve function signatures and add architecture handling
+- enhance platform support and add new build options for Android and Apple
+- enhance Android and Apple device support with new functionalities
+- enhance Android and Apple platform support, add Homebrew toolchain manager
+- *(android)* refactor backend and platform modules
+- Enhance async support and device scanning in backend implementations
+- Refactor toolchain error handling and enhance hot reload configuration
+- Implement report generation for various command results
+- Introduce async runtime and enhance file watcher functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance video component functionality and interrupt handling
+- Enhance Android packaging and hot reload functionality
+- Introduce permission management for playground projects
+- Add CLAUDE.md for project guidance and build instructions
+- Implement interruptible command execution and secure metadata handling
+- Enhance panic reporting and logging in hot reload system
+- Introduce comprehensive logging and panic reporting plan
+- Enhance debugging and layout system in Apple backend
+- Implement safe area handling in layout system
+- Enhance local development mode for WaterUI
+- Rename Android library to libwaterui_app.so
+- add Gemini CLI assistant documentation and subagent manager script
+- add Git commit hash to build output and update dependencies
+- enhance Dockerfile and documentation for improved build and configuration
+- enhance Android platform support with target triples and improve artifact stripping
+- integrate hyper and tungstenite for hot reload server functionality
+- *(run)* implement hot reload support and ensure cdylib generation
+- *(android)* enhance NDK toolchain checks and environment configuration
+- *(logging)* add log filter support for hot reload and CLI
+- *(logging)* enhance tracing and panic forwarding for improved log management
+- *(hot_reload)* implement hot reload support for FFI and backend configurations
+- update dependencies to use git sources and improve error handling in CLI
+- *(android)* enhance Java environment detection for macOS by including Android Studio's bundled JBR
+- add debugging workflow checklist and enhance non-interactive terminal handling
+- Add watcher functionality for AnyViews and related types
+- *(apple)* enhance simulator boot logic and add state checking
+- *(device)* add platform filtering for device listing
+- document hot reload support for Android, Apple, Web, and TUI backends
+- add TUI platform support and enhance hot reload functionality
+- *(hot-reload)* enhance hot reload configuration and update related commands
+- Introduce build command for native artifacts
+- *(cli)* enhance Android backend integration with improved logging and automation
+- enhance Android backend integration and logging capabilities
+- *(cli)* add backend list command
+- *(cli)* support backend upgrade with ffi checks
+- *(cli)* add backend management command
+- *(cli)* use local android backend in dev
+- Update Android project structure and dependencies for improved backend integration
+- Implement hot reload functionality with configurable environment
+
+### Fixed
+
+- fix playground cache layout and cli cache bugs
+- fix cli review regressions
+- *(preview)* harden symbol resolution and render error handling
+- *(android)* keep emulator alive and prefer Vulkan shared context
+- *(android)* bundle libc++_shared for Rust JNI apps
+- *(log)* Change log streaming level to default and increase timeout duration
+- enhance CLI launch command handling and update environment variable documentation
+- update android backend dependency version to 0.2.0
+- update minimum version for Swift package reference to 0.2.0
+- update repository URLs in template files for Apple and Android backends
+- update README and Cargo.toml files to specify README.md for all components
+- update waterui version to 0.2 in templates and documentation
+- format function parameters for better readability in tests
+- update dependencies and improve path handling in template context
+- improve code formatting and readability across multiple files
+- correct spelling errors and improve comments across the codebase
+- update llvm-strip command to preserve dynamic symbol table
+- improve interrupt handling in wait_for_interrupt function
+- remove hot reload import for non-WASM targets
+- clean up imports and improve command output messages in Android and Apple device modules
+- *(android)* add INTERNET permission to AndroidManifest for network access
+- *(dependencies)* replace log with tracing for improved logging consistency
+
+### Other
+
+- Prepare release baseline versions
+- Sync Android backend scaffold ref
+- Sync Apple backend scaffold ref
+- Verify Android host tools after doctor fixes
+- Prepare dev for release automation
+- Remove WaterKit fs from release crates
+- Sync Apple backend scaffold ref
+- Fix preview dylib platform matching
+- Fix CI coverage and preview dylib targets
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Fix Android packaging toolchain resolution
+- Fix Apple simulator packaging build settings
+- Optimize preview wrapper linking
+- expose support app render timings
+- trim crate-type override and persist support logs
+- trim dylib debug info and init support tracing
+- move rust stdlib rpath to build and drop runtime dylib patching
+- use local-path render in CLI and unify HasDylib cache truth
+- use local dylib path and extend support-app idle lifetime
+- enforce dev dynamic-linking and split runtime wrapper crates
+- Fix remaining preview support app workarounds
+- Optimize preview support app launch and hot path
+- Stabilize preview runtime fingerprint identity
+- Align scaffold backends and versions to build refs
+- Fix CLI dev checkout mode detection
+- Refactor waterui-cli lint-heavy command flows
+- *(cli)* type-safe template scaffolding
+- Refactor CLI managed build cache
+- snapshot in-progress canonical changes
+- remove legacy asset pipeline
+- add clean flag for global playground cache
+- unify cache and support app helpers
+- Remove cached font archives after extraction
+- Fix recursive clean cache discovery
+- Checkpoint current WaterUI changes
+- Refactor asset and icon build helpers
+- checkpoint all in-progress workspace changes
+- Fix form text-field freeze and add cross-distro Linux doctor checks
+- Bump dependency versions across workspace
+- checkpoint all in-progress workspace changes
+- include waterui dependency in generated hydrolysis backend crates
+- refresh stale playground hydrolysis scaffolding when deps drift
+- implement app/playground backend orchestration
+- *(cli)* remove obsolete dav1d toolchain integration
+- commit pending workspace changes on dev
+- enforce fast-fail rules and remove legacy fallback paths
+- commit full review and inspector/runtime updates
+- harden fast-fail paths and runtime compatibility
+- Auto-install Meson on macOS when cargo build fails
+- Fix GTK main thread executor and video renderer
+- Enhance video, chart, and locale platform support
+- Refactor MediaPicker and add reminders example
+- *(cli)* use async fs checks in recursive clean
+- Add smart asset management system with asset! macro
+- Remove hot reload functionality in favor of preview system
+- Add Android JNI FFI support and improve CLI process management
+- Move static assets to R2 CDN and add PID-based window capture
+- Enhance documentation and examples for reactive patterns in WaterUI, including new guidelines for bindings and real-time updates
+- Add sccache support for improved build performance and caching
+- Refactor preview app communication and remove unresponsive app handling
+- Enhance preview app communication and error handling
+- Refactor code for improved readability and consistency
+- anyviews watch FFI + preview/gtk/window improvements
+- Fix ZStack stretch behavior
+- Integrate preview TCP server into view
+- Add preview system and refactor core APIs
+- CLI improvements and misc updates
+- simplify `text!` macro calls by removing the `waterui::` prefix.
+- rename GTK backend to GTK4
+- release
+- Release 0.2.0
+- release
+- improve code readability and consistency across multiple files
+- Refactor layout tests to use approximate equality for floating-point comparisons
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- streamline media picker and loading state management
+- Refactor Native Component and Improve Error Handling
+- Refactor Android device run logic and update Gradle configurations for improved build process
+- Add log level management for device log streaming across platforms
+- Enhance Android and Apple backends with permission management and Gradle build improvements
+- Add AndroidEmulator device and defer launch to CLI
+- Embed CLI commit hash and add water dir management
+- Add Android SDK path helpers and use adb_path
+- Switch zenwave/skyzen to crates.io versions
+- Add playground backend paths and target dir support
+- Update submodules and enhance macOS launcher UI
+- Implement CLI commands for WaterUI: build, clean, create, devices, doctor, package, and run
+- Enhance documentation and improve code clarity across multiple modules
+- Refactor backend trait and implement new build system
+- WTF...Let's rewrite it!
+- clean up and enhance project structure and backend definitions
+- Refactor CLI toolchain and installation modules
+- Refactor and clean up code across multiple components
+- Refactor layout components and improve documentation
+- Simplify WebSocket close handling and clean up code formatting
+- Update workspace configuration and dependencies for examples
+- Clean up hot reload session logging and initialization
+- Simplify hot reload configuration for Android and Apple devices
+- Update hot reload configuration and enhance dependencies
+- Remove deprecated files and streamline project structure
+- Streamline playground project handling and enhance build process
+- Clean up project structure and enhance CLI functionality
+- Update backend submodules and enhance CLI device commands
+- Refactor CLI commands for device management and enhance roadmap documentation
+- Update Android backend submodule and adjust padding in template
+- Update Android backend submodule and modify build process
+- Standardize library naming for Android and Apple backends
+- Update android backend submodule and enhance clean command functionality
+- Update documentation and add CMake checks for Apple builds
+- Enhance WaterUI CLI documentation and add screenshot capture feature
+- Fix CLI to copy libc++_shared.so to jniLibs for Android builds
+- remove unused hyper and tungstenite dependencies, integrate skyzen for hot reload functionality
+- simplify hot reload library path handling and extract filename logic
+- prefer Android Studio JBR when Java missing
+- Align Android tooling and agent workflow
+- Refactor Apple backend integration and remove deprecated files
+- *(build)* streamline argument handling in build script
+- Enhance UI output handling and add terminal utilities for improved user experience
+- Improve command construction and error handling in project build and run functions
+- Refactor CLI structure and remove unused modules
+- Start to refractor WaterUI CLI...
+- Rename no_watch argument to no_hot_reload for clarity and update related function signatures
+
 ## [0.1.2](https://github.com/water-rs/waterui/compare/cli-v0.1.1...cli-v0.1.2) - 2025-12-14
 
 ### Fixed

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-cli"
-version = "0.1.3"
+version = "0.1.4"
 edition.workspace = true
 authors.workspace = true
 rust-version.workspace = true

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-cli"
-version = "0.1.2"
+version = "0.1.3"
 edition.workspace = true
 authors.workspace = true
 rust-version.workspace = true

--- a/components/assets-macros/CHANGELOG.md
+++ b/components/assets-macros/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-assets-macros-v0.1.0) - 2026-05-01
+
+### Added
+
+- *(video)* continue player parity work
+- integrate assets, media, and runtime updates
+
+### Other
+
+- Prepare dev for release automation
+- Fix Android tooling and strict linting
+- Reduce clippy noise across support crates
+- Refine clippy anti-pattern fixes
+- Refactor asset and icon build helpers
+- Unify asset planning and theme packaging
+- Refactor MediaPicker and add reminders example
+- Add smart asset management system with asset! macro

--- a/components/assets-planner/CHANGELOG.md
+++ b/components/assets-planner/CHANGELOG.md
@@ -1,0 +1,52 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/assets-planner-v0.1.0) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean reactive view composition anti-patterns
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/assets/CHANGELOG.md
+++ b/components/assets/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/assets-v0.1.0) - 2026-05-01
+
+### Added
+
+- *(video)* continue player parity work
+- integrate assets, media, and runtime updates
+
+### Other
+
+- Prepare dev for release automation
+- Add release crate READMEs
+- Remove WaterKit fs from release crates
+- Fix CI coverage and preview dylib targets
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- unify cache and support app helpers
+- Reduce clippy noise across support crates
+- Refactor asset and icon build helpers
+- Unify asset planning and theme packaging
+- enforce fast-fail rules and remove legacy fallback paths
+- commit full review and inspector/runtime updates
+- Refactor MediaPicker and add reminders example
+- Add smart asset management system with asset! macro

--- a/components/barcode/CHANGELOG.md
+++ b/components/barcode/CHANGELOG.md
@@ -1,0 +1,69 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-barcode-v0.1.0) - 2026-05-01
+
+### Added
+
+- *(graphics)* finalize GPU-first filters and generators
+- *(graphics)* finalize advanced filter pipeline and core integration
+- continue deep review fixes and ffi fast-fail cleanup
+- *(barcode)* add pure-GPU Code128 barcode support
+- integrate assets, media, and runtime updates
+- Migrate embedded shaders to separate WGSL files
+- Implement waterui-barcode component
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- complete gpu surface fast-fail redraw and abi sync
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Implement testing roadmap coverage and CI reporting
+- Reduce clippy noise across support crates
+- checkpoint all in-progress workspace changes
+- enforce GpuView SubView impls and explicit GpuContext lifetimes
+- commit pending workspace changes on dev
+- commit full review and inspector/runtime updates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/canvas/CHANGELOG.md
+++ b/components/canvas/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-canvas-v0.1.0) - 2026-05-01
+
+### Added
+
+- *(chart)* add interactive canvas gestures
+- *(graphics)* finalize advanced filter pipeline and core integration
+- *(scene2d)* add SceneView pipeline and migrate canvas from direct vello
+- continue deep review fixes and ffi fast-fail cleanup
+- integrate assets, media, and runtime updates
+- *(graphics)* Improve GPU surface and rendering pipeline
+- Migrate embedded shaders to separate WGSL files
+- Async GpuRenderer setup for flicker-free window display
+- Introduce `waterui-canvas`, `waterui-shape`, and `waterui-svg` crates, refactor graphics components, and integrate Vello for advanced rendering.
+
+### Fixed
+
+- complete gpu surface fast-fail redraw and abi sync
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI xcb dependency and canvas clippy
+- Fix CI formatting and dependency checks
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Implement testing roadmap coverage and CI reporting
+- Extract image crate and tighten native rendering
+- checkpoint local workspace changes
+- checkpoint all in-progress workspace changes
+- checkpoint all in-progress workspace changes
+- add reactive redraw pipeline and unified resource drawing
+- Implement Animatable pipeline and native filtered blur hooks
+- add reactive redraw pipeline and unified resource drawing
+- commit full review and inspector/runtime updates
+- Refactor code for improved readability and consistency

--- a/components/chart/CHANGELOG.md
+++ b/components/chart/CHANGELOG.md
@@ -1,0 +1,90 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-chart-v0.1.0) - 2026-05-01
+
+### Added
+
+- *(chart)* add interactive canvas gestures
+- *(chart)* migrate chart views to canvas scene pipeline
+- continue deep review fixes and ffi fast-fail cleanup
+- ship gpu on-demand rendering, animation updates, and cli/runtime sync
+- integrate assets, media, and runtime updates
+- *(chart)* Add chart component crate
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- complete gpu surface fast-fail redraw and abi sync
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Fix chart test lint issues
+- Prepare dev for release automation
+- Keep chart readout shell inside viewport
+- Fix CI fontconfig deps and README doctests
+- Fix CI formatting and dependency checks
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Fix Android packaging toolchain resolution
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Add view builder macros and migrate branchy views
+- Tighten reactive text updates and remove redundant AnyView
+- refactor handler state extraction
+- Unify semantic text and label inputs
+- Checkpoint current WaterUI changes
+- Reduce clippy noise across support crates
+- Implement review fixes and native multi-date picker
+- Add cartesian chart selection and scrolling APIs
+- Add chart tooltip overlay orchestration
+- Add scoped local state for chart composition overlays
+- Fix chart readout snapshots in offscreen testing
+- Remove legacy chart test support entry
+- Add semantic chart interaction testing
+- Refine chart E2E testing support
+- *(testing)* extract query builder and widen chart coverage
+- checkpoint all in-progress workspace changes
+- Bump dependency versions across workspace
+- checkpoint all in-progress workspace changes
+- commit pending workspace changes on dev
+- *(str)* migrate chart, drag-drop, and ime paths to Str
+- *(chart)* remove legacy wgsl renderer stack
+- commit full review and inspector/runtime updates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency
+- fix axis overlap and enable AA on HDR
+- Refactor handler API and modernize bindings
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/controls/Cargo.toml
+++ b/components/controls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-controls"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/form/Cargo.toml
+++ b/components/form/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-form"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/graphics/Cargo.toml
+++ b/components/graphics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-graphics"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/image/CHANGELOG.md
+++ b/components/image/CHANGELOG.md
@@ -1,0 +1,58 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/water-rs/waterui/releases/tag/image-v0.2.1) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Checkpoint current WaterUI changes
+- Extract image crate and tighten native rendering
+- Checkpoint image crate extraction and locale updates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/inspector-protocol/CHANGELOG.md
+++ b/components/inspector-protocol/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/inspector-protocol-v0.1.0) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean reactive view composition anti-patterns
+- Reduce clippy noise across support crates
+- commit full review and inspector/runtime updates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/layout/Cargo.toml
+++ b/components/layout/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-layout"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/map/CHANGELOG.md
+++ b/components/map/CHANGELOG.md
@@ -1,0 +1,60 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-map-v0.1.0) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- add Map component with FFI bindings, example, and configuration
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- *(map)* Use Location getter methods for private fields
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- Fix Android packaging toolchain resolution
+- Fix reactive constant API inputs
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Reduce clippy noise across support crates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Refactor MediaPicker and add reminders example
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/media/Cargo.toml
+++ b/components/media/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-media"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/navigation/Cargo.toml
+++ b/components/navigation/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-navigation"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/particle/CHANGELOG.md
+++ b/components/particle/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-particle-v0.1.0) - 2026-05-01
+
+### Added
+
+- *(particle)* add gpu neighbor grid interactions
+- *(particle)* support multi-obstacle gpu collisions
+- *(particle)* add gpu collision physics
+- continue deep review fixes and ffi fast-fail cleanup
+- *(particle)* Improve GPU particle system with encase
+- introduce GPU particle system and refactor filtrate-core with new filter implementations and shader architecture
+
+### Fixed
+
+- *(particle)* preserve blending on hdr surfaces
+- *(particle)* stabilize gpu offscreen rendering
+- *(particle)* correct particle rendering basics
+- complete gpu surface fast-fail redraw and abi sync
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI coverage and preview dylib targets
+- Fix CI formatting and dependency checks
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Expand hydrolysis UI testing coverage
+- *(particle)* move frame timing into renderer
+- Bump dependency versions across workspace
+- checkpoint all in-progress workspace changes
+- enforce GpuView SubView impls and explicit GpuContext lifetimes
+- commit pending workspace changes on dev
+- commit full review and inspector/runtime updates
+- Remove on_demand and add needs_redraw
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency
+- Refactor handler API and modernize bindings

--- a/components/preview-protocol/CHANGELOG.md
+++ b/components/preview-protocol/CHANGELOG.md
@@ -1,0 +1,64 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/preview-protocol-v0.1.0) - 2026-05-01
+
+### Added
+
+- ship gpu on-demand rendering, animation updates, and cli/runtime sync
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Remove WaterKit fs from release crates
+- Fix preview dylib platform matching
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- expose support app render timings
+- enforce dev dynamic-linking and split runtime wrapper crates
+- Optimize preview support app launch and hot path
+- Clean reactive view composition anti-patterns
+- Use imports for type paths
+- Reduce clippy noise across support crates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor preview app communication and remove unresponsive app handling
+- Refactor code for improved readability and consistency
+- anyviews watch FFI + preview/gtk/window improvements
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/preview/CHANGELOG.md
+++ b/components/preview/CHANGELOG.md
@@ -1,0 +1,76 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-preview-v0.1.0) - 2026-05-01
+
+### Added
+
+- ship gpu on-demand rendering, animation updates, and cli/runtime sync
+- integrate assets, media, and runtime updates
+- *(preview)* Add water preview command for view rendering
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- *(preview)* harden symbol resolution and render error handling
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI coverage and preview dylib targets
+- Fix CI fontconfig deps and README doctests
+- Clean dev CI and example builds
+- split blocking queue and dlopen timing
+- expose support app render timings
+- trim crate-type override and persist support logs
+- trim dylib debug info and init support tracing
+- move rust stdlib rpath to build and drop runtime dylib patching
+- use local-path render in CLI and unify HasDylib cache truth
+- use local dylib path and extend support-app idle lifetime
+- enforce dev dynamic-linking and split runtime wrapper crates
+- Optimize preview support app launch and hot path
+- Clean reactive view composition anti-patterns
+- unify cache and support app helpers
+- Reduce clippy noise across support crates
+- Bump dependency versions across workspace
+- enforce fast-fail rules and remove legacy fallback paths
+- commit full review and inspector/runtime updates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor preview app communication and remove unresponsive app handling
+- Enhance preview app communication and error handling
+- Refactor code for improved readability and consistency
+- anyviews watch FFI + preview/gtk/window improvements
+- Integrate preview TCP server into view
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/shape/CHANGELOG.md
+++ b/components/shape/CHANGELOG.md
@@ -1,0 +1,45 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-shape-v0.1.0) - 2026-05-01
+
+### Added
+
+- complete phase 0b and phase 1+2r foundation
+- continue deep review fixes and ffi fast-fail cleanup
+- ship gpu on-demand rendering, animation updates, and cli/runtime sync
+- integrate assets, media, and runtime updates
+- *(graphics)* Improve GPU surface and rendering pipeline
+- introduce GPU particle system and refactor filtrate-core with new filter implementations and shader architecture
+- Async GpuRenderer setup for flicker-free window display
+- introduce GPU texture filtering utility and image example, refactor media components
+- Introduce `waterui-canvas`, `waterui-shape`, and `waterui-svg` crates, refactor graphics components, and integrate Vello for advanced rendering.
+
+### Fixed
+
+- complete gpu surface fast-fail redraw and abi sync
+- *(graphics)* robust pipeline cache retry logic for renderers
+
+### Other
+
+- Prepare dev for release automation
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Reduce clippy noise across support crates
+- Bump dependency versions across workspace
+- checkpoint all in-progress workspace changes
+- enforce GpuView SubView impls and explicit GpuContext lifetimes
+- commit pending workspace changes on dev
+- commit full review and inspector/runtime updates
+- Auto-install Meson on macOS when cargo build fails
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Refactor code for improved readability and consistency

--- a/components/svg/CHANGELOG.md
+++ b/components/svg/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/svg-v0.1.0) - 2026-05-01
+
+### Added
+
+- *(svg)* switch Svg to SceneView and share scene data parser
+- continue deep review fixes and ffi fast-fail cleanup
+- integrate assets, media, and runtime updates
+- *(graphics)* Improve GPU surface and rendering pipeline
+- Migrate embedded shaders to separate WGSL files
+- Async GpuRenderer setup for flicker-free window display
+- Introduce `waterui-canvas`, `waterui-shape`, and `waterui-svg` crates, refactor graphics components, and integrate Vello for advanced rendering.
+
+### Fixed
+
+- complete gpu surface fast-fail redraw and abi sync
+
+### Other
+
+- Prepare dev for release automation
+- Add release crate READMEs
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Add view builder macros and migrate branchy views
+- Extract image crate and tighten native rendering
+- Reduce clippy noise across support crates
+- bridge view dimensions across backends
+- checkpoint all in-progress workspace changes
+- enforce GpuView SubView impls and explicit GpuContext lifetimes
+- add reactive redraw pipeline and unified resource drawing
+- Implement Animatable pipeline and native filtered blur hooks
+- add reactive redraw pipeline and unified resource drawing
+- commit full review and inspector/runtime updates
+- harden fast-fail paths and runtime compatibility
+- Remove on_demand and add needs_redraw
+- Refactor code for improved readability and consistency

--- a/components/text/Cargo.toml
+++ b/components/text/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-text"
-version = "0.2.2"
+version = "0.2.3"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/components/video/CHANGELOG.md
+++ b/components/video/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/water-rs/waterui/releases/tag/video-v0.2.1) - 2026-05-01
+
+### Added
+
+- unify label semantics and menu runtimes
+- unify label semantics and menu surfaces
+- *(form)* add picker parity across native backends
+- *(graphics)* finalize GPU-first filters and generators
+- *(video)* expand fallback player policy and diagnostics
+- continue deep review fixes and ffi fast-fail cleanup
+- integrate assets, media, and runtime updates
+
+### Fixed
+
+- complete gpu surface fast-fail redraw and abi sync
+
+### Other
+
+- Fix PiP button lint on unsupported platforms
+- Fix Hydrolysis and testing strict lints
+- Prepare dev for release automation
+- Fix video clippy on Linux
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Fix Android packaging toolchain resolution
+- Fix reactive constant API inputs
+- Simplify runtime player reactive composition
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Add view builder macros and migrate branchy views
+- Tighten reactive text updates and remove redundant AnyView
+- refactor handler state extraction
+- Fix reactive text and label misuse
+- Reduce clippy noise across support crates
+- bridge view dimensions across backends
+- checkpoint all in-progress workspace changes
+- checkpoint all in-progress workspace changes
+- enforce GpuView SubView impls and explicit GpuContext lifetimes
+- commit pending workspace changes on dev
+- enforce fast-fail rules and remove legacy fallback paths
+- commit full review and inspector/runtime updates
+- ship rust fallback player updates and HDR test example
+- Auto-install Meson on macOS when cargo build fails
+- Remove on_demand and add needs_redraw
+- Fix GTK main thread executor and video renderer
+- Enhance video, chart, and locale platform support

--- a/components/visualizer/CHANGELOG.md
+++ b/components/visualizer/CHANGELOG.md
@@ -1,0 +1,63 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/water-rs/waterui/releases/tag/waterui-visualizer-v0.2.1) - 2026-05-01
+
+### Added
+
+- continue deep review fixes and ffi fast-fail cleanup
+- integrate assets, media, and runtime updates
+- *(visualizer)* Add audio visualizer component crate
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- complete gpu surface fast-fail redraw and abi sync
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Bump dependency versions across workspace
+- checkpoint all in-progress workspace changes
+- enforce GpuView SubView impls and explicit GpuContext lifetimes
+- commit pending workspace changes on dev
+- commit full review and inspector/runtime updates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- *(deps)* route waterkit deps through workspace
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/components/webview/CHANGELOG.md
+++ b/components/webview/CHANGELOG.md
@@ -1,0 +1,65 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0](https://github.com/water-rs/waterui/releases/tag/waterui-webview-v0.2.0) - 2026-05-01
+
+### Added
+
+- continue deep review fixes and ffi fast-fail cleanup
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- *(webview)* Add redirect handling and script injection capabilities
+- *(webview)* Enhance WebView component with new methods and FFI bindings
+- *(webview)* Add WebView component with FFI bindings and enhanced functionality
+- add macOS local device gesture support and screenshot functionality
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Fix Android packaging toolchain resolution
+- Fix reactive constant API inputs
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Harden webview backend integration
+- Reduce clippy noise across support crates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor signal handling in filters and layout components to use IntoSignalF32
+- Update android backend
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/core/Cargo.toml
+++ b/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-core"
-version = "0.2.0"
+version = "0.2.1"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/crates/waterui-dylib/CHANGELOG.md
+++ b/crates/waterui-dylib/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/water-rs/waterui/releases/tag/waterui-dylib-v0.2.1) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- enforce dev dynamic-linking and split runtime wrapper crates
+- Clean reactive view composition anti-patterns
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/icon-packs/fontawesome7/CHANGELOG.md
+++ b/icon-packs/fontawesome7/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-icons-fontawesome7-v0.1.0) - 2026-05-01
+
+### Added
+
+- continue deep review fixes and ffi fast-fail cleanup
+- *(icons)* Refactor icon system with extensible CLI architecture
+- Introduce `waterui-canvas`, `waterui-shape`, and `waterui-svg` crates, refactor graphics components, and integrate Vello for advanced rendering.
+- enhance font management and color handling across platforms
+- font bundling system and download icons at build time
+- *(icon)* add webfont-based icon rendering with IconGlyph
+- Icon component
+
+### Other
+
+- Clean dev CI and example builds
+- Refactor asset and icon build helpers
+- Refactor code for improved readability and consistency

--- a/icon-packs/lucide/CHANGELOG.md
+++ b/icon-packs/lucide/CHANGELOG.md
@@ -1,0 +1,24 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-icons-lucide-v0.1.0) - 2026-05-01
+
+### Added
+
+- Implement waterui-barcode component
+- *(icons)* Refactor icon system with extensible CLI architecture
+
+### Other
+
+- Clean dev CI and example builds
+- Refactor asset and icon build helpers
+- Refactor MediaPicker and add reminders example
+- Add Android JNI FFI support and improve CLI process management
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency

--- a/icon-packs/material-icon/CHANGELOG.md
+++ b/icon-packs/material-icon/CHANGELOG.md
@@ -1,0 +1,26 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-icons-material-icon-v0.1.0) - 2026-05-01
+
+### Added
+
+- Implement waterui-barcode component
+- *(icons)* Refactor icon system with extensible CLI architecture
+- Introduce `waterui-canvas`, `waterui-shape`, and `waterui-svg` crates, refactor graphics components, and integrate Vello for advanced rendering.
+- Icon component
+
+### Other
+
+- Clean dev CI and example builds
+- Refactor asset and icon build helpers
+- Refactor MediaPicker and add reminders example
+- Add Android JNI FFI support and improve CLI process management
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency

--- a/icon-packs/native/CHANGELOG.md
+++ b/icon-packs/native/CHANGELOG.md
@@ -1,0 +1,55 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-icons-native-v0.1.0) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- Icon component
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean dev CI and example builds
+- Clean reactive view composition anti-patterns
+- Reduce clippy noise across support crates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/icon-packs/sf-symbol/CHANGELOG.md
+++ b/icon-packs/sf-symbol/CHANGELOG.md
@@ -1,0 +1,56 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-icons-sf-symbol-v0.1.0) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- Icon component
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean dev CI and example builds
+- Clean reactive view composition anti-patterns
+- Reduce clippy noise across support crates
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Refactor code for improved readability and consistency
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/internal/CHANGELOG.md
+++ b/internal/CHANGELOG.md
@@ -1,0 +1,54 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/water-rs/waterui/releases/tag/waterui-internal-v0.2.1) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean dev CI and example builds
+- enforce dev dynamic-linking and split runtime wrapper crates
+- Clean reactive view composition anti-patterns
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-macros"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/testing/CHANGELOG.md
+++ b/testing/CHANGELOG.md
@@ -1,0 +1,81 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.1](https://github.com/water-rs/waterui/releases/tag/waterui-testing-v0.2.1) - 2026-05-01
+
+### Added
+
+- align focus state across backends
+- *(runtime)* unify gesture semantics and picker backends
+- *(graphics)* finalize advanced filter pipeline and core integration
+- *(testing)* add waterui::test macro and a11y-first ui test runtime
+- *(testing)* add headless waterui-testing host and snapshot smoke test
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Fix Hydrolysis and testing strict lints
+- Prepare dev for release automation
+- Allow Hydrolysis testing adapters in test host
+- Fix CI fontconfig deps and README doctests
+- Fix Android tooling and strict linting
+- Clean dev CI and example builds
+- Clean reactive view composition anti-patterns
+- Expand hydrolysis UI testing coverage
+- Add view builder macros and migrate branchy views
+- Restore extractor-based testing actions
+- Stabilize waterui-testing gesture coverage
+- Refine semantic handles in waterui-testing
+- refactor handler state extraction
+- Use hydrolysis headless runtime in testing
+- Checkpoint current WaterUI changes
+- Fix local state rebuild semantics
+- Add cartesian chart selection and scrolling APIs
+- Fix chart readout snapshots in offscreen testing
+- Add semantic chart interaction testing
+- Refine chart E2E testing support
+- *(testing)* extract query builder and widen chart coverage
+- checkpoint local workspace changes
+- checkpoint all in-progress workspace changes
+- add reactive redraw pipeline and unified resource drawing
+- Implement Animatable pipeline and native filtered blur hooks
+- add reactive redraw pipeline and unified resource drawing
+- commit pending workspace changes on dev
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/utils/build-support/CHANGELOG.md
+++ b/utils/build-support/CHANGELOG.md
@@ -1,0 +1,53 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/waterui-build-support-v0.1.0) - 2026-05-01
+
+### Added
+
+- integrate assets, media, and runtime updates
+- introduce GPU texture filtering utility and image example, refactor media components
+- *(README)* update header layout and add badges for improved visibility and branding
+- *(README)* add WaterUI logo and update header for improved branding
+- Enhance window management and hot reload functionality
+- Revamp README and enhance Android hot reload functionality
+- Enhance local development mode for WaterUI
+- enhance Dockerfile and documentation for improved build and configuration
+- *(cli)* enhance Android backend integration with improved logging and automation
+
+### Fixed
+
+- update documentation links in README.md
+- remove outdated contribution guidelines from README
+- update README and Cargo.toml files to specify README.md for all components
+- add placeholder crate to work around missing workspace member in old commit; update waterui version in README
+- update documentation to reflect Android View terminology for consistency
+- correct spelling errors and improve comments across the codebase
+
+### Other
+
+- Prepare dev for release automation
+- Fix CI fontconfig deps and README doctests
+- Clean reactive view composition anti-patterns
+- Refactor asset and icon build helpers
+- Remove on_demand and add needs_redraw
+- Enhance video, chart, and locale platform support
+- Remove hot reload functionality in favor of preview system
+- Move static assets to R2 CDN and add PID-based window capture
+- Add preview system and refactor core APIs
+- update licenses to include Apache 2.0 and MIT, and update README badge
+- Release 0.2.0
+- Bump waterui version to 0.2 in documentation across multiple components
+- Add waterui-color, waterui-str, and waterui-url crates with comprehensive documentation
+- Update README and FFI components for consistency and clarity
+- Remove AGENT.md and enhance FFI bindings for events and gestures
+- Remove terminal backend mention from README.md
+- Update documentation and add CMake checks for Apple builds
+- Make Suspense/hot reload use thread-safe executor
+- update FFI header regeneration instructions and enhance README content

--- a/utils/filtrate-core/Cargo.toml
+++ b/utils/filtrate-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filtrate-core"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.87"
 readme = "../../README.md"

--- a/utils/filtrate/Cargo.toml
+++ b/utils/filtrate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "filtrate"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2024"
 rust-version = "1.87"
 readme = "../../README.md"

--- a/utils/locale/CHANGELOG.md
+++ b/utils/locale/CHANGELOG.md
@@ -1,0 +1,44 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0](https://github.com/water-rs/waterui/releases/tag/locale-v0.1.0) - 2026-05-01
+
+### Added
+
+- unify label semantics and menu runtimes
+- unify label semantics and menu surfaces
+- *(locale)* wire regional context into runtime i18n
+- continue deep review fixes and ffi fast-fail cleanup
+- integrate assets, media, and runtime updates
+- add VectorArithmetic trait for linear interpolation and implement for f64 and Point2
+- Update picker example and enhance UI components
+- Add Menu component example and enhance WebView error handling
+- *(locale)* add internationalization support with ICU4X
+
+### Other
+
+- Prepare dev for release automation
+- Fix release package dependency graph
+- Fix CI formatting and dependency checks
+- Fix Android tooling and strict linting
+- Fix Android packaging toolchain resolution
+- Expand hydrolysis UI testing coverage
+- Use imports for type paths
+- Tighten reactive text updates and remove redundant AnyView
+- Checkpoint image crate extraction and locale updates
+- Reduce clippy noise across support crates
+- Fix local state rebuild semantics
+- checkpoint all in-progress workspace changes
+- commit pending workspace changes on dev
+- Fix GTK main thread executor and video renderer
+- Enhance video, chart, and locale platform support
+- Enhance documentation and examples for reactive patterns in WaterUI, including new guidelines for bindings and real-time updates
+- Refactor code for improved readability and consistency
+- Add preview system and refactor core APIs
+- CLI improvements and misc updates

--- a/utils/str/Cargo.toml
+++ b/utils/str/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-str"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 license.workspace = true

--- a/utils/url/Cargo.toml
+++ b/utils/url/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "waterui-url"
-version = "0.2.1"
+version = "0.2.2"
 edition.workspace = true
 authors.workspace = true
 rust-version.workspace = true


### PR DESCRIPTION
Create a one-time release baseline PR after the dev -> main merge.

Why this PR exists:
- The normal Release workflow now delegates to release-plz and keeps `release_always = false`, so publishing requires a release PR merge.
- The previous main run could not create that release PR because release-plz had to compare already-published package versions against older historical commits whose manifests used local sibling paths such as `../nami`; those old commits are not packageable from a clean checkout.
- I did not change workflow logic or add validation scripts. This PR moves the published package versions forward so the next release baseline is this current packageable source tree.

Verification:
- `cargo metadata --no-deps --format-version 1`
- `cargo package -p waterui-core --list`
- `cargo package -p waterui-cli --list`
- `release-plz update --config release-plz.toml --repo-url https://github.com/water-rs/waterui` reports the repository is already up-to-date.
- `release-plz release --dry-run --config release-plz.toml` with a real GitHub token skips release before PR association, as expected with `release_always = false`.
- `cargo check --workspace --all-targets --all-features` completed successfully.

This PR is intentionally left for @lexoliu to approve and merge.