### PR TITLE
docs: stop telling waterui consumers to enable the removed map feature

### DIFF
--- a/docs/MIGRATION_0.3.md
+++ b/docs/MIGRATION_0.3.md
@@ -211,14 +211,18 @@ advances.
 
 ## Feature-gated FFI and GPU packages
 
-The map FFI is off by default, while the common GPU stack is a default-on
-feature. Consumers that disable defaults must opt into exactly the exported
-surface they use:
+The map FFI is off by default in `waterui-ffi`, while the common GPU stack is a
+default-on feature. Consumers that disable defaults must opt into the facade
+and FFI features they use. Map is no longer a `waterui` facade feature; depend
+on `waterui-map` directly, and add `waterui-map-gpu` when using the self-drawn
+realization:
 
 ```toml
 [dependencies]
-waterui = { version = "0.3", default-features = false, features = ["gpu", "map"] }
+waterui = { version = "0.3", default-features = false, features = ["gpu"] }
 waterui-ffi = { version = "0.3", default-features = false, features = ["gpu", "map"] }
+waterui-map = "0.1"
+waterui-map-gpu = "0.1"
 ```
 
 Regenerate native bindings and generated projects after changing these


### PR DESCRIPTION
The 0.3 migration guide told consumers that disable default features to opt back in with `features = ["gpu", "map"]` on the `waterui` facade. Commit 40890bb22 removed the facade's `map` feature along with the optional map dependencies, so that line fails to resolve. Only `waterui-ffi` still owns a `map` feature.

The snippet now lists only real facade features and points map consumers at `waterui-map` and `waterui-map-gpu` directly. Pre-existing defect, surfaced while reviewing that commit with an Antigravity CLI (Gemini 3.7 Flash) subagent; the edit was produced by the same subagent and I verified every crate name, version, and feature it cites against `Cargo.toml`, `src/Cargo.toml`, and `ffi/Cargo.toml`.

Fixes #203
