### PR TITLE
fix(examples): rename cef_webview_example to webview-cef-example

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -82,7 +82,7 @@ jobs:
       # `--all-features` pass is structurally impossible — `waterui-ffi`
       # enforces "exactly one ABI" with a `compile_error!` (ffi/src/lib.rs), so
       # enabling `c-api` and `android-jni` together can never build.
-      - run: cargo nextest run --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude cef_webview_example --exclude chromium-example --profile ci
+      - run: cargo nextest run --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude webview-cef-example --exclude chromium-example --profile ci
       # The root crate's feature-gated re-export surface. `--features all` rather
       # than `--all-features`: the latter turns on `dynamic_linking`, which pulls
       # in `waterui-dylib`, and that crate exports 77k symbols against a PE
@@ -96,7 +96,7 @@ jobs:
       # Compile the CEF backend without its binary distribution.
       - run: cargo check -p waterui-browser-cef --features compile-only
       # nextest cannot run doctests, and this workspace has plenty of them.
-      - run: cargo test --doc --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude cef_webview_example --exclude chromium-example
+      - run: cargo test --doc --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude webview-cef-example --exclude chromium-example
       # Windows-only code is invisible to every other leg: a `cfg(windows)` body
       # is compiled nowhere else, so a lint that fires only there reaches
       # nobody.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1563,15 +1563,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cef_webview_example"
-version = "0.1.0"
-dependencies = [
- "waterui",
- "waterui-browser-cef",
- "webview-example",
-]
-
-[[package]]
 name = "cesu8"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13361,6 +13352,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webview-cef-example"
+version = "0.1.0"
+dependencies = [
+ "waterui",
+ "waterui-browser-cef",
+ "webview-example",
 ]
 
 [[package]]

--- a/examples/webview-cef/Cargo.toml
+++ b/examples/webview-cef/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "cef_webview_example"
+name = "webview-cef-example"
 version = "0.1.0"
 edition = "2024"
 authors = ["Lexo Liu"]


### PR DESCRIPTION
Every example package follows the `<name>-example` convention except `examples/webview-cef`, whose manifest named the package `cef_webview_example`, so the Windows workflow exclusion lists had to special-case it.

This renames the package to `webview-cef-example`, updates both `--exclude` lists in `.github/workflows/windows.yml`, and regenerates the lockfile entry. `rg --hidden cef_webview_example` over the repository now returns nothing and `cargo metadata` lists `webview-cef-example`.

The edit itself was produced by an Antigravity CLI (Gemini 3.7 Flash) subagent as part of evaluating it as a helper; I verified the acceptance criteria and the diff.

Fixes #198
