### PR TITLE
fix: give the Send solver room for the wgpu-touching bounds

### DIFF
--- a/components/codes/barcode/src/lib.rs
+++ b/components/codes/barcode/src/lib.rs
@@ -21,6 +21,12 @@
 //! // Create a Code128 barcode view
 //! Barcode::code128("HELLO-WATERUI")
 //! ```
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 mod effect;
 mod qr;

--- a/components/multimedia/visualizer/src/lib.rs
+++ b/components/multimedia/visualizer/src/lib.rs
@@ -16,6 +16,12 @@
 //!     .sensitivity(1.5)
 //!     .glow(0.8)
 //! ```
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 mod audio;
 mod theme;

--- a/components/visual/graphics/src/lib.rs
+++ b/components/visual/graphics/src/lib.rs
@@ -1,4 +1,10 @@
 #![doc = "Graphics primitives for `WaterUI`."]
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 extern crate alloc;
 

--- a/components/visual/image/src/lib.rs
+++ b/components/visual/image/src/lib.rs
@@ -1,4 +1,10 @@
 //! Image primitives and decode helpers for `WaterUI`.
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 extern crate alloc;
 


### PR DESCRIPTION
Fixes #223.

On the workspace's default toolchain, four crates fail their own lint gate:

```
$ cargo clippy -p waterui-graphics --lib -- -D warnings
error: overflow evaluating the requirement
  `{closure@src/gpu/shared_context.rs:653:20}: std::marker::Send`
```

| crate | bound that overflows |
| --- | --- |
| `waterui-graphics` | the GPU completion thread's closure |
| `waterui-image` | `image::Image: Send` |
| `waterui-barcode` | `(&BarcodeSource, &GpuRuntime): Send` |
| `waterui-visualizer` | `&GpuContext<'_>: Send` |

Every one is the same shape: proving `Send` for something that reaches into wgpu's generic
type graph, deeper than rustc's default recursion limit of 128. The bounds genuinely hold;
the solver runs out of room before it can say so, and under `-D warnings` that diagnostic
is a hard error.

Raising each crate's recursion limit to 256 is a compiler resource knob, not a lint
exception: nothing is silenced, and a real `Send` violation would still be reported.

**Nightly-only.** `cargo +stable` never reaches the limit, so CI — which pins stable — was
never affected. What was affected is every local build in this repository,
which runs the workspace's nightly by default. An earlier revision of this PR claimed
it was blocking CI; that was wrong, and #223 carries the correction.

The defect is pre-existing. `waterui-graphics` acquired it with the completion thread in
 #210, whose teardown fix is itself correct.

Verified on `rustc 1.100.0-nightly (908501772 2026-08-30)`:
`cargo clippy -p waterui-graphics -p waterui-image -p waterui-barcode -p waterui-visualizer --lib -- -D warnings`
is clean. `waterui-canvas` and `waterui-svg` were swept too and were already clean;
`waterui-chart` fails for an unrelated pre-existing reason, filed as #225.