### PR TITLE
ci: refresh the apt index and verify setup-linux-deps actually installed

### DIFF
--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -73,21 +73,28 @@ runs:
     # ...and check what it did, because the action cannot fail on its own: a
     # fetch error leaves it reporting success over an empty package set, and the
     # next thing to notice is a cargo build twenty minutes later blaming
-    # whichever pkg-config crate it happened to reach first. `all-package-
-    # version-list` is the action's own record of what is installed, on both the
-    # install and the cache-restore path, so ask it directly.
+    # whichever pkg-config crate it happened to reach first.
+    #
+    # Two sources, because neither alone covers every package. The action's
+    # `all-package-version-list` is what it unpacked or restored from its cache,
+    # and a cache restore is a plain untar that never reaches dpkg's database.
+    # dpkg covers the rest: a package the runner image already ships is never
+    # unpacked and so never appears in that list.
     - name: Verify native dependencies are installed
       shell: bash
       env:
         REQUESTED: ${{ steps.pkgs.outputs.packages }}
-        INSTALLED: ${{ steps.apt.outputs.all-package-version-list }}
+        UNPACKED: ${{ steps.apt.outputs.all-package-version-list }}
       run: |
         missing=""
         for package in $REQUESTED; do
-          case ",$INSTALLED," in
-            *",$package="*) ;;
-            *) missing="$missing $package" ;;
+          case ",$UNPACKED," in
+            *",$package="*) continue ;;
           esac
+          status="$(dpkg-query --show --showformat='${Status}' "$package" 2>/dev/null || true)"
+          if [ "$status" != "install ok installed" ]; then
+            missing="$missing $package"
+          fi
         done
         if [ -n "$missing" ]; then
           echo "::error::apt reported success but did not install:$missing"

--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -2,8 +2,8 @@ name: Setup Linux native dependencies
 description: >
   Installs (and caches across runs) the native libraries a Linux build of the
   workspace needs: audio (ALSA, PipeWire), video (VA-API, nasm-assembled
-  codecs), fonts, GTK4, and udev. Every job that builds on Linux needs this
-  same list, so it lives here once instead of four independent `apt-get`
+  codecs), fonts, GTK4, EGL, and udev. Every job that builds on Linux needs
+  this same list, so it lives here once instead of four independent `apt-get`
   invocations drifting apart.
 
 inputs:
@@ -25,11 +25,26 @@ inputs:
 runs:
   using: composite
   steps:
+    # The runner image is baked, not live, so `/var/lib/apt/lists` is as old as
+    # the image. cache-apt-pkgs-action deliberately never refreshes it on a
+    # GitHub-hosted runner ("GitHub Actions runners have fresh package lists",
+    # in its lib.sh), so once Ubuntu supersedes any transitive dependency of the
+    # list below, the baked index still names a .deb that has left the pool,
+    # every fetch 404s, and `apt-fast` exits 0 anyway — leaving that step green
+    # with nothing installed. Resolve against an index that matches the mirror.
+    - name: Refresh APT package index
+      shell: bash
+      run: sudo apt-get update
+
     - name: Compute package list
       id: pkgs
       shell: bash
       run: |
-        packages="nasm libasound2-dev libva-dev libfontconfig1-dev libgbm-dev libxcb1-dev libglib2.0-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libgtk-4-dev libpipewire-0.3-dev libudev-dev"
+        # libegl-dev carries egl.pc, which the `khronos-egl` build script needs
+        # (xcap -> waterkit-screen pulls it in under --all-features). It has so
+        # far arrived only as a transitive dependency of libgtk-4-dev; declare
+        # what the workspace actually links rather than inheriting it.
+        packages="nasm libasound2-dev libva-dev libfontconfig1-dev libgbm-dev libegl-dev libxcb1-dev libglib2.0-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libgtk-4-dev libpipewire-0.3-dev libudev-dev"
         if [ "${{ inputs.gpu }}" = "true" ]; then
           packages="$packages mesa-vulkan-drivers libvulkan1"
         fi
@@ -48,8 +63,33 @@ runs:
     # reason `crate-ci/typos` is pinned above: an unpinned action changing
     # behavior underneath a caching step is a hard failure mode to diagnose.
     - name: Install native dependencies
