### PR TITLE
Move the font registry into TOML data and offer STIX Two Math

### DIFF
--- a/backends/hydrolysis/src/gpu_view.rs
+++ b/backends/hydrolysis/src/gpu_view.rs
@@ -48,7 +48,7 @@ where
 {
     async fn setup(&mut self, ctx: &GpuContext<'_>, env: &mut Environment) {
         let scoped_env = env.extending(SceneViewMergeToParent);
-        let mut renderer = HydrolysisRenderer::new(ctx.device);
+        let mut renderer = HydrolysisRenderer::new(ctx.adapter, ctx.device);
         renderer.set_host_redraw_handle(ctx.redraw_handle.clone());
         renderer.prepare_window_tree(AnyView::new(self.view.clone()), &scoped_env);
         renderer.setup_embedded_gpu_surfaces(ctx).await;

--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -149,7 +149,8 @@ use waterui_graphics::view_effect::{
 };
 use waterui_graphics::{
     AppliedFilter, GpuContext, GpuFrame, GpuSurface, GradientType, PointerState, RedrawHandle,
-    ResolvedGradient, ResolvedGradientStop, SceneView, VelloScene2D,
+    ResolvedGradient, ResolvedGradientStop, SceneEngine, SceneView, SharedSceneRenderer,
+    VelloScene2D,
 };
 
 use waterui_icon::SystemIcon;
@@ -232,7 +233,7 @@ pub struct HydrolysisRenderer {
     shader_cache: Arc<WgslModuleCache>,
     /// The scene renderer embedded GPU surfaces share, for the same reason: its
     /// pipelines belong to the device rather than to any one scene.
-    scene_renderer: Arc<waterui_graphics::SharedSceneRenderer>,
+    scene_renderer: Arc<SharedSceneRenderer>,
     lifecycle: LifecycleState,
     animation_controller: AnimationController,
     frame_instant: Instant,
@@ -308,9 +309,16 @@ impl HydrolysisRenderer {
         core::mem::take(&mut self.subview_structural_change)
     }
 
+    /// A renderer for `device`, which `adapter` produced.
+    ///
+    /// The adapter is not a formality: the scene renderer that embedded GPU
+    /// surfaces share is built for the engine `adapter` can actually run, and
+    /// an adapter without indirect execution aborts inside wgpu rather than
+    /// degrading when asked to run the classic compute pipeline.
     #[must_use]
-    pub fn new(device: &wgpu::Device) -> Self {
+    pub fn new(adapter: &wgpu::Adapter, device: &wgpu::Device) -> Self {
         Self::new_with_options(
+            adapter,
             device,
             vello::RendererOptions {
                 use_cpu: false,
@@ -324,8 +332,13 @@ impl HydrolysisRenderer {
         )
     }
 
+    /// As [`Self::new`], with the window renderer's Vello options spelled out.
     #[must_use]
-    pub fn new_with_options(device: &wgpu::Device, options: vello::RendererOptions) -> Self {
+    pub fn new_with_options(
+        adapter: &wgpu::Adapter,
+        device: &wgpu::Device,
+        options: vello::RendererOptions,
+    ) -> Self {
         let vello_renderer =
             vello::Renderer::new(device, options).expect("failed to create hydrolysis renderer");
         let frame_instant = Instant::now();
@@ -346,7 +359,7 @@ impl HydrolysisRenderer {
             signals: FrameSignals::new(frame_instant),
             host_redraw_handle: None,
             shader_cache: Arc::new(WgslModuleCache::new()),
-            scene_renderer: Arc::default(),
+            scene_renderer: Arc::new(SharedSceneRenderer::new(SceneEngine::for_adapter(adapter))),
             lifecycle: LifecycleState::default(),
             animation_controller: AnimationController::default(),
             frame_instant,

--- a/backends/hydrolysis/src/renderer/tests/mod.rs
+++ b/backends/hydrolysis/src/renderer/tests/mod.rs
@@ -52,7 +52,7 @@ fn test_renderer() -> HydrolysisRenderer {
     let mut platform =
         crate::platform::OffscreenWindow::new_for_tests(160, 160, wgpu::TextureFormat::Rgba8Unorm);
     let surface = platform.surface();
-    let mut renderer = HydrolysisRenderer::new(surface.device());
+    let mut renderer = HydrolysisRenderer::new(surface.adapter(), surface.device());
     renderer.set_frame_resources(surface.adapter(), surface.device(), surface.queue());
     renderer
 }
@@ -785,7 +785,7 @@ fn renderer_magnification_targets_outer_observer_in_stacked_gesture_chain() {
         crate::platform::OffscreenWindow::new_for_tests(160, 160, wgpu::TextureFormat::Rgba8Unorm);
     let mut renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     let env = test_environment();
     let bounds = vello::kurbo::Rect::new(0.0, 0.0, 160.0, 160.0);

--- a/backends/hydrolysis/src/runner/headless.rs
+++ b/backends/hydrolysis/src/runner/headless.rs
@@ -403,7 +403,7 @@ impl HeadlessRuntime {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         install_fonts(&mut renderer);
 
@@ -442,7 +442,7 @@ impl HeadlessRuntime {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         (self.install_fonts)(&mut renderer);
         RuntimeWindow::new(

--- a/backends/hydrolysis/src/runner/mod.rs
+++ b/backends/hydrolysis/src/runner/mod.rs
@@ -189,7 +189,7 @@ pub fn run(app: App) {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         load_native_resource_fonts(&mut renderer);
         let mut runtime = RuntimeWindow::new(window, platform, renderer, render_diagnostics_config);

--- a/backends/hydrolysis/src/runner/tests.rs
+++ b/backends/hydrolysis/src/runner/tests.rs
@@ -329,7 +329,7 @@ fn runtime_window_sized(
     platform.apply_properties(&window);
     let renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     RuntimeWindow::new(
         window,
@@ -434,7 +434,7 @@ fn test_runtime_window() -> RuntimeWindow<HeadlessPlatformWindow> {
     platform.apply_properties(&window);
     let renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     RuntimeWindow::new(
         window,

--- a/backends/hydrolysis/src/runner/web_runner.rs
+++ b/backends/hydrolysis/src/runner/web_runner.rs
@@ -288,7 +288,7 @@ pub fn run(app: App, inspector: Option<waterui::inspector::InspectorRuntime>) {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         load_web_fonts(&mut renderer).await;
         let runtime = RuntimeWindow::new(window, platform, renderer, render_diagnostics_config);

--- a/backends/hydrolysis/src/runner/winit_runner.rs
+++ b/backends/hydrolysis/src/runner/winit_runner.rs
@@ -430,7 +430,7 @@ impl WinitRunner {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         super::load_native_resource_fonts(&mut renderer);
         let mut runtime =

--- a/backends/hydrolysis/src/view_renderer.rs
+++ b/backends/hydrolysis/src/view_renderer.rs
@@ -78,7 +78,7 @@ impl CustomViewRenderer for HydrolysisViewRenderer {
             let rgba_data = {
                 let device = surface.device();
                 let queue = surface.queue();
-                let mut renderer = HydrolysisRenderer::new(device);
+                let mut renderer = HydrolysisRenderer::new(surface.adapter(), device);
                 renderer.set_frame_resources(surface.adapter(), device, queue);
                 renderer.reset_scene();
                 renderer.begin_rebuild_frame();

--- a/cli/src/project_model/assets.rs
+++ b/cli/src/project_model/assets.rs
@@ -1109,6 +1109,55 @@ mod tests {
         );
     }
 
+    /// The registry must offer a face carrying an OpenType `MATH` table, and it
+    /// must be reached through the archive code path.
+    #[test]
+    fn font_registry_offers_a_math_face() {
+        let registry = FontRegistry::builtin().expect("registry parses");
+        let url = registry
+            .url("STIX Two Math")
+            .expect("registry must offer an OpenType MATH font");
+        assert!(
+            is_zip_url(url),
+            "the math font must resolve through the archive path so the single \
+             matching face is extracted rather than the whole distribution"
+        );
+    }
+
+    /// `STIX Two Math` ships in the same archive as eight `STIX Two Text` faces,
+    /// none of which carry a `MATH` table. Picking a Text face would leave
+    /// formula layout with no table to read, and nothing downstream would say
+    /// so — the font would simply be there and be useless.
+    #[test]
+    fn math_face_wins_over_its_text_siblings_in_the_same_archive() {
+        let extracted = tempdir().expect("temp dir");
+        let root = extracted.path().join("static_otf");
+        fs::create_dir_all(&root).expect("create extract dir");
+        for face in [
+            "STIXTwoMath-Regular.otf",
+            "STIXTwoText-Bold.otf",
+            "STIXTwoText-BoldItalic.otf",
+            "STIXTwoText-Italic.otf",
+            "STIXTwoText-Medium.otf",
+            "STIXTwoText-MediumItalic.otf",
+            "STIXTwoText-Regular.otf",
+            "STIXTwoText-SemiBold.otf",
+            "STIXTwoText-SemiBoldItalic.otf",
+        ] {
+            fs::write(root.join(face), []).expect("write face");
+        }
+
+        let selected = smol::block_on(find_font_file(extracted.path(), "STIX Two Math"))
+            .expect("math face must be found");
+
+        assert_eq!(
+            selected.file_name().expect("selected face has a name"),
+            "STIXTwoMath-Regular.otf",
+            "selected {} instead of the Math face",
+            selected.display()
+        );
+    }
+
     #[test]
     fn hydrolysis_default_fonts_include_material_base_and_script_fallbacks() {
         let declarations = hydrolysis_default_font_declarations();

--- a/cli/src/project_model/assets.rs
+++ b/cli/src/project_model/assets.rs
@@ -24,64 +24,51 @@ mod icon;
 mod unified;
 mod web;
 
-/// Built-in font registry mapping font names to download URLs.
+/// A font the CLI can fetch when a crate names it and nothing else.
+#[derive(Debug, Clone, Deserialize)]
+struct RegistryFont {
+    /// Family name a crate declares.
+    name: String,
+    /// Where the face, or an archive containing it, is fetched from.
+    url: String,
+}
+
+/// The built-in font registry.
 ///
-/// These fonts can be declared in Cargo.toml with just a name:
+/// The list is data, so it lives in `assets/fonts.toml` rather than in Rust
+/// literals, and is parsed rather than compiled into a table. Fonts it offers
+/// can be declared in Cargo.toml with a name alone:
+///
 /// ```toml
 /// [[package.metadata.waterui.assets.font]]
 /// name = "Inter"
 /// ```
 ///
-/// Note: Icon pack fonts (Font Awesome, Material Icons, Lucide, etc.) should
-/// NOT be in this registry. They should declare their fonts in their own
-/// Cargo.toml with `remote_path` and `required-feature` fields.
-const FONT_REGISTRY: &[(&str, &str)] = &[
-    // Popular text fonts
-    (
-        "Inter",
-        "https://github.com/rsms/inter/releases/download/v4.0/Inter-4.0.zip",
-    ),
-    (
-        "Roboto",
-        "https://github.com/googlefonts/roboto/releases/download/v2.138/roboto-android.zip",
-    ),
-    (
-        "Noto Sans CJK JP",
-        "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip",
-    ),
-    (
-        "Noto Sans CJK KR",
-        "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/07_NotoSansCJKkr.zip",
-    ),
-    (
-        "Noto Sans CJK SC",
-        "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/08_NotoSansCJKsc.zip",
-    ),
-    (
-        "Noto Sans CJK TC",
-        "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/09_NotoSansCJKtc.zip",
-    ),
-    (
-        "Noto Sans Arabic",
-        "https://github.com/notofonts/arabic/releases/download/NotoSansArabic-v2.013/NotoSansArabic-v2.013.zip",
-    ),
-    (
-        "Noto Sans Hebrew",
-        "https://github.com/notofonts/hebrew/releases/download/NotoSansHebrew-v3.001/NotoSansHebrew-v3.001.zip",
-    ),
-    (
-        "JetBrainsMono",
-        "https://github.com/JetBrains/JetBrainsMono/releases/download/v2.304/JetBrainsMono-2.304.zip",
-    ),
-    (
-        "FiraCode",
-        "https://github.com/tonsky/FiraCode/releases/download/6.2/Fira_Code_v6.2.zip",
-    ),
-    (
-        "SourceCodePro",
-        "https://github.com/adobe-fonts/source-code-pro/releases/download/2.042R-u%2F1.062R-i%2F1.026R-vf/OTF-source-code-pro-2.042R-u_1.062R-i.zip",
-    ),
-];
+/// Icon pack fonts (Font Awesome, Material Icons, Lucide, ...) do NOT belong
+/// here. They declare their own faces in their own Cargo.toml with
+/// `remote_path` and `required-feature`.
+#[derive(Debug, Clone, Deserialize)]
+struct FontRegistry {
+    #[serde(rename = "font")]
+    fonts: Vec<RegistryFont>,
+}
+
+impl FontRegistry {
+    /// The registry shipped with this CLI.
+    fn builtin() -> eyre::Result<Self> {
+        toml::from_str(include_str!("assets/fonts.toml")).wrap_err(
+            "built-in font registry `cli/src/project_model/assets/fonts.toml` is malformed",
+        )
+    }
+
+    /// Where `name` is fetched from, if the registry offers it.
+    fn url(&self, name: &str) -> Option<&str> {
+        self.fonts
+            .iter()
+            .find(|font| font.name == name)
+            .map(|font| font.url.as_str())
+    }
+}
 const HYDROLYSIS_DEFAULT_FONT_FAMILY: &str = "Roboto";
 const HYDROLYSIS_WEB_FONT_MANIFEST_FILE_NAME: &str = "waterui-fonts.json";
 const HYDROLYSIS_DEFAULT_FONT_FAMILIES: &[&str] = &[
@@ -363,6 +350,7 @@ pub async fn resolve_fonts(declarations: Vec<FontDeclaration>) -> eyre::Result<V
 
     let mut resolved = Vec::new();
     let cache_dir = cache_dir()?;
+    let registry = FontRegistry::builtin()?;
 
     for (name, decls) in by_name {
         // Sort by priority: Local > Remote > BuiltIn
@@ -402,13 +390,7 @@ pub async fn resolve_fonts(declarations: Vec<FontDeclaration>) -> eyre::Result<V
             },
             FontSource::Remote { url } => download_font(&name, url, &cache_dir).await?,
             FontSource::BuiltIn => {
-                // Look up in registry
-                let url = FONT_REGISTRY
-                    .iter()
-                    .find(|(n, _)| *n == name)
-                    .map(|(_, url)| *url);
-
-                if let Some(url) = url {
+                if let Some(url) = registry.url(&name) {
                     download_font(&name, url, &cache_dir).await?
                 } else {
                     warn!(
@@ -1107,24 +1089,23 @@ mod tests {
 
     #[test]
     fn test_font_registry_has_entries() {
-        assert!(!FONT_REGISTRY.is_empty());
-        assert!(FONT_REGISTRY.iter().any(|(name, _)| *name == "Inter"));
-        assert!(FONT_REGISTRY.iter().any(|(name, _)| *name == "Roboto"));
-        assert!(
-            FONT_REGISTRY
-                .iter()
-                .any(|(name, _)| *name == "Noto Sans CJK SC")
-        );
+        let registry = FontRegistry::builtin().expect("registry parses");
+        assert!(!registry.fonts.is_empty());
+        assert!(registry.url("Inter").is_some());
+        assert!(registry.url("Roboto").is_some());
+        assert!(registry.url("Noto Sans CJK SC").is_some());
         // Icon pack fonts should NOT be in the built-in registry
         assert!(
-            !FONT_REGISTRY
+            !registry
+                .fonts
                 .iter()
-                .any(|(name, _)| name.contains("Font Awesome"))
+                .any(|font| font.name.contains("Font Awesome"))
         );
         assert!(
-            !FONT_REGISTRY
+            !registry
+                .fonts
                 .iter()
-                .any(|(name, _)| name.contains("Material Design"))
+                .any(|font| font.name.contains("Material Design"))
         );
     }
 

--- a/cli/src/project_model/assets/fonts.toml
+++ b/cli/src/project_model/assets/fonts.toml
@@ -60,3 +60,19 @@ url = "https://github.com/tonsky/FiraCode/releases/download/6.2/Fira_Code_v6.2.z
 [[font]]
 name = "SourceCodePro"
 url = "https://github.com/adobe-fonts/source-code-pro/releases/download/2.042R-u%2F1.062R-i%2F1.026R-vf/OTF-source-code-pro-2.042R-u_1.062R-i.zip"
+
+# Math fonts.
+#
+# A math font is not a stylistic choice: formula layout is computed from the
+# OpenType `MATH` table — axis height, fraction and radical metrics, script
+# shifts, glyph variants and assemblies — so a face without that table cannot
+# lay out a formula at all.
+#
+# The upstream STIX releases carry no attachments, so this points at the
+# `zipfiles/` archive in the tagged tree. That archive also holds eight
+# `STIX Two Text` faces, none of which carry a `MATH` table; only the Math face
+# matches this entry's name.
+
+[[font]]
+name = "STIX Two Math"
+url = "https://raw.githubusercontent.com/stipub/stixfonts/v2.13b171/zipfiles/static_otf.zip"

--- a/cli/src/project_model/assets/fonts.toml
+++ b/cli/src/project_model/assets/fonts.toml
@@ -1,0 +1,62 @@
+# Built-in font registry.
+#
+# Fonts listed here can be requested by a crate with a name alone:
+#
+#     [[package.metadata.waterui.assets.font]]
+#     name = "Inter"
+#
+# Icon pack fonts (Font Awesome, Material Icons, Lucide, ...) do NOT belong
+# here. They declare their own faces in their own Cargo.toml with `remote_path`
+# and `required-feature`.
+#
+# `url` may point at an archive or at a single face. When it is an archive, only
+# the one face matching `name` is extracted and bundled, never the whole
+# distribution.
+
+# Popular text fonts
+
+[[font]]
+name = "Inter"
+url = "https://github.com/rsms/inter/releases/download/v4.0/Inter-4.0.zip"
+
+[[font]]
+name = "Roboto"
+url = "https://github.com/googlefonts/roboto/releases/download/v2.138/roboto-android.zip"
+
+[[font]]
+name = "Noto Sans CJK JP"
+url = "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/06_NotoSansCJKjp.zip"
+
+[[font]]
+name = "Noto Sans CJK KR"
+url = "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/07_NotoSansCJKkr.zip"
+
+[[font]]
+name = "Noto Sans CJK SC"
+url = "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/08_NotoSansCJKsc.zip"
+
+[[font]]
+name = "Noto Sans CJK TC"
+url = "https://github.com/notofonts/noto-cjk/releases/download/Sans2.004/09_NotoSansCJKtc.zip"
+
+[[font]]
+name = "Noto Sans Arabic"
+url = "https://github.com/notofonts/arabic/releases/download/NotoSansArabic-v2.013/NotoSansArabic-v2.013.zip"
+
+[[font]]
+name = "Noto Sans Hebrew"
+url = "https://github.com/notofonts/hebrew/releases/download/NotoSansHebrew-v3.001/NotoSansHebrew-v3.001.zip"
+
+# Monospace fonts
+
+[[font]]
+name = "JetBrainsMono"
+url = "https://github.com/JetBrains/JetBrainsMono/releases/download/v2.304/JetBrainsMono-2.304.zip"
+
+[[font]]
+name = "FiraCode"
+url = "https://github.com/tonsky/FiraCode/releases/download/6.2/Fira_Code_v6.2.zip"
+
+[[font]]
+name = "SourceCodePro"
+url = "https://github.com/adobe-fonts/source-code-pro/releases/download/2.042R-u%2F1.062R-i%2F1.026R-vf/OTF-source-code-pro-2.042R-u_1.062R-i.zip"

--- a/components/visual/graphics/src/gpu/shared_context.rs
+++ b/components/visual/graphics/src/gpu/shared_context.rs
@@ -138,12 +138,6 @@ pub struct HybridRenderer {
     pub resources: vello_hybrid::Resources,
 }
 
-impl Default for SharedSceneRenderer {
-    fn default() -> Self {
-        Self::new(SceneEngine::Classic)
-    }
-}
-
 impl fmt::Debug for SharedSceneRenderer {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter

--- a/testing/src/snapshot.rs
+++ b/testing/src/snapshot.rs
@@ -77,7 +77,7 @@ impl TestHost {
         );
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         let bounds = vello::kurbo::Rect::new(
             0.0,

--- a/testing/src/tests.rs
+++ b/testing/src/tests.rs
@@ -559,7 +559,7 @@ fn smoke_scene_view_snapshot_runs_build_scene_and_returns_buffer() {
     );
     let mut renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     let bounds = vello::kurbo::Rect::new(0.0, 0.0, 96.0, 72.0);
     let env = Environment::new().extending(SceneViewMergeToParent);


### PR DESCRIPTION
Two commits, kept together because the second edits the exact lines the first
restructures — splitting them into separate PRs would mean adding the math font
as a Rust literal and then immediately moving it.

**`refactor(cli): move the built-in font registry into TOML data`** — `Fixes #218`

`FONT_REGISTRY` was a table of data written as Rust literals. It now lives in
`cli/src/project_model/assets/fonts.toml` as `[[font]]` entries and is parsed
with `serde`/`toml` (both already dependencies of this crate), embedded with
`include_str!` so `cargo install` is unaffected. No global — statics are banned
here, so `FontRegistry::builtin()` parses on demand and the value is passed;
`resolve_fonts` is the only consumer and now consults it once per call instead
of doing a linear scan per declaration. A malformed registry fails with a
message naming the file rather than resolving to an empty list.

The eleven existing entries and their URLs are unchanged, which is what makes
this commit reviewable as behaviour-preserving on its own.

**`feat(cli): offer STIX Two Math in the built-in font registry`** — `Fixes #212`

The registry carried no OpenType MATH font, so no crate could declare one by
name. Formula layout is computed from the `MATH` table — axis height, fraction
and radical metrics, script shifts, glyph variants and assemblies — so a face
without it gives a layout engine nothing to read, and a font stack ending in
`serif` resolves to exactly that.

STIX Two Math: SIL OFL 1.1, the most thoroughly validated `MATH` table across
browser engines, complete Unicode math coverage. Upstream releases carry no
attachments, so the entry points at `zipfiles/static_otf.zip` in the tagged
tree; only the matching face is extracted and bundled, as with every other
archive here.

That archive also holds eight `STIX Two Text` faces, none of which carry a
`MATH` table. `find_font_file` matches on the declared name's first three words
plus a style keyword, so `STIX Two Math` selects only `STIXTwoMath-Regular.otf`.
`math_face_wins_over_its_text_siblings_in_the_same_archive` pins that against
the real sibling filenames, because picking a Text face would leave the font
present and useless with nothing downstream reporting it.

## Verification

`cargo nextest run -p waterui-cli -E 'test(font) or test(math_face)'` — 9 passed.
`cargo clippy -p waterui-cli --all-targets` — no warnings from these changes.

I deliberately did not add a test that downloads the font and asserts the face
exposes `ttf_parser::Face::tables().math`. Every existing test in this module is
offline, and putting a network fetch on the CI path would make the suite flaky
for a check that belongs where the font is actually loaded. That assertion goes
into the math component (#213), which fails fast if the resolved face has no
`MATH` table.

## Pre-existing, not touched by this PR

`cargo clippy -p waterui-cli --all-targets` reports three `assert_is_empty`
warnings on clippy 0.1.100. Confirmed pre-existing by stashing these changes.
CI is green today because its pinned toolchain does not carry that lint yet;
filed as #219 since it becomes a hard CI failure on the next toolchain bump.