+      id: apt
       uses: awalsh128/cache-apt-pkgs-action@v1.6.3
       with:
         packages: ${{ steps.pkgs.outputs.packages }}
         version: "1.0"
         execute_install_scripts: true
+
+    # ...and check what it did, because the action cannot fail on its own: a
+    # fetch error leaves it reporting success over an empty package set, and the
+    # next thing to notice is a cargo build twenty minutes later blaming
+    # whichever pkg-config crate it happened to reach first. `all-package-
+    # version-list` is the action's own record of what is installed, on both the
+    # install and the cache-restore path, so ask it directly.
+    - name: Verify native dependencies are installed
+      shell: bash
+      env:
+        REQUESTED: ${{ steps.pkgs.outputs.packages }}
+        INSTALLED: ${{ steps.apt.outputs.all-package-version-list }}
+      run: |
+        missing=""
+        for package in $REQUESTED; do
+          case ",$INSTALLED," in
+            *",$package="*) ;;
+            *) missing="$missing $package" ;;
+          esac
+        done
+        if [ -n "$missing" ]; then
+          echo "::error::apt reported success but did not install:$missing"
+          exit 1
+        fi


### PR DESCRIPTION
Fixes #201

Every Linux job that uses `.github/actions/setup-linux-deps` has been installing
**zero** native packages since 2026-08-31, with the step reporting success. The
visible symptom was the `Features` job dying at `cargo hack check --each-feature
--no-dev-deps` with `khronos-egl`'s build script unable to find `egl.pc` — but
that is just the first pkg-config crate the build reaches. GTK4, GLib, ALSA and
`nasm` were equally absent. Pre-existing defect; PR #199 and #200 merely happened
to be the first PRs to run afterwards, and both fail identically.

### Why

`awalsh128/cache-apt-pkgs-action` never refreshes the apt index on a
GitHub-hosted runner, by design (`lib.sh`: *"GitHub Actions runners have fresh
package lists, so skip this overhead"*). The runner image is baked, not live:
image `20260823.283.1` carries `/var/lib/apt/lists` from ~2026-08-23. Ubuntu
then superseded two transitive dependencies of our package list on 2026-08-31:

| source | superseded | replacement | published (noble) |
| --- | --- | --- | --- |
| `util-linux` | `2.39.3-9ubuntu6.5` | `2.39.3-9ubuntu6.6` | 2026-08-31 12:41 Security / 15:03 Updates |
| `bzip2` | `1.0.8-5.1build0.1` | `1.0.8-5.1ubuntu0.1` | 2026-08-31 05:47 Security / 07:08 Updates |

So the baked index still named `.deb`s that had left the pool, all five fetches
404'd, `apt-fast` exited 0 regardless (so the action's `set -e` never fired), and
the step went green having installed nothing — then saved an *empty* cache under
its deterministic key. The last green run (33232820155 on `dev` at bf9545ce3,
2026-08-29) used the *same* image, the *same* twelve resolved versions and the
*same* cache key; it worked only because the pool files still existed two days
before they were superseded.

### The fix

1. **Refresh the apt index before resolving**, so apt picks versions the mirror
   still serves. This is the actual failure. (`ci.yml`'s `Hygiene` job already
   does its own `apt-get update` and passed throughout.)
2. **Assert afterwards that the packages are actually there**, comparing the
   requested list against the action's own `all-package-version-list` output —
   which is populated on both the install and the cache-restore path. A
   swallowed apt failure otherwise surfaces twenty minutes later as an unrelated
   compile error naming the wrong crate, which is what made this cost a full
   investigation.
3. **Declare `libegl-dev` outright.** `khronos-egl` is a genuine `--all-features`
   dependency (`khronos-egl` *static* ← `libwayshot-xcap` ← `xcap` ←
   `waterkit-screen` ← `waterui-internal`), and `egl.pc` has been arriving only
   as an accident of `libgtk-4-dev` → `libepoxy-dev` → `libegl-dev`.

`actionlint .github/workflows/ci.yml` is clean (it cannot parse composite action
files, which it treats as workflows missing `on`/`jobs`).
