### PR TITLE
Add waterui-math: formula rendering on the OpenType MATH table

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8630,6 +8630,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "007d8adb5ddab6f8e3f491ac63566a7d5002cc7ed73901f72057943fa71ae1ae"
 
 [[package]]
+name = "pulldown-latex"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1cf850381ae0dbb131f36e31d6090f55363d079ab3e518ad0323b9cb6a96d115"
+dependencies = [
+ "bumpalo",
+]
+
+[[package]]
 name = "pxfm"
 version = "0.1.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12901,6 +12910,28 @@ dependencies = [
  "waterui-url",
  "wgpu",
  "zenwave",
+]
+
+[[package]]
+name = "waterui-math"
+version = "0.1.0"
+dependencies = [
+ "kurbo 0.13.1",
+ "nami",
+ "parley",
+ "peniko",
+ "pulldown-latex",
+ "quick-xml",
+ "serde",
+ "thiserror 2.0.20",
+ "toml 1.1.4+spec-1.1.0",
+ "tracing",
+ "ttf-parser",
+ "waterui",
+ "waterui-core",
+ "waterui-graphics",
+ "waterui-layout",
+ "waterui-str",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12920,6 +12920,7 @@ dependencies = [
  "nami",
  "parley",
  "peniko",
+ "pollster 1.0.1",
  "pulldown-latex",
  "quick-xml",
  "serde",
@@ -12932,6 +12933,7 @@ dependencies = [
  "waterui-graphics",
  "waterui-layout",
  "waterui-str",
+ "wgpu",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12928,7 +12928,6 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "ttf-parser",
- "waterui",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -208,6 +208,21 @@ usvg = "0.46.0"
 kurbo = "0.13"
 peniko = "0.6"
 skrifa = "0.42.1"
+# The only crate in the Rust ecosystem that reads the OpenType `MATH` table.
+# `read-fonts`/`skrifa` do not expose it (googlefonts/fontations#1269 has been
+# open since 2024-11), and neither `rustybuzz` nor `harfrust` port HarfBuzz's
+# `hb-ot-math`. Math layout is computed from that table, so it is depended on
+# directly rather than reached through the text stack.
+ttf-parser = "0.25"
+# LaTeX front end. A pull parser over a public `Event` enum, so events are
+# consumed straight into the math AST; the alternative (`math-core`) only emits
+# a MathML string, which would have to be parsed back.
+pulldown-latex = "0.8"
+# Writes the MathML an accessibility tree carries. XML is structured output, so
+# it goes through a writer that escapes and balances tags rather than through
+# `push_str`/`format!` chains.
+quick-xml = "0.41"
+toml = "1.1.3"
 vello_cpu = { version = "0.0.9", default-features = false }
 lyon = "1.0"
 wgpu-hal = { version = "29.0.4", features = ["gles", "metal"] }

--- a/components/visual/math/Cargo.toml
+++ b/components/visual/math/Cargo.toml
@@ -1,0 +1,41 @@
+[package]
+name = "waterui-math"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+readme = "README.md"
+repository.workspace = true
+description = "Mathematical formula rendering for WaterUI, laid out against the OpenType MATH table"
+keywords = ["math", "latex", "mathml", "opentype", "waterui"]
+categories = ["gui"]
+
+[dependencies]
+waterui-core.workspace = true
+waterui-graphics.workspace = true
+waterui-layout.workspace = true
+waterui-str.workspace = true
+nami.workspace = true
+# `system` brings in the font collection the math family is looked up through.
+parley = { workspace = true, features = ["system"] }
+kurbo.workspace = true
+peniko.workspace = true
+ttf-parser.workspace = true
+pulldown-latex.workspace = true
+quick-xml.workspace = true
+serde = { workspace = true, features = ["derive"] }
+thiserror.workspace = true
+toml.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+waterui = { path = "../../.." }
+
+[lints]
+workspace = true
+
+# The formula font. Layout reads the OpenType `MATH` table, so a face without
+# one cannot lay out a formula at all; this is the default the component asks
+# for when the environment names no other math family.
+[[package.metadata.waterui.assets.font]]
+name = "STIX Two Math"

--- a/components/visual/math/Cargo.toml
+++ b/components/visual/math/Cargo.toml
@@ -29,7 +29,6 @@ toml.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
-waterui = { path = "../../.." }
 # The gallery drives a headless surface, which is the only thing in this crate
 # that touches the GPU stack at all.
 waterui-graphics = { workspace = true, features = ["gpu"] }

--- a/components/visual/math/Cargo.toml
+++ b/components/visual/math/Cargo.toml
@@ -30,6 +30,11 @@ tracing.workspace = true
 
 [dev-dependencies]
 waterui = { path = "../../.." }
+# The gallery drives a headless surface, which is the only thing in this crate
+# that touches the GPU stack at all.
+waterui-graphics = { workspace = true, features = ["gpu"] }
+pollster.workspace = true
+wgpu.workspace = true
 
 [lints]
 workspace = true

--- a/components/visual/math/README.md
+++ b/components/visual/math/README.md
@@ -1,0 +1,72 @@
+# waterui-math
+
+Mathematical formula rendering for WaterUI.
+
+```rust
+use waterui_math::view::Math;
+
+Math::new(r"\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}").display().font_size(28.0)
+```
+
+## How it works
+
+```
+LaTeX ──(pulldown-latex)──► MathItem tree ──► layout ──► Scene2D commands
+                                  │                          │
+                                  └──► MathML ──► a11y        └──► any backend
+```
+
+A formula is parsed into a semantic tree, laid out against the chosen face's
+OpenType `MATH` table, and drawn through the engine-independent `Scene2D`
+contract — so it renders on the classic compute pipeline, on the CPU/GPU split
+engine that adapters without compute shaders fall to, and on dew's CPU scene,
+without knowing which it is talking to.
+
+## What the font supplies
+
+Every measurement comes from the `MATH` table: the axis the fraction bar centres
+on, the numerator and denominator shifts and their minimum gaps, the radical's
+rule thickness, vertical gap and extra ascender, the script shifts and the
+minimum gap between a superscript and a subscript, and italic correction so a
+script clears a slanted base's overhang. Constants that come in a display and a
+non-display flavour are resolved by style when the constants are read, so layout
+cannot reach for the wrong one.
+
+Glyphs that grow — radicals, parentheses, braces, brackets — go through one
+mechanism: `MathVariants`, taking a designed variant when one is large enough
+and assembling a multi-part glyph when none is. Nothing measures a glyph outline
+to discover where its parts are.
+
+## Spacing
+
+The gap between two adjacent atoms is a function of the class on each side, so
+`a+b` and `a=b` are spaced differently and `f(x)` closes up. The table lives in
+`src/spacing.toml` and is TeX's, which MathML Core reproduces.
+
+## Accessibility
+
+The semantic tree is kept after layout, not consumed by it. `mathml::to_mathml`
+publishes it as MathML, which is what assistive technology reads — a formula
+drawn as anonymous filled paths has no content at all to a screen reader.
+
+## Fonts
+
+Only a face carrying an OpenType `MATH` table can set mathematics. The default
+is **STIX Two Math**, declared in this crate's manifest so the WaterUI CLI
+bundles it. A face without the table is refused rather than substituted: it
+supplies no layout constants, so drawing with it would not be the same formula
+set differently, it would be a formula with no geometry.
+
+## Not yet supported
+
+Matrices and arrays, `cases`, multi-line environments, negation, and font/style
+changes (`\mathbf`, `\mathbb`, …) are reported as errors naming the construct
+rather than silently dropped.
+
+## Reference
+
+Layout follows [MathML Core Ch. 3](https://www.w3.org/TR/mathml-core/#layout-algorithms)
+and the [OpenType MATH specification](https://learn.microsoft.com/en-us/typography/opentype/spec/math),
+rather than TeXbook Appendix G, which is bound to 1982 TFM font metrics. For the
+mapping between the two, see Ulrik Vieth, ["OpenType Math Illuminated", TUGboat
+30:1 (2009)](https://www.tug.org/TUGboat/tb30-1/tb30-1-vieth.pdf).

--- a/components/visual/math/src/ast.rs
+++ b/components/visual/math/src/ast.rs
@@ -1,0 +1,278 @@
+//! The semantic tree a formula is parsed into.
+//!
+//! The shape follows `MathML` Core's element model rather than TeX's token
+//! model, because `MathML` Core is what the layout algorithms in
+//! [`crate::layout`] are specified against, and because the same tree is what
+//! the accessibility layer publishes.
+//!
+//! The tree carries no font, no size and no position. Everything that depends
+//! on the chosen face lives in [`crate::font`], and everything that depends on
+//! a size lives in [`crate::layout`].
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+
+use waterui_str::Str;
+
+/// How an atom relates to its neighbours.
+///
+/// This is the single most important thing the tree carries that a plain list
+/// of characters does not: inter-atom spacing is a function of the classes of
+/// the two atoms either side of the gap, so `a+b` and `a=b` are spaced
+/// differently and `f(x)` has no gap before the parenthesis. Dropping the class
+/// and concatenating advance widths produces a formula that is legible only by
+/// accident.
+///
+/// The classes are `MathML` Core's, which are TeX's with `Inner` folded in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum MathClass {
+    /// An ordinary atom: a variable, a number, most symbols.
+    #[default]
+    Ord,
+    /// A large operator, such as a summation or an integral sign.
+    Op,
+    /// A binary operator, such as `+`. Spaced on both sides, but only in
+    /// contexts where a binary reading is possible.
+    Bin,
+    /// A relation, such as `=` or `<`. The widest spacing.
+    Rel,
+    /// An opening fence.
+    Open,
+    /// A closing fence.
+    Close,
+    /// Punctuation, such as the comma between arguments.
+    Punct,
+    /// A subformula treated as a unit, such as a fenced group.
+    Inner,
+}
+
+/// The four TeX/MathML layout styles.
+///
+/// The style selects which of the paired OpenType `MATH` constants applies —
+/// several come in a display and a non-display flavour — and how far scripts
+/// scale down.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Default)]
+pub enum MathStyle {
+    /// A formula set on its own line.
+    Display,
+    /// A formula set in running text.
+    #[default]
+    Text,
+    /// First-level script.
+    Script,
+    /// Second-level script and beyond.
+    ScriptScript,
+}
+
+impl MathStyle {
+    /// The style a superscript, subscript or index takes inside `self`.
+    #[must_use]
+    pub const fn script(self) -> Self {
+        match self {
+            Self::Display | Self::Text => Self::Script,
+            Self::Script | Self::ScriptScript => Self::ScriptScript,
+        }
+    }
+
+    /// The style a fraction's numerator and denominator take inside `self`.
+    #[must_use]
+    pub const fn fraction(self) -> Self {
+        match self {
+            Self::Display => Self::Text,
+            Self::Text => Self::Script,
+            Self::Script | Self::ScriptScript => Self::ScriptScript,
+        }
+    }
+
+    /// Whether the display flavour of a paired `MATH` constant applies.
+    #[must_use]
+    pub const fn is_display(self) -> bool {
+        matches!(self, Self::Display)
+    }
+
+    /// Whether inter-atom spacing beyond a thin space is suppressed.
+    ///
+    /// TeX drops medium and thick spacing in script styles, which is why a
+    /// superscripted sum does not acquire the gaps its display form has.
+    #[must_use]
+    pub const fn is_cramped_spacing(self) -> bool {
+        matches!(self, Self::Script | Self::ScriptScript)
+    }
+}
+
+/// An operator, relation, fence or punctuation mark.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Operator {
+    /// The character(s) drawn.
+    pub glyph: Str,
+    /// How it spaces against its neighbours.
+    pub class: MathClass,
+    /// Whether it grows to match the thing it encloses or spans.
+    ///
+    /// Fences around a fraction stretch; a `+` never does.
+    pub stretchy: bool,
+}
+
+impl Operator {
+    /// An operator of the given class, not stretchy.
+    #[must_use]
+    pub fn new(glyph: impl Into<Str>, class: MathClass) -> Self {
+        Self {
+            glyph: glyph.into(),
+            class,
+            stretchy: false,
+        }
+    }
+
+    /// The same operator, marked as growing with its content.
+    #[must_use]
+    pub const fn stretchy(mut self) -> Self {
+        self.stretchy = true;
+        self
+    }
+}
+
+/// One node of a formula.
+#[derive(Debug, Clone, PartialEq)]
+pub enum MathItem {
+    /// A variable name. `MathML` `<mi>`; set in italic when it is a single
+    /// letter, which is the convention the layer above applies.
+    Ident(Str),
+    /// A numeric literal. `MathML` `<mn>`; always upright.
+    Number(Str),
+    /// An operator, relation, fence or punctuation mark. `MathML` `<mo>`.
+    Operator(Operator),
+    /// Literal text, set upright with its spaces intact. `MathML` `<mtext>`.
+    ///
+    /// This is what `\text{}` produces. Keeping it a distinct node is what
+    /// stops "if" from being read as the product of two variables and from
+    /// losing the space after it.
+    Text(Str),
+    /// A horizontal sequence. `MathML` `<mrow>`.
+    Row(Vec<Self>),
+    /// A fraction. `MathML` `<mfrac>`.
+    Fraction {
+        /// The expression above the rule.
+        numerator: Box<Self>,
+        /// The expression below the rule.
+        denominator: Box<Self>,
+    },
+    /// A radical, with an optional degree. `MathML` `<msqrt>` / `<mroot>`.
+    Radical {
+        /// What sits under the bar.
+        radicand: Box<Self>,
+        /// The index, as in a cube root. `None` is a square root.
+        degree: Option<Box<Self>>,
+    },
+    /// Scripts attached to a base. `MathML` `<msub>` / `<msup>` / `<msubsup>`.
+    Scripts {
+        /// What the scripts attach to.
+        base: Box<Self>,
+        /// The subscript, if any.
+        sub: Option<Box<Self>>,
+        /// The superscript, if any.
+        sup: Option<Box<Self>>,
+    },
+    /// Explicit horizontal space, in ems.
+    ///
+    /// This is what `\,` and its relatives produce. It is distinct from the
+    /// automatic inter-atom spacing in [`crate::spacing`]: that is a property
+    /// of the classes either side of a gap, this is an author's instruction.
+    Space(f32),
+    /// A group held between fences that grow to fit it.
+    Fenced {
+        /// The opening fence, absent for a half-open group.
+        open: Option<Operator>,
+        /// The enclosed expression.
+        body: Box<Self>,
+        /// The closing fence, absent for a half-open group.
+        close: Option<Operator>,
+    },
+}
+
+impl MathItem {
+    /// An empty row, which is what an empty formula parses to.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self::Row(Vec::new())
+    }
+
+    /// Wraps a sequence, collapsing the one-element case.
+    ///
+    /// A row of one is indistinguishable from its only child for both layout
+    /// and accessibility, and keeping the wrapper would make every script base
+    /// a nested row.
+    #[must_use]
+    pub fn row(mut items: Vec<Self>) -> Self {
+        if items.len() == 1 {
+            items.pop().unwrap_or_else(Self::empty)
+        } else {
+            Self::Row(items)
+        }
+    }
+
+    /// How this node spaces against its neighbours.
+    ///
+    /// Only an operator carries a class of its own; everything else is either
+    /// ordinary or, when it is a fenced group, an inner subformula.
+    #[must_use]
+    pub fn class(&self) -> MathClass {
+        match self {
+            Self::Operator(operator) => operator.class,
+            Self::Fenced { .. } => MathClass::Inner,
+            Self::Row(items) => match items.as_slice() {
+                [only] => only.class(),
+                _ => MathClass::Ord,
+            },
+            _ => MathClass::Ord,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::vec;
+
+    use super::*;
+
+    #[test]
+    fn a_row_of_one_collapses_to_its_child() {
+        let collapsed = MathItem::row(vec![MathItem::Number(Str::from_static("1"))]);
+        assert_eq!(collapsed, MathItem::Number(Str::from_static("1")));
+    }
+
+    #[test]
+    fn an_empty_row_stays_a_row() {
+        assert_eq!(MathItem::row(Vec::new()), MathItem::Row(Vec::new()));
+    }
+
+    /// A single-child row must not hide the class of what it wraps, or the
+    /// operator inside it would be spaced as an ordinary atom.
+    #[test]
+    fn a_wrapped_operator_keeps_its_class() {
+        let wrapped = MathItem::Row(vec![MathItem::Operator(Operator::new("=", MathClass::Rel))]);
+        assert_eq!(wrapped.class(), MathClass::Rel);
+    }
+
+    #[test]
+    fn styles_step_down_for_scripts_and_bottom_out() {
+        assert_eq!(MathStyle::Display.script(), MathStyle::Script);
+        assert_eq!(MathStyle::Text.script(), MathStyle::Script);
+        assert_eq!(MathStyle::Script.script(), MathStyle::ScriptScript);
+        assert_eq!(
+            MathStyle::ScriptScript.script(),
+            MathStyle::ScriptScript,
+            "script style must bottom out rather than shrink without limit"
+        );
+    }
+
+    /// A display fraction sets its parts in text style, not display style —
+    /// otherwise nested fractions never shrink and a continued fraction is
+    /// drawn at full size all the way down.
+    #[test]
+    fn fraction_parts_step_down_from_display() {
+        assert_eq!(MathStyle::Display.fraction(), MathStyle::Text);
+        assert_eq!(MathStyle::Text.fraction(), MathStyle::Script);
+        assert_eq!(MathStyle::Script.fraction(), MathStyle::ScriptScript);
+    }
+}

--- a/components/visual/math/src/font.rs
+++ b/components/visual/math/src/font.rs
@@ -1,0 +1,588 @@
+//! Access to a face's OpenType `MATH` table.
+//!
+//! Everything layout needs from the font is reached through here: the layout
+//! constants, glyph outlines and advances, italic correction, and the
+//! construction of glyphs that grow to fit their content.
+//!
+//! Two things about this module are load-bearing.
+//!
+//! First, the paired constants are resolved by [`MathStyle`] at the point the
+//! constants are built, so layout code cannot reach for the non-display gap
+//! while setting a display formula. Several `MATH` constants come in exactly
+//! that pair and picking the wrong one is invisible until someone compares a
+//! display fraction against a reference.
+//!
+//! Second, growing a glyph is a *general* facility. Radicals, parentheses,
+//! braces, brackets, arrows and bars all stretch through the same
+//! `MathVariants` mechanism — discrete variants first, then a multi-part
+//! assembly when no variant is large enough. Special-casing the radical is how
+//! an implementation ends up measuring outlines to find where its bar sits.
+
+use alloc::vec::Vec;
+
+use kurbo::{Affine, BezPath, Point};
+use ttf_parser::math::{GlyphAssembly, Variants};
+use ttf_parser::{Face, GlyphId, OutlineBuilder};
+
+use crate::ast::MathStyle;
+
+/// Why a face could not be used to set mathematics.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MathFontError {
+    /// The bytes are not a font this parser understands.
+    #[error("could not parse the math font face (index {index})")]
+    Unparsable {
+        /// The face index that was requested.
+        index: u32,
+    },
+    /// The face parsed, but carries no `MATH` table.
+    ///
+    /// This is the common failure, and it is not recoverable by drawing
+    /// something approximate: without the table there are no layout constants,
+    /// no glyph variants and no assemblies, so there is nothing to lay out
+    /// against.
+    #[error(
+        "font `{family}` has no OpenType MATH table, so it cannot set mathematics; \
+         choose a math font such as STIX Two Math"
+    )]
+    NotAMathFont {
+        /// The family name reported by the face, for the error message.
+        family: alloc::string::String,
+    },
+    /// A glyph the formula needs is not in the face.
+    #[error("math font has no glyph for {character:?}")]
+    MissingGlyph {
+        /// The character that could not be mapped.
+        character: char,
+    },
+    /// A glyph exists but carries no outline to draw.
+    #[error("math font glyph {glyph:?} has no outline")]
+    MissingOutline {
+        /// The glyph that could not be outlined.
+        glyph: u16,
+    },
+    /// A stretchy glyph's assembly is malformed.
+    #[error("math font cannot assemble a stretched glyph: {reason}")]
+    Assembly {
+        /// What about the assembly could not be honoured.
+        reason: &'static str,
+    },
+}
+
+/// The `MATH` constants a formula needs, in pixels, at one size and style.
+///
+/// Built once per style change rather than read per use, so the display and
+/// non-display members of each pair are chosen exactly once.
+#[derive(Debug, Clone, Copy)]
+pub struct MathConstants {
+    /// Height of the imaginary line operators and fraction bars centre on.
+    pub axis_height: f32,
+    /// Thickness of a fraction rule, and the reference thickness for bars.
+    pub fraction_rule_thickness: f32,
+    /// How far a numerator's baseline sits above the axis.
+    pub fraction_numerator_shift_up: f32,
+    /// How far a denominator's baseline sits below the axis.
+    pub fraction_denominator_shift_down: f32,
+    /// Smallest gap between the numerator and the rule.
+    pub fraction_numerator_gap_min: f32,
+    /// Smallest gap between the rule and the denominator.
+    pub fraction_denominator_gap_min: f32,
+    /// Smallest gap between a radical's bar and what it covers.
+    pub radical_vertical_gap: f32,
+    /// Thickness of a radical's bar.
+    pub radical_rule_thickness: f32,
+    /// How far the radical sign rises above its bar.
+    pub radical_extra_ascender: f32,
+    /// Space before a radical's degree.
+    pub radical_kern_before_degree: f32,
+    /// Space after a radical's degree.
+    pub radical_kern_after_degree: f32,
+    /// Where the degree sits, as a fraction of the radical's height.
+    pub radical_degree_bottom_raise_percent: f32,
+    /// Default upward shift of a superscript's baseline.
+    pub superscript_shift_up: f32,
+    /// Default downward shift of a subscript's baseline.
+    pub subscript_shift_down: f32,
+    /// A superscript's baseline may not sit lower than this.
+    pub superscript_bottom_min: f32,
+    /// A subscript's top may not rise above this.
+    pub subscript_top_max: f32,
+    /// Smallest gap between a superscript and a subscript on the same base.
+    pub sub_superscript_gap_min: f32,
+    /// Space added after a script, so the next atom does not touch it.
+    pub space_after_script: f32,
+}
+
+impl MathConstants {
+    fn read(constants: &ttf_parser::math::Constants<'_>, scale: f32, style: MathStyle) -> Self {
+        let px = |value: ttf_parser::math::MathValue<'_>| f32::from(value.value) * scale;
+        let display = style.is_display();
+
+        Self {
+            axis_height: px(constants.axis_height()),
+            fraction_rule_thickness: px(constants.fraction_rule_thickness()),
+            fraction_numerator_shift_up: if display {
+                px(constants.fraction_numerator_display_style_shift_up())
+            } else {
+                px(constants.fraction_numerator_shift_up())
+            },
+            fraction_denominator_shift_down: if display {
+                px(constants.fraction_denominator_display_style_shift_down())
+            } else {
+                px(constants.fraction_denominator_shift_down())
+            },
+            fraction_numerator_gap_min: if display {
+                px(constants.fraction_num_display_style_gap_min())
+            } else {
+                px(constants.fraction_numerator_gap_min())
+            },
+            fraction_denominator_gap_min: if display {
+                px(constants.fraction_denom_display_style_gap_min())
+            } else {
+                px(constants.fraction_denominator_gap_min())
+            },
+            radical_vertical_gap: if display {
+                px(constants.radical_display_style_vertical_gap())
+            } else {
+                px(constants.radical_vertical_gap())
+            },
+            radical_rule_thickness: px(constants.radical_rule_thickness()),
+            radical_extra_ascender: px(constants.radical_extra_ascender()),
+            radical_kern_before_degree: px(constants.radical_kern_before_degree()),
+            radical_kern_after_degree: px(constants.radical_kern_after_degree()),
+            radical_degree_bottom_raise_percent: f32::from(
+                constants.radical_degree_bottom_raise_percent(),
+            ) / 100.0,
+            superscript_shift_up: px(constants.superscript_shift_up()),
+            subscript_shift_down: px(constants.subscript_shift_down()),
+            superscript_bottom_min: px(constants.superscript_bottom_min()),
+            subscript_top_max: px(constants.subscript_top_max()),
+            sub_superscript_gap_min: px(constants.sub_superscript_gap_min()),
+            space_after_script: px(constants.space_after_script()),
+        }
+    }
+}
+
+/// A glyph placed by layout: which glyph, from which face, at what size.
+///
+/// Positions are filled in by layout; this is the identity half.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Glyph {
+    /// Index into the face.
+    pub id: GlyphId,
+}
+
+/// A glyph grown to a requested size, as an outline in pixels.
+#[derive(Debug, Clone)]
+pub struct StretchedGlyph {
+    /// The outline, already scaled and in the y-down space layout works in,
+    /// with its top-left at the origin.
+    pub outline: BezPath,
+    /// Total height of the outline.
+    pub height: f32,
+    /// Total width of the outline.
+    pub width: f32,
+}
+
+/// A face that can set mathematics.
+pub struct MathFont<'a> {
+    face: Face<'a>,
+    units_per_em: f32,
+}
+
+impl core::fmt::Debug for MathFont<'_> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("MathFont")
+            .field("units_per_em", &self.units_per_em)
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> MathFont<'a> {
+    /// Reads a face, rejecting it if it cannot set mathematics.
+    ///
+    /// The `MATH` table is checked here rather than at first use, so a face
+    /// without one is refused while there is still a clear place to say so.
+    ///
+    /// # Errors
+    ///
+    /// [`MathFontError::Unparsable`] if the bytes are not a font, or
+    /// [`MathFontError::NotAMathFont`] if they are a font that carries no
+    /// `MATH` table and so cannot set mathematics.
+    pub fn new(data: &'a [u8], index: u32) -> Result<Self, MathFontError> {
+        let face = Face::parse(data, index).map_err(|_| MathFontError::Unparsable { index })?;
+
+        if face.tables().math.and_then(|math| math.constants).is_none() {
+            let family = face
+                .names()
+                .into_iter()
+                .find(|name| name.name_id == ttf_parser::name_id::FAMILY)
+                .and_then(|name| name.to_string())
+                .unwrap_or_else(|| alloc::string::String::from("<unnamed>"));
+            return Err(MathFontError::NotAMathFont { family });
+        }
+
+        let units_per_em = f32::from(face.units_per_em());
+        Ok(Self { face, units_per_em })
+    }
+
+    /// Font units to pixels at `font_size`.
+    fn scale(&self, font_size: f32) -> f32 {
+        font_size / self.units_per_em
+    }
+
+    fn math(&self) -> ttf_parser::math::Table<'a> {
+        self.face
+            .tables()
+            .math
+            .expect("MathFont::new refuses a face without a MATH table")
+    }
+
+    fn variants(&self) -> Option<Variants<'a>> {
+        self.math().variants
+    }
+
+    /// The layout constants at this size and style.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice: [`MathFont::new`] refuses a face whose `MATH` table
+    /// has no constants, so a `MathFont` that exists has them.
+    #[must_use]
+    pub fn constants(&self, font_size: f32, style: MathStyle) -> MathConstants {
+        let constants = self
+            .math()
+            .constants
+            .expect("MathFont::new refuses a face without MATH constants");
+        MathConstants::read(&constants, self.scale(font_size), style)
+    }
+
+    /// How far scripts shrink at `style`, as a multiple of the base size.
+    ///
+    /// # Panics
+    ///
+    /// Never in practice, for the same reason as [`MathFont::constants`].
+    #[must_use]
+    pub fn script_scale(&self, style: MathStyle) -> f32 {
+        let constants = self
+            .math()
+            .constants
+            .expect("MathFont::new refuses a face without MATH constants");
+        match style {
+            MathStyle::Display | MathStyle::Text => 1.0,
+            MathStyle::Script => f32::from(constants.script_percent_scale_down()) / 100.0,
+            MathStyle::ScriptScript => {
+                f32::from(constants.script_script_percent_scale_down()) / 100.0
+            }
+        }
+    }
+
+    /// The glyph `character` maps to.
+    ///
+    /// # Errors
+    ///
+    /// [`MathFontError::MissingGlyph`] if the face has no glyph for it.
+    pub fn glyph(&self, character: char) -> Result<Glyph, MathFontError> {
+        self.face
+            .glyph_index(character)
+            .map(|id| Glyph { id })
+            .ok_or(MathFontError::MissingGlyph { character })
+    }
+
+    /// How far the pen moves after drawing `glyph`.
+    #[must_use]
+    pub fn advance(&self, glyph: Glyph, font_size: f32) -> f32 {
+        self.face
+            .glyph_hor_advance(glyph.id)
+            .map_or(0.0, |advance| f32::from(advance) * self.scale(font_size))
+    }
+
+    /// The correction that keeps a script clear of a slanted glyph's overhang.
+    ///
+    /// Without it a superscript on an italic letter sits visibly too far left,
+    /// because the letter's advance stops before its ink does.
+    #[must_use]
+    pub fn italic_correction(&self, glyph: Glyph, font_size: f32) -> f32 {
+        self.math()
+            .glyph_info
+            .and_then(|info| info.italic_corrections)
+            .and_then(|corrections| corrections.get(glyph.id))
+            .map_or(0.0, |value| f32::from(value.value) * self.scale(font_size))
+    }
+
+    /// How far above and below the baseline `glyph`'s ink reaches, in the
+    /// y-down space layout works in.
+    ///
+    /// Returns `(ascent, descent)`, both non-negative.
+    #[must_use]
+    pub fn vertical_extents(&self, glyph: Glyph, font_size: f32) -> (f32, f32) {
+        let scale = self.scale(font_size);
+        self.face
+            .glyph_bounding_box(glyph.id)
+            .map_or((0.0, 0.0), |bbox| {
+                (
+                    (f32::from(bbox.y_max) * scale).max(0.0),
+                    (-f32::from(bbox.y_min) * scale).max(0.0),
+                )
+            })
+    }
+
+    /// `glyph`'s outline in pixels, in the y-down space, relative to its
+    /// baseline origin.
+    ///
+    /// # Errors
+    ///
+    /// [`MathFontError::MissingOutline`] if the glyph carries no outline, as a
+    /// bitmap-only or blank glyph does.
+    pub fn outline(&self, glyph: Glyph, font_size: f32) -> Result<BezPath, MathFontError> {
+        let mut builder = OutlineToBezPath::default();
+        self.face
+            .outline_glyph(glyph.id, &mut builder)
+            .ok_or(MathFontError::MissingOutline { glyph: glyph.id.0 })?;
+        let mut path = builder.path;
+        path.apply_affine(Affine::scale(f64::from(self.scale(font_size))));
+        Ok(path)
+    }
+
+    /// Grows `character` vertically to at least `target` pixels.
+    ///
+    /// Discrete variants are tried in order first, since a designed variant is
+    /// always better than an assembled one; only when the largest is still too
+    /// small is the multi-part assembly built. This is the mechanism behind
+    /// every growing glyph — radicals, fences, braces and bars alike.
+    ///
+    /// # Errors
+    ///
+    /// [`MathFontError::MissingGlyph`] or [`MathFontError::MissingOutline`] if
+    /// the face cannot supply a piece, or [`MathFontError::Assembly`] if the
+    /// glyph's assembly is malformed or cannot reach the requested size.
+    pub fn stretch_vertical(
+        &self,
+        character: char,
+        target: f32,
+        font_size: f32,
+    ) -> Result<StretchedGlyph, MathFontError> {
+        let glyph = self.glyph(character)?;
+        let scale = self.scale(font_size);
+        let target_units = target / scale;
+
+        let construction = self
+            .variants()
+            .and_then(|variants| variants.vertical_constructions.get(glyph.id));
+
+        let Some(construction) = construction else {
+            return self.as_stretched(glyph, font_size);
+        };
+
+        let mut best = None;
+        for variant in construction.variants {
+            best = Some(variant);
+            if f32::from(variant.advance_measurement) >= target_units {
+                break;
+            }
+        }
+
+        let large_enough =
+            best.is_some_and(|variant| f32::from(variant.advance_measurement) >= target_units);
+
+        if !large_enough && let Some(assembly) = construction.assembly {
+            let min_overlap = self
+                .variants()
+                .map_or(0, |variants| variants.min_connector_overlap);
+            return self.assemble_vertical(assembly, min_overlap, target_units, font_size);
+        }
+
+        let variant = best.ok_or(MathFontError::Assembly {
+            reason: "glyph construction has no variants",
+        })?;
+        self.as_stretched(
+            Glyph {
+                id: variant.variant_glyph,
+            },
+            font_size,
+        )
+    }
+
+    /// One glyph, normalised so its top-left sits at the origin.
+    fn as_stretched(&self, glyph: Glyph, font_size: f32) -> Result<StretchedGlyph, MathFontError> {
+        let scale = self.scale(font_size);
+        let bbox = self
+            .face
+            .glyph_bounding_box(glyph.id)
+            .ok_or(MathFontError::MissingOutline { glyph: glyph.id.0 })?;
+        let mut outline = self.outline(glyph, font_size)?;
+
+        // Font space is y-up and the outline builder already flipped it, so the
+        // top edge is at `-y_max`.
+        let left = f32::from(bbox.x_min) * scale;
+        let top = -f32::from(bbox.y_max) * scale;
+        outline.apply_affine(Affine::translate((f64::from(-left), f64::from(-top))));
+
+        Ok(StretchedGlyph {
+            outline,
+            height: (f32::from(bbox.y_max) - f32::from(bbox.y_min)) * scale,
+            width: (f32::from(bbox.x_max) - f32::from(bbox.x_min)) * scale,
+        })
+    }
+
+    /// Builds a glyph from its parts, repeating the extenders until it is long
+    /// enough.
+    fn assemble_vertical(
+        &self,
+        assembly: GlyphAssembly<'a>,
+        min_connector_overlap: u16,
+        target_units: f32,
+        font_size: f32,
+    ) -> Result<StretchedGlyph, MathFontError> {
+        let parts: Vec<_> = assembly.parts.into_iter().collect();
+        if parts.is_empty() {
+            return Err(MathFontError::Assembly {
+                reason: "assembly has no parts",
+            });
+        }
+        if !parts.iter().any(|part| part.part_flags.extender()) {
+            return Err(MathFontError::Assembly {
+                reason: "assembly has no extender part",
+            });
+        }
+
+        // Repeat every extender equally, growing the run until it spans the
+        // target. Each pass adds one copy of each extender, which is what keeps
+        // a brace's two halves symmetric.
+        //
+        // The bound is on the repeat count rather than on the measured length,
+        // so a font whose connectors overlap by their whole advance — which
+        // would never grow the run — terminates with an error instead of
+        // looping.
+        let mut sequence = None;
+        for repeats in 1..=MAX_REPEATS {
+            let candidate = expand(&parts, repeats);
+            if advance_of(&candidate, min_connector_overlap) >= target_units {
+                sequence = Some(candidate);
+                break;
+            }
+            if repeats == MAX_REPEATS {
+                return Err(MathFontError::Assembly {
+                    reason: "assembly did not reach the requested size",
+                });
+            }
+        }
+        let Some(sequence) = sequence else {
+            return Err(MathFontError::Assembly {
+                reason: "assembly did not reach the requested size",
+            });
+        };
+
+        let scale = self.scale(font_size);
+        let mut outline = BezPath::new();
+        let mut offset_units = 0.0_f32;
+        let mut width = 0.0_f32;
+
+        for (index, part) in sequence.iter().enumerate() {
+            let glyph = Glyph { id: part.glyph_id };
+            let mut piece = self.outline(glyph, font_size)?;
+            // Parts stack downward in the y-down space.
+            piece.apply_affine(Affine::translate((0.0, f64::from(offset_units * scale))));
+            outline.extend(piece.iter());
+
+            if let Some(bbox) = self.face.glyph_bounding_box(glyph.id) {
+                width = width.max((f32::from(bbox.x_max) - f32::from(bbox.x_min)) * scale);
+            }
+
+            if let Some(next) = sequence.get(index + 1) {
+                let overlap = overlap_between(part, next, min_connector_overlap);
+                offset_units += f32::from(part.full_advance) - overlap;
+            } else {
+                offset_units += f32::from(part.full_advance);
+            }
+        }
+
+        let height = offset_units * scale;
+        Ok(StretchedGlyph {
+            outline,
+            height,
+            width,
+        })
+    }
+}
+
+/// How many times an extender may repeat before the assembly is declared
+/// unable to reach the requested size.
+const MAX_REPEATS: usize = 128;
+
+/// How far two adjacent parts may overlap without breaking either connector.
+fn overlap_between(
+    previous: &ttf_parser::math::GlyphPart,
+    next: &ttf_parser::math::GlyphPart,
+    min_connector_overlap: u16,
+) -> f32 {
+    f32::from(min_connector_overlap)
+        .min(f32::from(previous.end_connector_length))
+        .min(f32::from(next.start_connector_length))
+}
+
+/// The part run with every extender repeated `repeats` times.
+fn expand(
+    parts: &[ttf_parser::math::GlyphPart],
+    repeats: usize,
+) -> Vec<ttf_parser::math::GlyphPart> {
+    let mut sequence = Vec::new();
+    for part in parts {
+        let copies = if part.part_flags.extender() {
+            repeats
+        } else {
+            1
+        };
+        for _ in 0..copies {
+            sequence.push(*part);
+        }
+    }
+    sequence
+}
+
+/// Total length of a part run once connectors overlap.
+fn advance_of(parts: &[ttf_parser::math::GlyphPart], min_connector_overlap: u16) -> f32 {
+    let Some(first) = parts.first() else {
+        return 0.0;
+    };
+    let mut total = f32::from(first.full_advance);
+    for pair in parts.windows(2) {
+        let overlap = overlap_between(&pair[0], &pair[1], min_connector_overlap);
+        total += f32::from(pair[1].full_advance) - overlap;
+    }
+    total
+}
+
+/// Collects a glyph outline into a `kurbo` path, flipping to the y-down space
+/// the rest of the framework works in.
+#[derive(Default)]
+struct OutlineToBezPath {
+    path: BezPath,
+}
+
+impl OutlineBuilder for OutlineToBezPath {
+    fn move_to(&mut self, x: f32, y: f32) {
+        self.path.move_to(flip(x, y));
+    }
+
+    fn line_to(&mut self, x: f32, y: f32) {
+        self.path.line_to(flip(x, y));
+    }
+
+    fn quad_to(&mut self, x1: f32, y1: f32, x: f32, y: f32) {
+        self.path.quad_to(flip(x1, y1), flip(x, y));
+    }
+
+    fn curve_to(&mut self, x1: f32, y1: f32, x2: f32, y2: f32, x: f32, y: f32) {
+        self.path.curve_to(flip(x1, y1), flip(x2, y2), flip(x, y));
+    }
+
+    fn close(&mut self) {
+        self.path.close_path();
+    }
+}
+
+fn flip(x: f32, y: f32) -> Point {
+    Point::new(f64::from(x), f64::from(-y))
+}

--- a/components/visual/math/src/latex.rs
+++ b/components/visual/math/src/latex.rs
@@ -1,0 +1,460 @@
+//! Reading LaTeX into the semantic tree.
+//!
+//! The parsing itself is `pulldown-latex`'s: it produces a flat stream of
+//! events in which a construct is followed by the fixed number of items it
+//! consumes, exactly like `pulldown-cmark`. This module's whole job is to fold
+//! that stream into the tree in [`crate::ast`].
+//!
+//! Constructs this crate cannot yet lay out are reported as
+//! [`LatexError::Unsupported`] naming the construct. They are not skipped:
+//! silently dropping a matrix leaves a formula that is wrong in a way nobody
+//! can see, which is worse than refusing it.
+
+use alloc::boxed::Box;
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use pulldown_latex::Storage;
+use pulldown_latex::event::{Content, DelimiterType, Event, Grouping, ScriptType, Visual};
+use waterui_str::Str;
+
+use crate::ast::{MathClass, MathItem, Operator};
+
+/// Why a formula could not be read.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum LatexError {
+    /// The source is not well-formed LaTeX.
+    #[error("could not parse the formula: {message}")]
+    Parse {
+        /// What the parser objected to.
+        message: String,
+    },
+    /// The source is valid, but uses something this layout engine does not
+    /// implement yet.
+    #[error("`{construct}` is not supported yet")]
+    Unsupported {
+        /// The construct that was met.
+        construct: &'static str,
+    },
+    /// A construct promised operands the stream did not deliver.
+    #[error("the formula ended in the middle of `{construct}`")]
+    Truncated {
+        /// The construct that was left incomplete.
+        construct: &'static str,
+    },
+}
+
+/// Reads a LaTeX formula into the semantic tree.
+///
+/// # Errors
+///
+/// Returns [`LatexError`] when the source does not parse, or uses a construct
+/// this engine does not implement.
+pub fn parse(source: &str) -> Result<MathItem, LatexError> {
+    let storage = Storage::new();
+    let parser = pulldown_latex::Parser::new(source, &storage);
+
+    let mut events = Vec::new();
+    for event in parser {
+        events.push(event.map_err(|error| LatexError::Parse {
+            message: error.to_string(),
+        })?);
+    }
+
+    let mut reader = Reader {
+        events: &events,
+        position: 0,
+    };
+    let mut items = Vec::new();
+    while reader.position < reader.events.len() {
+        items.push(reader.item()?);
+    }
+    Ok(MathItem::row(items))
+}
+
+struct Reader<'a, 'b> {
+    events: &'a [Event<'b>],
+    position: usize,
+}
+
+impl Reader<'_, '_> {
+    /// Reads exactly one item: an atom, a group, or a construct with its
+    /// operands.
+    fn item(&mut self) -> Result<MathItem, LatexError> {
+        // Taken by value so the reader stays free to advance while a construct
+        // reads the operands that follow it.
+        let Some(event) = self.events.get(self.position).cloned() else {
+            return Err(LatexError::Truncated {
+                construct: "expression",
+            });
+        };
+        self.position += 1;
+
+        match event {
+            Event::Content(content) => Ok(atom(&content)),
+            Event::Begin(grouping) => self.group(&grouping),
+            Event::End => Err(LatexError::Parse {
+                message: String::from("unbalanced group"),
+            }),
+            Event::Visual(visual) => self.visual(visual),
+            Event::Script { ty, .. } => self.script(ty),
+            Event::Space { width, .. } => Ok(MathItem::Space(width.map_or(0.0, em_of))),
+            // A state change alters font variant or size for what follows.
+            // Honouring it needs the mathematical-alphanumeric mapping for each
+            // variant, which is a separate piece of work; ignoring it would
+            // render bold as regular with nothing to say so.
+            Event::StateChange(_) => Err(LatexError::Unsupported {
+                construct: "font and style changes",
+            }),
+            Event::EnvironmentFlow(_) => Err(LatexError::Unsupported {
+                construct: "multi-line and tabular environments",
+            }),
+        }
+    }
+
+    fn group(&mut self, grouping: &Grouping) -> Result<MathItem, LatexError> {
+        match grouping {
+            Grouping::Normal => {
+                let items = self.until_end()?;
+                Ok(MathItem::row(items))
+            }
+            Grouping::LeftRight(open, close) => {
+                let items = self.until_end()?;
+                Ok(MathItem::Fenced {
+                    open: open.map(|character| fence(character, MathClass::Open)),
+                    body: Box::new(MathItem::row(items)),
+                    close: close.map(|character| fence(character, MathClass::Close)),
+                })
+            }
+            Grouping::Array(_) | Grouping::Matrix { .. } | Grouping::SubArray { .. } => {
+                Err(LatexError::Unsupported {
+                    construct: "matrices and arrays",
+                })
+            }
+            Grouping::Cases { .. } => Err(LatexError::Unsupported { construct: "cases" }),
+            _ => Err(LatexError::Unsupported {
+                construct: "multi-line and tabular environments",
+            }),
+        }
+    }
+
+    /// Reads items until the matching `End`.
+    fn until_end(&mut self) -> Result<Vec<MathItem>, LatexError> {
+        let mut items = Vec::new();
+        loop {
+            match self.events.get(self.position) {
+                None => return Err(LatexError::Truncated { construct: "group" }),
+                Some(Event::End) => {
+                    self.position += 1;
+                    return Ok(items);
+                }
+                Some(_) => items.push(self.item()?),
+            }
+        }
+    }
+
+    fn visual(&mut self, visual: Visual) -> Result<MathItem, LatexError> {
+        match visual {
+            Visual::SquareRoot => Ok(MathItem::Radical {
+                radicand: Box::new(self.item()?),
+                degree: None,
+            }),
+            Visual::Root => {
+                // The stream gives the radicand first, then the index.
+                let radicand = self.item()?;
+                let degree = self.item()?;
+                Ok(MathItem::Radical {
+                    radicand: Box::new(radicand),
+                    degree: Some(Box::new(degree)),
+                })
+            }
+            Visual::Fraction(_) => {
+                let numerator = self.item()?;
+                let denominator = self.item()?;
+                Ok(MathItem::Fraction {
+                    numerator: Box::new(numerator),
+                    denominator: Box::new(denominator),
+                })
+            }
+            Visual::Negation => Err(LatexError::Unsupported {
+                construct: "negation",
+            }),
+        }
+    }
+
+    fn script(&mut self, ty: ScriptType) -> Result<MathItem, LatexError> {
+        let base = Box::new(self.item()?);
+        match ty {
+            ScriptType::Subscript => Ok(MathItem::Scripts {
+                base,
+                sub: Some(Box::new(self.item()?)),
+                sup: None,
+            }),
+            ScriptType::Superscript => Ok(MathItem::Scripts {
+                base,
+                sub: None,
+                sup: Some(Box::new(self.item()?)),
+            }),
+            ScriptType::SubSuperscript => {
+                let sub = Box::new(self.item()?);
+                let sup = Box::new(self.item()?);
+                Ok(MathItem::Scripts {
+                    base,
+                    sub: Some(sub),
+                    sup: Some(sup),
+                })
+            }
+        }
+    }
+}
+
+/// One content event as a leaf of the tree.
+fn atom(content: &Content<'_>) -> MathItem {
+    match content {
+        Content::Text(text) => MathItem::Text(Str::from((*text).to_string())),
+        Content::Number(number) => MathItem::Number(Str::from((*number).to_string())),
+        // A function name is several letters that must not be read as a product
+        // of variables, so it is upright, like literal text.
+        Content::Function(name) => MathItem::Ident(Str::from((*name).to_string())),
+        Content::Ordinary { content, stretchy } => {
+            let glyph = Str::from(content.to_string());
+            if *stretchy {
+                MathItem::Operator(Operator::new(glyph, MathClass::Ord).stretchy())
+            } else if content.is_alphabetic() {
+                MathItem::Ident(glyph)
+            } else {
+                MathItem::Operator(Operator::new(glyph, MathClass::Ord))
+            }
+        }
+        Content::LargeOp { content, .. } => {
+            MathItem::Operator(Operator::new(Str::from(content.to_string()), MathClass::Op))
+        }
+        Content::BinaryOp { content, .. } => MathItem::Operator(Operator::new(
+            Str::from(content.to_string()),
+            MathClass::Bin,
+        )),
+        Content::Relation { content, .. } => MathItem::Operator(Operator::new(
+            Str::from(relation_text(*content)),
+            MathClass::Rel,
+        )),
+        Content::Delimiter { content, ty, .. } => {
+            let class = match ty {
+                DelimiterType::Open => MathClass::Open,
+                DelimiterType::Close => MathClass::Close,
+                DelimiterType::Fence => MathClass::Ord,
+            };
+            MathItem::Operator(Operator::new(Str::from(content.to_string()), class).stretchy())
+        }
+        Content::Punctuation(character) => MathItem::Operator(Operator::new(
+            Str::from(character.to_string()),
+            MathClass::Punct,
+        )),
+    }
+}
+
+fn fence(character: char, class: MathClass) -> Operator {
+    Operator::new(Str::from(character.to_string()), class).stretchy()
+}
+
+/// A relation's characters.
+///
+/// `RelationContent` keeps its fields private and hands out UTF-8 through a
+/// caller-supplied buffer. A relation is one character, or two stacked ones, so
+/// eight bytes covers it with room to spare.
+fn relation_text(content: pulldown_latex::event::RelationContent) -> String {
+    let mut buffer = [0_u8; 8];
+    let encoded = content.encode_utf8_to_buf(&mut buffer);
+    core::str::from_utf8(encoded).map_or_else(|_| String::new(), ToString::to_string)
+}
+
+/// A dimension as a multiple of the em.
+fn em_of(dimension: pulldown_latex::event::Dimension) -> f32 {
+    use pulldown_latex::event::DimensionUnit;
+
+    let value = dimension.value;
+    match dimension.unit {
+        DimensionUnit::Em => value,
+        DimensionUnit::Ex => value * 0.5,
+        // The remaining units are absolute; at the reference 10pt em they come
+        // out as these multiples. A formula's own size scales the result, which
+        // is why the conversion lands in ems rather than pixels.
+        DimensionUnit::Pt => value / 10.0,
+        DimensionUnit::Pc => value * 1.2,
+        DimensionUnit::In => value * 7.227,
+        DimensionUnit::Cm => value * 2.845,
+        DimensionUnit::Mm => value * 0.2845,
+        DimensionUnit::Bp => value * 0.1004,
+        DimensionUnit::Dd => value * 0.107,
+        DimensionUnit::Cc => value * 1.284,
+        DimensionUnit::Sp => value / 655_360.0,
+        DimensionUnit::Mu => value / 18.0,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ast::MathStyle;
+    use crate::spacing::SpacingTable;
+
+    fn parsed(source: &str) -> MathItem {
+        parse(source).unwrap_or_else(|error| panic!("`{source}` must parse: {error}"))
+    }
+
+    #[test]
+    fn a_fraction_becomes_a_fraction_node() {
+        assert!(matches!(parsed(r"\frac{a}{b}"), MathItem::Fraction { .. }));
+    }
+
+    #[test]
+    fn a_square_root_becomes_a_radical_without_a_degree() {
+        let MathItem::Radical { degree, .. } = parsed(r"\sqrt{x}") else {
+            panic!("expected a radical");
+        };
+        assert!(degree.is_none());
+    }
+
+    #[test]
+    fn a_cube_root_carries_its_index() {
+        let MathItem::Radical { degree, .. } = parsed(r"\sqrt[3]{x}") else {
+            panic!("expected a radical");
+        };
+        assert!(
+            degree.is_some(),
+            "the index of a cube root must survive parsing"
+        );
+    }
+
+    #[test]
+    fn scripts_attach_to_their_base() {
+        let MathItem::Scripts { sub, sup, .. } = parsed("x^2") else {
+            panic!("expected scripts");
+        };
+        assert!(sup.is_some() && sub.is_none());
+
+        let MathItem::Scripts { sub, sup, .. } = parsed("x_i^2") else {
+            panic!("expected scripts");
+        };
+        assert!(sup.is_some() && sub.is_some());
+    }
+
+    /// The classes are the whole point of parsing into this tree rather than a
+    /// list of characters: without them there is no spacing.
+    #[test]
+    fn operators_carry_the_class_that_drives_spacing() {
+        let MathItem::Row(items) = parsed("a+b=c") else {
+            panic!("expected a row");
+        };
+        let classes: Vec<_> = items.iter().map(MathItem::class).collect();
+        assert!(
+            classes.contains(&MathClass::Bin),
+            "`+` must be a binary operator, got {classes:?}"
+        );
+        assert!(
+            classes.contains(&MathClass::Rel),
+            "`=` must be a relation, got {classes:?}"
+        );
+    }
+
+    /// The gaps `a+b=c` gets must actually differ, end to end from source to
+    /// spacing table. This is the regression that catches a formula rendered as
+    /// one unbroken run.
+    #[test]
+    fn a_plus_b_equals_c_is_spaced_at_three_widths() {
+        let MathItem::Row(items) = parsed("a+b=c") else {
+            panic!("expected a row");
+        };
+        let table = SpacingTable::load().expect("spacing table loads");
+        let gaps: Vec<f32> = items
+            .windows(2)
+            .map(|pair| table.between(pair[0].class(), pair[1].class(), MathStyle::Text))
+            .collect();
+
+        assert!(
+            gaps.iter().any(|gap| *gap > 0.0),
+            "at least one gap must be non-zero, got {gaps:?}"
+        );
+        let widest = gaps.iter().copied().fold(0.0_f32, f32::max);
+        let narrowest = gaps.iter().copied().fold(f32::INFINITY, f32::min);
+        assert!(
+            widest > narrowest,
+            "the gaps around `+` and `=` must differ, got {gaps:?}"
+        );
+    }
+
+    /// `\text{}` keeps its spaces and stays one node. Splitting it into
+    /// characters and dropping the whitespace turns `\text{if } x` into an
+    /// italic `ifx`.
+    #[test]
+    fn literal_text_keeps_its_spaces() {
+        let item = parsed(r"\text{if }");
+        let text = match &item {
+            MathItem::Text(text) => text.as_str(),
+            MathItem::Row(items) => match items.as_slice() {
+                [MathItem::Text(text)] => text.as_str(),
+                other => panic!("expected literal text, got {other:?}"),
+            },
+            other => panic!("expected literal text, got {other:?}"),
+        };
+        assert!(
+            text.contains("if"),
+            "the words inside \\text must survive, got {text:?}"
+        );
+        assert!(
+            text.ends_with(' '),
+            "the trailing space inside \\text must survive, got {text:?}"
+        );
+    }
+
+    /// A multi-letter function name is one identifier, not a product of
+    /// single-letter variables — so it is set upright.
+    #[test]
+    fn a_function_name_stays_one_identifier() {
+        let item = parsed(r"\sin");
+        assert!(
+            matches!(&item, MathItem::Ident(name) if name.as_str().contains("sin")),
+            "expected a single `sin` identifier, got {item:?}"
+        );
+    }
+
+    /// Stretchy fences survive as a fenced group so they can grow later.
+    #[test]
+    fn left_right_becomes_a_fenced_group() {
+        let item = parsed(r"\left(\frac{a}{b}\right)");
+        let MathItem::Fenced { open, close, .. } = &item else {
+            panic!("expected a fenced group, got {item:?}");
+        };
+        assert!(open.as_ref().is_some_and(|fence| fence.stretchy));
+        assert!(close.as_ref().is_some_and(|fence| fence.stretchy));
+    }
+
+    /// Greek letters the old implementation was missing must simply work,
+    /// because the symbol table is the parser's, not ours.
+    #[test]
+    fn greek_letters_outside_a_hand_written_table_parse() {
+        for source in [r"\psi", r"\eta", r"\tau", r"\xi", r"\Upsilon", r"\zeta"] {
+            parse(source).unwrap_or_else(|error| panic!("`{source}` must parse: {error}"));
+        }
+    }
+
+    /// An unsupported construct is refused by name. It is not dropped: a
+    /// silently missing matrix is a formula that is wrong with nothing to show
+    /// for it.
+    #[test]
+    fn unsupported_constructs_are_refused_rather_than_dropped() {
+        let error = parse(r"\begin{matrix}a & b\\c & d\end{matrix}")
+            .expect_err("a matrix is not supported yet and must say so");
+        assert!(
+            matches!(error, LatexError::Unsupported { .. }),
+            "expected an unsupported-construct error, got {error:?}"
+        );
+    }
+
+    /// A parse failure is an error the caller can handle, never a panic: the
+    /// source routinely comes from user or model output.
+    #[test]
+    fn malformed_input_is_an_error_not_a_panic() {
+        assert!(parse(r"\frac{a}").is_err());
+        assert!(parse(r"\nosuchcommand").is_err());
+    }
+}

--- a/components/visual/math/src/layout.rs
+++ b/components/visual/math/src/layout.rs
@@ -1,0 +1,637 @@
+//! Turning a semantic tree into positioned glyphs and rules.
+//!
+//! Every measurement here comes from the face's OpenType `MATH` table. Nothing
+//! is derived by inspecting glyph outlines, and nothing is a tuned constant:
+//! where a position looks arbitrary it is the value the font supplies, and
+//! where a minimum is enforced it is a `*GapMin` the table names.
+//!
+//! # Coordinates
+//!
+//! A [`MathLayout`] is expressed about its own baseline: `y` grows downward,
+//! the baseline is `y = 0`, [`MathLayout::ascent`] is how far the ink reaches
+//! above it and [`MathLayout::descent`] how far below, both non-negative. `x`
+//! grows rightward from the fragment's left edge. Fragments compose by
+//! translation, which is why every layout function can work in its own frame
+//! and be placed by its caller.
+
+use alloc::vec::Vec;
+
+use kurbo::{Affine, BezPath};
+
+use crate::ast::{MathClass, MathItem, MathStyle, Operator};
+use crate::font::{Glyph, MathConstants, MathFont, MathFontError};
+use crate::spacing::{SpacingError, SpacingTable};
+
+/// Why a formula could not be laid out.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum LayoutError {
+    /// The font could not supply something the formula needs.
+    #[error(transparent)]
+    Font(#[from] MathFontError),
+    /// The spacing table could not be read.
+    #[error(transparent)]
+    Spacing(#[from] SpacingError),
+    /// The requested size is not a size.
+    #[error("font size must be finite and positive, got {size}")]
+    Size {
+        /// The rejected size.
+        size: f32,
+    },
+}
+
+/// One thing to draw, positioned in its fragment's frame.
+#[derive(Debug, Clone)]
+pub enum Placed {
+    /// A glyph from the math face, drawn at its baseline origin.
+    Glyph {
+        /// Which glyph.
+        glyph: Glyph,
+        /// Left edge of the glyph's advance.
+        x: f32,
+        /// The baseline it sits on.
+        baseline: f32,
+        /// The size it is drawn at, which differs from the formula's size
+        /// inside scripts.
+        size: f32,
+    },
+    /// A prebuilt outline, already scaled and already positioned.
+    ///
+    /// This is how a stretched glyph arrives: assembling one produces an
+    /// outline rather than a glyph index, because it is several glyphs joined
+    /// at their connectors. The path carries its own position, so there is no
+    /// separate origin to keep in step with it.
+    Outline(BezPath),
+    /// A filled rectangle: a fraction bar or a radical's overbar.
+    Rule {
+        /// Left edge.
+        x: f32,
+        /// Top edge.
+        y: f32,
+        /// Horizontal extent.
+        width: f32,
+        /// Vertical extent.
+        height: f32,
+    },
+}
+
+impl Placed {
+    /// The same item moved by `(dx, dy)`.
+    #[must_use]
+    fn translated(self, dx: f32, dy: f32) -> Self {
+        match self {
+            Self::Glyph {
+                glyph,
+                x,
+                baseline,
+                size,
+            } => Self::Glyph {
+                glyph,
+                x: x + dx,
+                baseline: baseline + dy,
+                size,
+            },
+            Self::Outline(mut outline) => {
+                outline.apply_affine(Affine::translate((f64::from(dx), f64::from(dy))));
+                Self::Outline(outline)
+            }
+            Self::Rule {
+                x,
+                y,
+                width,
+                height,
+            } => Self::Rule {
+                x: x + dx,
+                y: y + dy,
+                width,
+                height,
+            },
+        }
+    }
+}
+
+/// A laid-out formula, or a piece of one.
+#[derive(Debug, Clone, Default)]
+pub struct MathLayout {
+    /// What to draw.
+    pub items: Vec<Placed>,
+    /// Total advance width.
+    pub width: f32,
+    /// How far the ink reaches above the baseline.
+    pub ascent: f32,
+    /// How far the ink reaches below the baseline.
+    pub descent: f32,
+}
+
+impl MathLayout {
+    /// Total height, ascent plus descent.
+    #[must_use]
+    pub fn height(&self) -> f32 {
+        self.ascent + self.descent
+    }
+
+    /// Absorbs `other`, placing its origin at `(dx, dy)` in this frame.
+    fn absorb(&mut self, other: Self, dx: f32, dy: f32) {
+        self.items
+            .extend(other.items.into_iter().map(|item| item.translated(dx, dy)));
+        self.ascent = self.ascent.max(other.ascent - dy);
+        self.descent = self.descent.max(other.descent + dy);
+        self.width = self.width.max(dx + other.width);
+    }
+}
+
+/// Lays formulas out against one face.
+#[derive(Debug)]
+pub struct Layouter<'a> {
+    font: &'a MathFont<'a>,
+    spacing: SpacingTable,
+}
+
+impl<'a> Layouter<'a> {
+    /// Prepares a layouter over `font`.
+    ///
+    /// # Errors
+    ///
+    /// [`LayoutError::Spacing`] if the shipped spacing table is malformed,
+    /// which is a defect in this crate rather than in the caller's input.
+    pub fn new(font: &'a MathFont<'a>) -> Result<Self, LayoutError> {
+        Ok(Self {
+            font,
+            spacing: SpacingTable::load()?,
+        })
+    }
+
+    /// Lays `item` out at `size` pixels in `style`.
+    ///
+    /// # Errors
+    ///
+    /// [`LayoutError::Size`] if `size` is not finite and positive, or
+    /// [`LayoutError::Font`] if the face cannot supply a glyph the formula
+    /// needs or cannot grow one to the size the formula requires.
+    pub fn layout(
+        &self,
+        item: &MathItem,
+        size: f32,
+        style: MathStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        if !(size.is_finite() && size > 0.0) {
+            return Err(LayoutError::Size { size });
+        }
+        self.item(item, size, style)
+    }
+
+    fn constants(&self, size: f32, style: MathStyle) -> MathConstants {
+        self.font.constants(size, style)
+    }
+
+    /// The size a child in `child_style` takes, given a parent at `size` in
+    /// `style`.
+    ///
+    /// Stepping relatively rather than absolutely is what keeps a script inside
+    /// a script from being scaled twice from the top.
+    fn child_size(&self, size: f32, style: MathStyle, child_style: MathStyle) -> f32 {
+        let from = self.font.script_scale(style);
+        let to = self.font.script_scale(child_style);
+        if from > 0.0 { size * (to / from) } else { size }
+    }
+
+    fn item(
+        &self,
+        item: &MathItem,
+        size: f32,
+        style: MathStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        match item {
+            MathItem::Ident(text) => self.glyph_run(text, size, IdentStyle::Italic),
+            MathItem::Number(text) | MathItem::Text(text) => {
+                self.glyph_run(text, size, IdentStyle::Upright)
+            }
+            MathItem::Operator(operator) => {
+                self.glyph_run(&operator.glyph, size, IdentStyle::Upright)
+            }
+            MathItem::Space(em) => Ok(MathLayout {
+                width: em * size,
+                ..MathLayout::default()
+            }),
+            MathItem::Row(items) => self.row(items, size, style),
+            MathItem::Fraction {
+                numerator,
+                denominator,
+            } => self.fraction(numerator, denominator, size, style),
+            MathItem::Radical { radicand, degree } => {
+                self.radical(radicand, degree.as_deref(), size, style)
+            }
+            MathItem::Scripts { base, sub, sup } => {
+                self.scripts(base, sub.as_deref(), sup.as_deref(), size, style)
+            }
+            MathItem::Fenced { open, body, close } => {
+                self.fenced(open.as_ref(), body, close.as_ref(), size, style)
+            }
+        }
+    }
+
+    /// A run of characters set as glyphs on one baseline.
+    fn glyph_run(
+        &self,
+        text: &str,
+        size: f32,
+        ident_style: IdentStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        let mut layout = MathLayout::default();
+        let letters = text.chars().count();
+
+        for character in text.chars() {
+            // A single-letter identifier is italic, which is the convention
+            // for a variable; a multi-letter one (`sin`, `max`) stays upright,
+            // because it is a name rather than a product of variables.
+            let drawn = match ident_style {
+                IdentStyle::Italic if letters == 1 => math_italic(character),
+                _ => character,
+            };
+            let glyph = self.font.glyph(drawn).or_else(|error| {
+                // A face may lack the mathematical-alphanumeric codepoint while
+                // having the plain letter. Falling back to the plain letter is
+                // a different glyph, not a different rendering strategy, so it
+                // stays inside the font layer's contract.
+                if drawn == character {
+                    Err(error)
+                } else {
+                    self.font.glyph(character)
+                }
+            })?;
+
+            let (ascent, descent) = self.font.vertical_extents(glyph, size);
+            layout.items.push(Placed::Glyph {
+                glyph,
+                x: layout.width,
+                baseline: 0.0,
+                size,
+            });
+            layout.width += self.font.advance(glyph, size);
+            layout.ascent = layout.ascent.max(ascent);
+            layout.descent = layout.descent.max(descent);
+        }
+
+        Ok(layout)
+    }
+
+    /// A horizontal sequence, with the gaps the spacing table calls for.
+    fn row(
+        &self,
+        items: &[MathItem],
+        size: f32,
+        style: MathStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        let mut layout = MathLayout::default();
+        let mut previous: Option<MathClass> = None;
+
+        for item in items {
+            if let Some(left) = previous {
+                layout.width = self
+                    .spacing
+                    .between(left, item.class(), style)
+                    .mul_add(size, layout.width);
+            }
+            let child = self.item(item, size, style)?;
+            let x = layout.width;
+            let advance = child.width;
+            layout.absorb(child, x, 0.0);
+            layout.width = x + advance;
+            previous = Some(item.class());
+        }
+
+        Ok(layout)
+    }
+
+    /// A fraction: numerator, rule on the axis, denominator.
+    fn fraction(
+        &self,
+        numerator: &MathItem,
+        denominator: &MathItem,
+        size: f32,
+        style: MathStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        let constants = self.constants(size, style);
+        let inner_style = style.fraction();
+        let inner_size = self.child_size(size, style, inner_style);
+
+        let num = self.item(numerator, inner_size, inner_style)?;
+        let den = self.item(denominator, inner_size, inner_style)?;
+
+        let thickness = constants.fraction_rule_thickness;
+        let axis_y = -constants.axis_height;
+        let rule_top = axis_y - thickness / 2.0;
+        let rule_bottom = axis_y + thickness / 2.0;
+
+        // Start from the font's preferred shifts, then open them up if the
+        // minimum gaps are not met. Both are needed: the shifts alone let a
+        // tall numerator collide with the rule.
+        let numerator_baseline = (-constants.fraction_numerator_shift_up)
+            .min(rule_top - constants.fraction_numerator_gap_min - num.descent);
+        let denominator_baseline = constants
+            .fraction_denominator_shift_down
+            .max(rule_bottom + constants.fraction_denominator_gap_min + den.ascent);
+
+        // The rule spans the wider of the two parts, and each part is centred
+        // over it.
+        let width = num.width.max(den.width);
+        let num_x = (width - num.width) / 2.0;
+        let den_x = (width - den.width) / 2.0;
+
+        let mut layout = MathLayout::default();
+        layout.absorb(num, num_x, numerator_baseline);
+        layout.absorb(den, den_x, denominator_baseline);
+        layout.items.push(Placed::Rule {
+            x: 0.0,
+            y: rule_top,
+            width,
+            height: thickness,
+        });
+        layout.width = width;
+        layout.ascent = layout.ascent.max(-rule_top);
+        layout.descent = layout.descent.max(rule_bottom);
+
+        Ok(layout)
+    }
+
+    /// Sub- and superscripts attached to a base.
+    fn scripts(
+        &self,
+        base: &MathItem,
+        sub: Option<&MathItem>,
+        sup: Option<&MathItem>,
+        size: f32,
+        style: MathStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        let constants = self.constants(size, style);
+        let script_style = style.script();
+        let script_size = self.child_size(size, style, script_style);
+
+        let base_layout = self.item(base, size, style)?;
+        let base_width = base_layout.width;
+
+        // The correction that keeps a superscript clear of a slanted base's
+        // overhang. It applies to the superscript only: the subscript sits
+        // under the overhang, which is the point of the shape.
+        let italic = self.italic_correction(base, size);
+
+        let mut layout = MathLayout::default();
+        layout.absorb(base_layout, 0.0, 0.0);
+        layout.width = base_width;
+
+        let superscript = sup
+            .map(|item| self.item(item, script_size, script_style))
+            .transpose()?;
+        let subscript = sub
+            .map(|item| self.item(item, script_size, script_style))
+            .transpose()?;
+
+        let mut superscript_baseline = 0.0_f32;
+        let mut subscript_baseline = 0.0_f32;
+
+        if let Some(sup) = &superscript {
+            // Raise until the script's own bottom clears the minimum.
+            superscript_baseline = (-constants.superscript_shift_up)
+                .min(-constants.superscript_bottom_min - sup.descent);
+        }
+        if let Some(sub) = &subscript {
+            subscript_baseline = constants
+                .subscript_shift_down
+                .max(sub.ascent - constants.subscript_top_max);
+        }
+        if let (Some(sup), Some(sub)) = (&superscript, &subscript) {
+            // Open the pair apart until the gap between the superscript's
+            // bottom edge and the subscript's top edge meets the minimum.
+            let gap = (subscript_baseline - sub.ascent) - (superscript_baseline + sup.descent);
+            let shortfall = constants.sub_superscript_gap_min - gap;
+            if shortfall > 0.0 {
+                superscript_baseline -= shortfall / 2.0;
+                subscript_baseline += shortfall / 2.0;
+            }
+        }
+
+        let mut right = base_width;
+        if let Some(sup) = superscript {
+            let width = sup.width;
+            layout.absorb(sup, base_width + italic, superscript_baseline);
+            right = right.max(base_width + italic + width);
+        }
+        if let Some(sub) = subscript {
+            let width = sub.width;
+            layout.absorb(sub, base_width, subscript_baseline);
+            right = right.max(base_width + width);
+        }
+
+        layout.width = right + constants.space_after_script;
+        Ok(layout)
+    }
+
+    /// The italic correction of a base, when the base is a single glyph.
+    ///
+    /// A composite base has no single correction to read, and its rightmost
+    /// ink is already accounted for by its own layout.
+    fn italic_correction(&self, base: &MathItem, size: f32) -> f32 {
+        let MathItem::Ident(text) = base else {
+            return 0.0;
+        };
+        let mut characters = text.chars();
+        let (Some(character), None) = (characters.next(), characters.next()) else {
+            return 0.0;
+        };
+        self.font
+            .glyph(math_italic(character))
+            .or_else(|_| self.font.glyph(character))
+            .map_or(0.0, |glyph| self.font.italic_correction(glyph, size))
+    }
+
+    /// A radical: a sign grown to its content, and a bar across the top.
+    fn radical(
+        &self,
+        radicand: &MathItem,
+        degree: Option<&MathItem>,
+        size: f32,
+        style: MathStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        let constants = self.constants(size, style);
+        let inner = self.item(radicand, size, style)?;
+
+        let thickness = constants.radical_rule_thickness;
+        let gap = constants.radical_vertical_gap;
+
+        // The sign has to span the content plus the gap and the bar above it.
+        let target = inner.height() + gap + thickness;
+        let sign = self.font.stretch_vertical('\u{221A}', target, size)?;
+
+        let bar_top = -(inner.ascent + gap + thickness);
+        let mut layout = MathLayout::default();
+
+        // An index, as in a cube root, sits before the sign and raised.
+        let mut x = 0.0_f32;
+        if let Some(degree) = degree {
+            let degree_style = style.script().script();
+            let degree_size = self.child_size(size, style, degree_style);
+            let degree_layout = self.item(degree, degree_size, degree_style)?;
+            let width = degree_layout.width;
+            let raise = constants.radical_degree_bottom_raise_percent * sign.height;
+            let baseline = bar_top + sign.height - raise;
+            x += constants.radical_kern_before_degree;
+            layout.absorb(degree_layout, x, baseline);
+            x += width + constants.radical_kern_after_degree;
+        }
+
+        let mut sign_outline = sign.outline.clone();
+        sign_outline.apply_affine(Affine::translate((f64::from(x), f64::from(bar_top))));
+        layout.items.push(Placed::Outline(sign_outline));
+        layout.ascent = layout
+            .ascent
+            .max(-bar_top + constants.radical_extra_ascender);
+        layout.descent = layout.descent.max(bar_top + sign.height);
+
+        let content_x = x + sign.width;
+        layout.absorb(inner, content_x, 0.0);
+        let content_width = layout.width - content_x;
+
+        layout.items.push(Placed::Rule {
+            x: content_x,
+            y: bar_top,
+            width: content_width,
+            height: thickness,
+        });
+        layout.width = content_x + content_width;
+
+        Ok(layout)
+    }
+
+    /// A group between fences that grow to fit it.
+    fn fenced(
+        &self,
+        open: Option<&Operator>,
+        body: &MathItem,
+        close: Option<&Operator>,
+        size: f32,
+        style: MathStyle,
+    ) -> Result<MathLayout, LayoutError> {
+        let constants = self.constants(size, style);
+        let inner = self.item(body, size, style)?;
+        let axis = constants.axis_height;
+
+        // A fence is centred on the axis and must reach whichever of the
+        // content's edges is further from it, so the pair stays symmetric
+        // about the axis rather than about the content's own centre.
+        let reach = (inner.ascent - axis).max(inner.descent + axis).max(0.0);
+        let target = reach * 2.0;
+
+        let mut layout = MathLayout::default();
+        let mut x = 0.0_f32;
+
+        if let Some(open) = open {
+            x = self.place_fence(&mut layout, open, target, axis, x, size)?;
+        }
+        layout.absorb(inner, x, 0.0);
+        x = layout.width.max(x);
+        if let Some(close) = close {
+            x = self.place_fence(&mut layout, close, target, axis, x, size)?;
+        }
+
+        layout.width = x;
+        Ok(layout)
+    }
+
+    /// Draws one fence, grown when it is marked stretchy.
+    fn place_fence(
+        &self,
+        layout: &mut MathLayout,
+        fence: &Operator,
+        target: f32,
+        axis: f32,
+        x: f32,
+        size: f32,
+    ) -> Result<f32, LayoutError> {
+        let mut characters = fence.glyph.chars();
+        let (Some(character), None) = (characters.next(), characters.next()) else {
+            // A multi-character fence is not a stretchable glyph; set it as a
+            // run so it is at least drawn correctly.
+            let run = self.glyph_run(&fence.glyph, size, IdentStyle::Upright)?;
+            let width = run.width;
+            layout.absorb(run, x, 0.0);
+            return Ok(x + width);
+        };
+
+        if !fence.stretchy {
+            let run = self.glyph_run(&fence.glyph, size, IdentStyle::Upright)?;
+            let width = run.width;
+            layout.absorb(run, x, 0.0);
+            return Ok(x + width);
+        }
+
+        let grown = self.font.stretch_vertical(character, target, size)?;
+        // Centre it on the axis.
+        let top = -(axis + grown.height / 2.0);
+        let mut outline = grown.outline.clone();
+        outline.apply_affine(Affine::translate((f64::from(x), f64::from(top))));
+        layout.items.push(Placed::Outline(outline));
+        layout.ascent = layout.ascent.max(-top);
+        layout.descent = layout.descent.max(top + grown.height);
+        Ok(x + grown.width)
+    }
+}
+
+/// Whether an identifier is set slanted.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum IdentStyle {
+    /// Single-letter variables.
+    Italic,
+    /// Numbers, operators, function names and literal text.
+    Upright,
+}
+
+/// The mathematical-italic codepoint for a Latin letter.
+///
+/// Math fonts put the slanted variable shapes in the Mathematical Alphanumeric
+/// Symbols block rather than in an italic face, so `x` in a formula is
+/// U+1D465, not U+0078 rendered obliquely.
+fn math_italic(character: char) -> char {
+    // U+1D455 is unassigned; the italic small h lives at U+210E, which is the
+    // one hole in an otherwise contiguous block and the classic way to get a
+    // missing glyph here.
+    const ITALIC_SMALL_H: char = '\u{210E}';
+
+    match character {
+        'h' => ITALIC_SMALL_H,
+        'a'..='z' => offset(character, 'a', 0x1D44E),
+        'A'..='Z' => offset(character, 'A', 0x1D434),
+        other => other,
+    }
+}
+
+fn offset(character: char, base: char, target: u32) -> char {
+    let index = character as u32 - base as u32;
+    char::from_u32(target + index).unwrap_or(character)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn italic_maps_latin_letters_into_the_math_block() {
+        assert_eq!(math_italic('x'), '\u{1D465}');
+        assert_eq!(math_italic('a'), '\u{1D44E}');
+        assert_eq!(math_italic('A'), '\u{1D434}');
+        assert_eq!(math_italic('Z'), '\u{1D44D}');
+    }
+
+    /// U+1D455 is a hole in the block. Mapping into it yields a codepoint no
+    /// font has, so the letter would silently vanish.
+    #[test]
+    fn italic_small_h_avoids_the_unassigned_slot() {
+        assert_eq!(math_italic('h'), '\u{210E}');
+        assert_ne!(math_italic('h'), '\u{1D455}');
+    }
+
+    #[test]
+    fn non_latin_characters_pass_through_unchanged() {
+        assert_eq!(math_italic('α'), 'α');
+        assert_eq!(math_italic('1'), '1');
+        assert_eq!(math_italic('+'), '+');
+    }
+}

--- a/components/visual/math/src/lib.rs
+++ b/components/visual/math/src/lib.rs
@@ -1,0 +1,23 @@
+//! Mathematical formula rendering for `WaterUI`.
+//!
+//! A formula is parsed into a semantic tree ([`ast`]), laid out against the
+//! chosen face's OpenType `MATH` table ([`font`], [`layout`]), and drawn
+//! through the engine-independent `Scene2D` contract ([`scene`]) — so it
+//! renders on whichever engine the backend supplies, including the CPU/GPU
+//! split engine that adapters without compute shaders fall to.
+//!
+//! The semantic tree is kept rather than discarded after layout, because it is
+//! also the accessibility representation: a formula drawn as anonymous vector
+//! paths is unreadable to a screen reader, and the tree is what `MathML` is
+//! published from.
+
+extern crate alloc;
+
+pub mod ast;
+pub mod font;
+pub mod latex;
+pub mod layout;
+pub mod mathml;
+pub mod scene;
+pub mod spacing;
+pub mod view;

--- a/components/visual/math/src/lib.rs
+++ b/components/visual/math/src/lib.rs
@@ -10,6 +10,43 @@
 //! also the accessibility representation: a formula drawn as anonymous vector
 //! paths is unreadable to a screen reader, and the tree is what `MathML` is
 //! published from.
+//!
+//! # Displaying a formula
+//!
+//! ```
+//! use waterui_math::view::Math;
+//!
+//! let quadratic = Math::new(r"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}")
+//!     .display()
+//!     .font_size(28.0);
+//! ```
+//!
+//! # Reading one without drawing it
+//!
+//! Parsing and the accessibility markup need no font and no GPU, which is what
+//! makes them usable from a test or a server.
+//!
+//! ```
+//! use waterui_math::ast::MathStyle;
+//! use waterui_math::{latex, mathml};
+//!
+//! let formula = latex::parse(r"\frac{a}{b}")?;
+//! let markup = mathml::to_mathml(&formula, MathStyle::Display)?;
+//!
+//! assert!(markup.contains("<mfrac>"));
+//! assert!(markup.contains(r#"display="block""#));
+//! # Ok::<(), Box<dyn core::error::Error>>(())
+//! ```
+//!
+//! A construct the layout engine does not implement is refused by name rather
+//! than silently dropped, so a formula never renders as a quietly wrong one.
+//!
+//! ```
+//! use waterui_math::latex::{self, LatexError};
+//!
+//! let refused = latex::parse(r"\begin{matrix}a & b\\c & d\end{matrix}");
+//! assert!(matches!(refused, Err(LatexError::Unsupported { .. })));
+//! ```
 
 extern crate alloc;
 

--- a/components/visual/math/src/mathml.rs
+++ b/components/visual/math/src/mathml.rs
@@ -1,0 +1,190 @@
+//! Publishing the semantic tree as `MathML`.
+//!
+//! A formula drawn through [`crate::scene`] reaches the screen as filled paths
+//! and glyph runs. To a screen reader that is a picture with no content, which
+//! is why the tree is kept after layout rather than consumed by it: `MathML` is
+//! what assistive technology actually reads, and this is where it comes from.
+//!
+//! The markup is written through an XML writer rather than assembled from
+//! strings, so tags balance and content is escaped by construction — a formula
+//! containing `<` or `&` is ordinary, not an edge case.
+
+use alloc::string::{String, ToString};
+use alloc::vec::Vec;
+
+use quick_xml::Writer;
+use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
+
+use crate::ast::{MathItem, MathStyle};
+
+/// Why a tree could not be written as `MathML`.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum MathMlError {
+    /// The writer failed, or produced bytes that are not UTF-8.
+    #[error("could not write MathML: {message}")]
+    Write {
+        /// What went wrong.
+        message: String,
+    },
+}
+
+/// Renders `item` as a `MathML` `<math>` element.
+///
+/// `style` sets the `display` attribute, which is the difference between a
+/// formula announced as set on its own line and one announced inline.
+///
+/// # Errors
+///
+/// Returns [`MathMlError`] if the underlying writer fails.
+pub fn to_mathml(item: &MathItem, style: MathStyle) -> Result<String, MathMlError> {
+    let mut writer = Writer::new(Vec::new());
+
+    let mut root = BytesStart::new("math");
+    root.push_attribute(("xmlns", "http://www.w3.org/1998/Math/MathML"));
+    root.push_attribute((
+        "display",
+        if style.is_display() {
+            "block"
+        } else {
+            "inline"
+        },
+    ));
+    write(&mut writer, Event::Start(root))?;
+    element(&mut writer, item)?;
+    write(&mut writer, Event::End(BytesEnd::new("math")))?;
+
+    String::from_utf8(writer.into_inner()).map_err(|error| MathMlError::Write {
+        message: error.to_string(),
+    })
+}
+
+fn write(writer: &mut Writer<Vec<u8>>, event: Event<'_>) -> Result<(), MathMlError> {
+    writer
+        .write_event(event)
+        .map_err(|error| MathMlError::Write {
+            message: error.to_string(),
+        })
+}
+
+fn leaf(writer: &mut Writer<Vec<u8>>, tag: &str, text: &str) -> Result<(), MathMlError> {
+    write(writer, Event::Start(BytesStart::new(tag)))?;
+    write(writer, Event::Text(BytesText::new(text)))?;
+    write(writer, Event::End(BytesEnd::new(tag)))
+}
+
+fn wrap(
+    writer: &mut Writer<Vec<u8>>,
+    tag: &str,
+    children: &[&MathItem],
+) -> Result<(), MathMlError> {
+    write(writer, Event::Start(BytesStart::new(tag)))?;
+    for child in children {
+        element(writer, child)?;
+    }
+    write(writer, Event::End(BytesEnd::new(tag)))
+}
+
+fn element(writer: &mut Writer<Vec<u8>>, item: &MathItem) -> Result<(), MathMlError> {
+    match item {
+        MathItem::Ident(text) => leaf(writer, "mi", text.as_str()),
+        MathItem::Number(text) => leaf(writer, "mn", text.as_str()),
+        MathItem::Text(text) => leaf(writer, "mtext", text.as_str()),
+        MathItem::Operator(operator) => leaf(writer, "mo", operator.glyph.as_str()),
+        MathItem::Space(em) => {
+            let mut space = BytesStart::new("mspace");
+            let width = alloc::format!("{em}em");
+            space.push_attribute(("width", width.as_str()));
+            write(writer, Event::Empty(space))
+        }
+        MathItem::Row(items) => {
+            let children: Vec<&MathItem> = items.iter().collect();
+            wrap(writer, "mrow", &children)
+        }
+        MathItem::Fraction {
+            numerator,
+            denominator,
+        } => wrap(writer, "mfrac", &[numerator, denominator]),
+        MathItem::Radical { radicand, degree } => match degree {
+            None => wrap(writer, "msqrt", &[radicand]),
+            Some(degree) => wrap(writer, "mroot", &[radicand, degree]),
+        },
+        MathItem::Scripts { base, sub, sup } => match (sub, sup) {
+            (Some(sub), Some(sup)) => wrap(writer, "msubsup", &[base, sub, sup]),
+            (Some(sub), None) => wrap(writer, "msub", &[base, sub]),
+            (None, Some(sup)) => wrap(writer, "msup", &[base, sup]),
+            (None, None) => element(writer, base),
+        },
+        MathItem::Fenced { open, body, close } => {
+            write(writer, Event::Start(BytesStart::new("mrow")))?;
+            if let Some(open) = open {
+                leaf(writer, "mo", open.glyph.as_str())?;
+            }
+            element(writer, body)?;
+            if let Some(close) = close {
+                leaf(writer, "mo", close.glyph.as_str())?;
+            }
+            write(writer, Event::End(BytesEnd::new("mrow")))
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::latex;
+
+    fn mathml(source: &str) -> String {
+        let item = latex::parse(source).unwrap_or_else(|error| panic!("`{source}`: {error}"));
+        to_mathml(&item, MathStyle::Text).expect("MathML must be writable")
+    }
+
+    #[test]
+    fn a_fraction_is_an_mfrac() {
+        let markup = mathml(r"\frac{a}{b}");
+        assert!(markup.contains("<mfrac>"), "got {markup}");
+        assert!(markup.contains("</mfrac>"), "got {markup}");
+    }
+
+    #[test]
+    fn a_square_root_is_an_msqrt_and_a_cube_root_an_mroot() {
+        assert!(mathml(r"\sqrt{x}").contains("<msqrt>"));
+        assert!(mathml(r"\sqrt[3]{x}").contains("<mroot>"));
+    }
+
+    #[test]
+    fn scripts_choose_the_matching_element() {
+        assert!(mathml("x^2").contains("<msup>"));
+        assert!(mathml("x_i").contains("<msub>"));
+        assert!(mathml("x_i^2").contains("<msubsup>"));
+    }
+
+    #[test]
+    fn the_root_declares_the_mathml_namespace() {
+        let markup = mathml("x");
+        assert!(
+            markup.contains("http://www.w3.org/1998/Math/MathML"),
+            "assistive technology keys off the namespace: {markup}"
+        );
+    }
+
+    #[test]
+    fn display_mode_reaches_the_markup() {
+        let item = latex::parse(r"\frac{a}{b}").expect("parses");
+        let block = to_mathml(&item, MathStyle::Display).expect("writes");
+        let inline = to_mathml(&item, MathStyle::Text).expect("writes");
+        assert!(block.contains("display=\"block\""), "got {block}");
+        assert!(inline.contains("display=\"inline\""), "got {inline}");
+    }
+
+    /// A relation like `<` must not corrupt the markup. This is exactly what
+    /// hand-assembled XML gets wrong.
+    #[test]
+    fn markup_special_characters_are_escaped() {
+        let markup = mathml("a<b");
+        assert!(
+            !markup.contains("<mo><</mo>"),
+            "a raw `<` would make the document unparseable: {markup}"
+        );
+        assert!(markup.contains("&lt;"), "expected an escaped `<`: {markup}");
+    }
+}

--- a/components/visual/math/src/scene.rs
+++ b/components/visual/math/src/scene.rs
@@ -1,0 +1,100 @@
+//! Drawing a laid-out formula through the engine-independent `Scene2D`
+//! contract.
+//!
+//! Nothing here knows which engine is underneath. That is the point: the same
+//! commands render on the classic compute pipeline, on the CPU/GPU split engine
+//! that adapters without compute shaders fall to, and on dew's CPU scene.
+
+use alloc::vec::Vec;
+
+use kurbo::{Affine, Rect, Shape};
+use peniko::{Brush, Fill, FontData, StyleRef};
+use waterui_graphics::{Glyph, GlyphRun, Scene2D};
+
+use crate::layout::{MathLayout, Placed};
+
+/// Draws `layout` into `scene`, with its baseline origin at `(x, y)`.
+///
+/// Items are emitted in layout order rather than grouped by kind, because a
+/// rule drawn out of order would paint over a glyph that should sit on top of
+/// it. Consecutive glyphs at the same size are still batched into one run,
+/// which is what keeps a formula from becoming one draw call per character.
+pub fn draw(
+    layout: &MathLayout,
+    scene: &mut dyn Scene2D,
+    font: &FontData,
+    brush: &Brush,
+    x: f32,
+    y: f32,
+) {
+    let origin = Affine::translate((f64::from(x), f64::from(y)));
+    let mut pending: Vec<Glyph> = Vec::new();
+    let mut pending_size = 0.0_f32;
+
+    for item in &layout.items {
+        match item {
+            Placed::Glyph {
+                glyph,
+                x,
+                baseline,
+                size,
+            } => {
+                // A run carries one em size, so a size change ends the run.
+                if !pending.is_empty() && (*size - pending_size).abs() > f32::EPSILON {
+                    flush(scene, font, brush, origin, pending_size, &mut pending);
+                }
+                pending_size = *size;
+                pending.push(Glyph {
+                    id: u32::from(glyph.id.0),
+                    x: *x,
+                    y: *baseline,
+                });
+            }
+            Placed::Outline(outline) => {
+                flush(scene, font, brush, origin, pending_size, &mut pending);
+                scene.fill(Fill::NonZero, origin, brush, None, outline);
+            }
+            Placed::Rule {
+                x,
+                y,
+                width,
+                height,
+            } => {
+                flush(scene, font, brush, origin, pending_size, &mut pending);
+                let rect = Rect::new(
+                    f64::from(*x),
+                    f64::from(*y),
+                    f64::from(*x + *width),
+                    f64::from(*y + *height),
+                );
+                scene.fill(Fill::NonZero, origin, brush, None, &rect.to_path(0.1));
+            }
+        }
+    }
+
+    flush(scene, font, brush, origin, pending_size, &mut pending);
+}
+
+fn flush(
+    scene: &mut dyn Scene2D,
+    font: &FontData,
+    brush: &Brush,
+    transform: Affine,
+    size: f32,
+    glyphs: &mut Vec<Glyph>,
+) {
+    if glyphs.is_empty() {
+        return;
+    }
+    scene.draw_glyph_run(&GlyphRun {
+        font,
+        font_size: size,
+        normalized_coords: &[],
+        transform,
+        brush,
+        brush_alpha: 1.0,
+        style: StyleRef::Fill(Fill::NonZero),
+        glyphs,
+    });
+    glyphs.clear();
+}

--- a/components/visual/math/src/spacing.rs
+++ b/components/visual/math/src/spacing.rs
@@ -178,6 +178,25 @@ mod tests {
         SpacingTable::load().expect("the shipped spacing table must load")
     }
 
+    /// Well under the smallest gap the table can produce (3mu, or 1/6 em), so
+    /// it separates "no gap" from "a gap" without asserting on exact float
+    /// equality.
+    const TOLERANCE: f32 = 1e-6;
+
+    fn assert_no_gap(actual: f32, message: &str) {
+        assert!(
+            actual.abs() < TOLERANCE,
+            "{message}: expected no gap, got {actual}"
+        );
+    }
+
+    fn assert_same_gap(left: f32, right: f32, message: &str) {
+        assert!(
+            (left - right).abs() < TOLERANCE,
+            "{message}: {left} and {right} should be the same gap"
+        );
+    }
+
     /// The shipped table must be well formed; this is the test that turns a
     /// typo in `spacing.toml` into a failure rather than a mis-spaced formula.
     #[test]
@@ -194,7 +213,7 @@ mod tests {
         let binary = table.between(MathClass::Ord, MathClass::Bin, MathStyle::Text);
         let relation = table.between(MathClass::Ord, MathClass::Rel, MathStyle::Text);
 
-        assert_eq!(ordinary, 0.0, "adjacent ordinary atoms must not be spaced");
+        assert_no_gap(ordinary, "adjacent ordinary atoms");
         assert!(
             binary > ordinary,
             "a binary operator must be spaced away from its left operand"
@@ -210,13 +229,13 @@ mod tests {
     #[test]
     fn an_opening_fence_does_not_take_a_gap() {
         let table = table();
-        assert_eq!(
+        assert_no_gap(
             table.between(MathClass::Ord, MathClass::Open, MathStyle::Text),
-            0.0
+            "before an opening fence",
         );
-        assert_eq!(
+        assert_no_gap(
             table.between(MathClass::Open, MathClass::Ord, MathStyle::Text),
-            0.0
+            "after an opening fence",
         );
     }
 
@@ -226,15 +245,13 @@ mod tests {
     fn wide_gaps_vanish_in_script_styles() {
         let table = table();
         for style in [MathStyle::Script, MathStyle::ScriptScript] {
-            assert_eq!(
+            assert_no_gap(
                 table.between(MathClass::Ord, MathClass::Rel, style),
-                0.0,
-                "{style:?} must suppress the relation gap"
+                &alloc::format!("{style:?} must suppress the relation gap"),
             );
-            assert_eq!(
+            assert_no_gap(
                 table.between(MathClass::Ord, MathClass::Bin, style),
-                0.0,
-                "{style:?} must suppress the binary gap"
+                &alloc::format!("{style:?} must suppress the binary gap"),
             );
         }
     }
@@ -246,7 +263,7 @@ mod tests {
         let text = table.between(MathClass::Ord, MathClass::Op, MathStyle::Text);
         let script = table.between(MathClass::Ord, MathClass::Op, MathStyle::Script);
         assert!(text > 0.0);
-        assert_eq!(text, script);
+        assert_same_gap(text, script, "an unsuppressed gap in text and script style");
     }
 
     /// The table is not symmetric, and must not be "tidied" into symmetry:
@@ -256,9 +273,9 @@ mod tests {
     fn the_table_is_deliberately_asymmetric() {
         let table = table();
         assert!(table.between(MathClass::Close, MathClass::Bin, MathStyle::Text) > 0.0);
-        assert_eq!(
+        assert_no_gap(
             table.between(MathClass::Bin, MathClass::Close, MathStyle::Text),
-            0.0
+            "a binary operator before a closing fence",
         );
     }
 }

--- a/components/visual/math/src/spacing.rs
+++ b/components/visual/math/src/spacing.rs
@@ -1,0 +1,264 @@
+//! Inter-atom spacing, read from `spacing.toml`.
+//!
+//! The gap between two adjacent atoms is a function of the class on each side
+//! and the current style. Getting this wrong is not subtle once you look for
+//! it: a layout that concatenates advance widths renders `a+b=c` as one
+//! unbroken run, which is the single most visible way a formula can be wrong
+//! while every glyph in it is correct.
+//!
+//! The table is data, so it lives in TOML. It is parsed once per formula into
+//! a fixed-size array and then indexed, rather than being consulted as text.
+
+use alloc::collections::BTreeMap;
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use serde::Deserialize;
+
+use crate::ast::{MathClass, MathStyle};
+
+/// One math unit as a fraction of an em. TeX's `18mu = 1em`.
+const MU: f32 = 1.0 / 18.0;
+
+/// How many classes the table is square over.
+const CLASS_COUNT: usize = 8;
+
+/// A gap, before the style is taken into account.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Spacing {
+    /// Width in math units.
+    mu: u8,
+    /// Whether script styles drop it.
+    script_suppressed: bool,
+}
+
+impl Spacing {
+    /// The gap in ems at `style`.
+    fn em(self, style: MathStyle) -> f32 {
+        if self.script_suppressed && style.is_cramped_spacing() {
+            0.0
+        } else {
+            f32::from(self.mu) * MU
+        }
+    }
+}
+
+/// Why the shipped spacing table could not be read.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SpacingError {
+    /// The TOML did not parse.
+    #[error("the spacing table is not valid TOML: {message}")]
+    Malformed {
+        /// What the parser objected to.
+        message: String,
+    },
+    /// A row was missing, or the wrong length.
+    #[error("the spacing table is not square over {CLASS_COUNT} classes: {detail}")]
+    NotSquare {
+        /// Which row is wrong and how.
+        detail: String,
+    },
+    /// A cell named an amount the table does not define.
+    #[error("the spacing table row `{row}` has unknown amount `{amount}`")]
+    UnknownAmount {
+        /// The row the bad cell is in.
+        row: String,
+        /// The text that was not recognised.
+        amount: String,
+    },
+}
+
+#[derive(Deserialize)]
+struct RawTable {
+    order: Vec<String>,
+    rows: BTreeMap<String, Vec<String>>,
+}
+
+/// The spacing table, indexed by the classes either side of a gap.
+#[derive(Debug, Clone)]
+pub struct SpacingTable {
+    cells: [[Spacing; CLASS_COUNT]; CLASS_COUNT],
+}
+
+impl SpacingTable {
+    /// Reads the table shipped with this crate.
+    ///
+    /// # Errors
+    ///
+    /// [`SpacingError`] if `spacing.toml` does not parse, is not square over
+    /// the eight classes, or names an amount the table does not define. All
+    /// three are defects in this crate's own data, not in caller input.
+    pub fn load() -> Result<Self, SpacingError> {
+        let raw: RawTable = toml::from_str(include_str!("spacing.toml")).map_err(|error| {
+            SpacingError::Malformed {
+                message: error.to_string(),
+            }
+        })?;
+
+        if raw.order.len() != CLASS_COUNT {
+            return Err(SpacingError::NotSquare {
+                detail: alloc::format!("`order` names {} classes", raw.order.len()),
+            });
+        }
+
+        let mut cells = [[Spacing {
+            mu: 0,
+            script_suppressed: false,
+        }; CLASS_COUNT]; CLASS_COUNT];
+        for (row_index, row_name) in raw.order.iter().enumerate() {
+            let row = raw
+                .rows
+                .get(row_name)
+                .ok_or_else(|| SpacingError::NotSquare {
+                    detail: alloc::format!("no row for class `{row_name}`"),
+                })?;
+            if row.len() != CLASS_COUNT {
+                return Err(SpacingError::NotSquare {
+                    detail: alloc::format!("row `{row_name}` has {} cells", row.len()),
+                });
+            }
+            for (column, cell) in row.iter().enumerate() {
+                cells[row_index][column] = parse_cell(row_name, cell)?;
+            }
+        }
+
+        Ok(Self { cells })
+    }
+
+    /// The gap between an atom of class `left` and one of class `right`, in
+    /// ems, at `style`.
+    #[must_use]
+    pub fn between(&self, left: MathClass, right: MathClass, style: MathStyle) -> f32 {
+        self.cells[class_index(left)][class_index(right)].em(style)
+    }
+}
+
+fn parse_cell(row: &str, cell: &str) -> Result<Spacing, SpacingError> {
+    let (name, script_suppressed) = cell
+        .strip_suffix('*')
+        .map_or((cell, false), |base| (base, true));
+    let mu = match name {
+        "none" => 0,
+        "thin" => 3,
+        "medium" => 4,
+        "thick" => 5,
+        other => {
+            return Err(SpacingError::UnknownAmount {
+                row: String::from(row),
+                amount: String::from(other),
+            });
+        }
+    };
+    Ok(Spacing {
+        mu,
+        script_suppressed,
+    })
+}
+
+/// The table's column order, which `spacing.toml` states explicitly and this
+/// mirrors.
+const fn class_index(class: MathClass) -> usize {
+    match class {
+        MathClass::Ord => 0,
+        MathClass::Op => 1,
+        MathClass::Bin => 2,
+        MathClass::Rel => 3,
+        MathClass::Open => 4,
+        MathClass::Close => 5,
+        MathClass::Punct => 6,
+        MathClass::Inner => 7,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn table() -> SpacingTable {
+        SpacingTable::load().expect("the shipped spacing table must load")
+    }
+
+    /// The shipped table must be well formed; this is the test that turns a
+    /// typo in `spacing.toml` into a failure rather than a mis-spaced formula.
+    #[test]
+    fn the_shipped_table_loads() {
+        let _ = table();
+    }
+
+    /// The reason the table exists: `a+b` and `a=b` are not spaced alike, and
+    /// neither is spaced like `ab`.
+    #[test]
+    fn binary_relation_and_ordinary_gaps_differ() {
+        let table = table();
+        let ordinary = table.between(MathClass::Ord, MathClass::Ord, MathStyle::Text);
+        let binary = table.between(MathClass::Ord, MathClass::Bin, MathStyle::Text);
+        let relation = table.between(MathClass::Ord, MathClass::Rel, MathStyle::Text);
+
+        assert_eq!(ordinary, 0.0, "adjacent ordinary atoms must not be spaced");
+        assert!(
+            binary > ordinary,
+            "a binary operator must be spaced away from its left operand"
+        );
+        assert!(
+            relation > binary,
+            "a relation must be spaced more widely than a binary operator, \
+             got relation={relation} binary={binary}"
+        );
+    }
+
+    /// `f(x)` must close up: nothing is inserted before an opening fence.
+    #[test]
+    fn an_opening_fence_does_not_take_a_gap() {
+        let table = table();
+        assert_eq!(
+            table.between(MathClass::Ord, MathClass::Open, MathStyle::Text),
+            0.0
+        );
+        assert_eq!(
+            table.between(MathClass::Open, MathClass::Ord, MathStyle::Text),
+            0.0
+        );
+    }
+
+    /// Script styles drop the wide gaps, which is why a superscripted sum is
+    /// not set with the gaps its display form has.
+    #[test]
+    fn wide_gaps_vanish_in_script_styles() {
+        let table = table();
+        for style in [MathStyle::Script, MathStyle::ScriptScript] {
+            assert_eq!(
+                table.between(MathClass::Ord, MathClass::Rel, style),
+                0.0,
+                "{style:?} must suppress the relation gap"
+            );
+            assert_eq!(
+                table.between(MathClass::Ord, MathClass::Bin, style),
+                0.0,
+                "{style:?} must suppress the binary gap"
+            );
+        }
+    }
+
+    /// A gap that is not marked suppressed survives into script styles.
+    #[test]
+    fn unsuppressed_gaps_survive_script_styles() {
+        let table = table();
+        let text = table.between(MathClass::Ord, MathClass::Op, MathStyle::Text);
+        let script = table.between(MathClass::Ord, MathClass::Op, MathStyle::Script);
+        assert!(text > 0.0);
+        assert_eq!(text, script);
+    }
+
+    /// The table is not symmetric, and must not be "tidied" into symmetry:
+    /// a closing fence followed by a binary operator is spaced, the reverse
+    /// is not.
+    #[test]
+    fn the_table_is_deliberately_asymmetric() {
+        let table = table();
+        assert!(table.between(MathClass::Close, MathClass::Bin, MathStyle::Text) > 0.0);
+        assert_eq!(
+            table.between(MathClass::Bin, MathClass::Close, MathStyle::Text),
+            0.0
+        );
+    }
+}

--- a/components/visual/math/src/spacing.toml
+++ b/components/visual/math/src/spacing.toml
@@ -1,0 +1,34 @@
+# Inter-atom spacing.
+#
+# The gap between two adjacent atoms is a function of the class on each side.
+# This is what makes `a+b` and `a=b` space differently and `f(x)` close up, and
+# it is the table a layout that merely concatenates advance widths is missing.
+#
+# Source: TeXbook Chapter 18 (the `\mathsurround` spacing table), which MathML
+# Core Ch. 3 reproduces. Amounts are in math units, 18mu = 1em:
+#
+#   none   = 0mu
+#   thin   = 3mu
+#   medium = 4mu
+#   thick  = 5mu
+#
+# A trailing `*` means the gap is suppressed in script and scriptscript styles.
+# That is why a superscripted sum does not acquire the gaps its display form
+# has. A combination TeX marks impossible (a binary operator that cannot be
+# binary in that position) degrades to `none`, which is what TeX itself does
+# after reclassifying the atom.
+#
+# Rows are the class to the LEFT of the gap, columns the class to the RIGHT,
+# both in the order given by `order`.
+
+order = ["ord", "op", "bin", "rel", "open", "close", "punct", "inner"]
+
+[rows]
+ord   = ["none",    "thin",    "medium*", "thick*", "none",    "none",  "none",  "thin*"]
+op    = ["thin",    "thin",    "none",    "thick*", "none",    "none",  "none",  "thin*"]
+bin   = ["medium*", "medium*", "none",    "none",   "medium*", "none",  "none",  "medium*"]
+rel   = ["thick*",  "thick*",  "none",    "none",   "thick*",  "none",  "none",  "thick*"]
+open  = ["none",    "none",    "none",    "none",   "none",    "none",  "none",  "none"]
+close = ["none",    "thin",    "medium*", "thick*", "none",    "none",  "none",  "thin*"]
+punct = ["thin*",   "thin*",   "none",    "thin*",  "thin*",   "thin*", "thin*", "thin*"]
+inner = ["thin*",   "thin",    "medium*", "thick*", "thin*",   "none",  "thin*", "thin*"]

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -1,0 +1,323 @@
+//! The `Math` view.
+
+use alloc::string::String;
+
+use nami::signal::IntoComputed;
+use parley::FontContext;
+use peniko::{Brush, Color as PenikoColor, FontData};
+use waterui_core::{Computed, Environment, Signal, View};
+use waterui_graphics::color::{Color, ForegroundColor, ResolvedColor};
+use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
+use waterui_layout::frame::Frame;
+use waterui_str::Str;
+
+use crate::ast::{MathItem, MathStyle};
+use crate::font::MathFont;
+use crate::layout::Layouter;
+use crate::{latex, mathml, scene};
+
+/// The math family used when the caller names none.
+///
+/// Only a face with an OpenType `MATH` table can set mathematics, so this is
+/// not a stylistic default that something else could stand in for.
+pub const DEFAULT_MATH_FAMILY: &str = "STIX Two Math";
+
+/// Why a formula could not be prepared for drawing.
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum MathError {
+    /// The source did not parse.
+    #[error(transparent)]
+    Latex(#[from] crate::latex::LatexError),
+    /// No installed family by that name carries a `MATH` table.
+    #[error(
+        "no math font available: `{family}` is not installed, or carries no OpenType MATH table"
+    )]
+    NoFont {
+        /// The family that was asked for.
+        family: String,
+    },
+    /// The formula parsed but could not be laid out.
+    #[error(transparent)]
+    Layout(#[from] crate::layout::LayoutError),
+}
+
+/// A rendered mathematical formula.
+///
+/// The source is LaTeX. It is parsed into a semantic tree, laid out against the
+/// OpenType `MATH` table of the chosen family, and drawn through `Scene2D`, so
+/// it renders on every engine the backend may supply.
+#[derive(Debug, Clone)]
+pub struct Math {
+    source: Computed<Str>,
+    style: MathStyle,
+    font_size: f32,
+    family: Str,
+    color: Option<Color>,
+}
+
+impl Math {
+    /// A formula from LaTeX source.
+    ///
+    /// The source takes a signal, so a formula bound to state updates without
+    /// its subtree being rebuilt.
+    #[must_use]
+    pub fn new(source: impl IntoComputed<Str>) -> Self {
+        Self {
+            source: source.into_computed(),
+            style: MathStyle::Text,
+            font_size: 18.0,
+            family: Str::from_static(DEFAULT_MATH_FAMILY),
+            color: None,
+        }
+    }
+
+    /// Sets the formula on its own line, in display style.
+    #[must_use]
+    pub const fn display(mut self) -> Self {
+        self.style = MathStyle::Display;
+        self
+    }
+
+    /// Sets the formula inline, in text style.
+    #[must_use]
+    pub const fn inline(mut self) -> Self {
+        self.style = MathStyle::Text;
+        self
+    }
+
+    /// Sets the em size the formula is set at.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `size` is not finite and positive, which is a caller bug
+    /// rather than bad input.
+    #[must_use]
+    pub fn font_size(mut self, size: f32) -> Self {
+        assert!(
+            size.is_finite() && size > 0.0,
+            "math font size must be finite and positive, got {size}"
+        );
+        self.font_size = size;
+        self
+    }
+
+    /// Sets the math family. It must carry an OpenType `MATH` table.
+    #[must_use]
+    pub fn font_family(mut self, family: impl Into<Str>) -> Self {
+        self.family = family.into();
+        self
+    }
+
+    /// Overrides the colour the formula is drawn in.
+    #[must_use]
+    pub fn color(mut self, color: impl Into<Color>) -> Self {
+        self.color = Some(color.into());
+        self
+    }
+}
+
+/// A formula prepared for drawing: the tree, its `MathML`, and its metrics.
+#[derive(Debug, Clone)]
+pub struct PreparedMath {
+    /// The semantic tree, kept because it is the accessibility representation.
+    pub item: MathItem,
+    /// The tree as `MathML`, for the accessibility payload.
+    pub mathml: String,
+    /// Total advance width in pixels.
+    pub width: f32,
+    /// Height above the baseline.
+    pub ascent: f32,
+    /// Depth below the baseline.
+    pub descent: f32,
+}
+
+impl PreparedMath {
+    /// Total height.
+    #[must_use]
+    pub fn height(&self) -> f32 {
+        self.ascent + self.descent
+    }
+}
+
+/// Parses and measures `source` against `font`.
+///
+/// # Errors
+///
+/// Returns [`MathError`] when the source does not parse or cannot be laid out.
+pub fn prepare(
+    source: &str,
+    font: &FontData,
+    font_size: f32,
+    style: MathStyle,
+) -> Result<PreparedMath, MathError> {
+    let item = latex::parse(source)?;
+    let math_font = MathFont::new(font.data.data(), font.index)
+        .map_err(|error| MathError::Layout(crate::layout::LayoutError::Font(error)))?;
+    let layouter = Layouter::new(&math_font)?;
+    let layout = layouter.layout(&item, font_size, style)?;
+    let mathml = mathml::to_mathml(&item, style).unwrap_or_else(|_| String::new());
+
+    Ok(PreparedMath {
+        item,
+        mathml,
+        width: layout.width,
+        ascent: layout.ascent,
+        descent: layout.descent,
+    })
+}
+
+/// Finds an installed family that can set mathematics.
+///
+/// # Errors
+///
+/// Returns [`MathError::NoFont`] when no installed face by that name carries a
+/// `MATH` table. There is deliberately no substitute: a face without the table
+/// has no layout constants, so drawing with it would not be the same formula
+/// set differently, it would be a formula with no geometry.
+pub fn resolve_font(fonts: &mut FontContext, family: &str) -> Result<FontData, MathError> {
+    let no_font = || MathError::NoFont {
+        family: String::from(family),
+    };
+
+    let info = fonts
+        .collection
+        .family_by_name(family)
+        .ok_or_else(no_font)?;
+    for font in info.fonts() {
+        let Some(blob) = fonts.source_cache.get(font.source()) else {
+            continue;
+        };
+        let data = FontData::new(blob, font.index());
+        if MathFont::new(data.data.data(), data.index).is_ok() {
+            return Ok(data);
+        }
+    }
+    Err(no_font())
+}
+
+/// Scene content that draws one formula.
+struct MathContent {
+    source: Computed<Str>,
+    style: MathStyle,
+    font_size: f32,
+    family: Str,
+    brush: Brush,
+    fonts: Option<FontContext>,
+    font: Option<FontData>,
+    invalidator: Option<SceneInvalidator>,
+}
+
+impl core::fmt::Debug for MathContent {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("MathContent")
+            .field("family", &self.family)
+            .field("font_size", &self.font_size)
+            .field("style", &self.style)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SceneContent for MathContent {
+    fn build_scene(&mut self, scene: &mut dyn Scene2D, width: f32, height: f32) -> bool {
+        if !(width.is_finite() && height.is_finite()) || width <= 0.0 || height <= 0.0 {
+            return false;
+        }
+
+        // The font collection is discovered once and kept for the life of this
+        // surface, which is where per-surface resources belong.
+        if self.font.is_none() {
+            let fonts = self.fonts.get_or_insert_with(FontContext::new);
+            match resolve_font(fonts, self.family.as_str()) {
+                Ok(font) => self.font = Some(font),
+                Err(error) => {
+                    tracing::error!(%error, "math formula has no usable font");
+                    return false;
+                }
+            }
+        }
+        let Some(font) = self.font.clone() else {
+            return false;
+        };
+
+        let source = self.source.get();
+        let prepared = match prepare(source.as_str(), &font, self.font_size, self.style) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                tracing::error!(%error, formula = %source, "could not render math formula");
+                return false;
+            }
+        };
+
+        let math_font = match MathFont::new(font.data.data(), font.index) {
+            Ok(math_font) => math_font,
+            Err(error) => {
+                tracing::error!(%error, "math font became unusable");
+                return false;
+            }
+        };
+        let Ok(layouter) = Layouter::new(&math_font) else {
+            return false;
+        };
+        let Ok(layout) = layouter.layout(&prepared.item, self.font_size, self.style) else {
+            return false;
+        };
+
+        scene::draw(&layout, scene, &font, &self.brush, 0.0, prepared.ascent);
+        false
+    }
+
+    fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
+        self.invalidator = invalidator;
+    }
+}
+
+impl View for Math {
+    fn body(self, env: &Environment) -> impl View {
+        let color = self
+            .color
+            .clone()
+            .map(|color| color.resolve(env))
+            .or_else(|| {
+                env.query::<ForegroundColor, Computed<ResolvedColor>>()
+                    .cloned()
+            });
+
+        let brush = color.map_or_else(
+            || Brush::Solid(PenikoColor::BLACK),
+            |signal| Brush::Solid(to_peniko(&signal.get())),
+        );
+
+        let content = MathContent {
+            source: self.source,
+            style: self.style,
+            font_size: self.font_size,
+            family: self.family,
+            brush,
+            fonts: None,
+            font: None,
+            invalidator: None,
+        };
+
+        Frame::new(SceneView::new(content))
+    }
+}
+
+fn to_peniko(color: &ResolvedColor) -> PenikoColor {
+    let srgb = color.to_srgb();
+    let channel = |value: f32| {
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "clamped to 0..=255 before the cast"
+        )]
+        let byte = (value * 255.0).clamp(0.0, 255.0).round() as u8;
+        byte
+    };
+    PenikoColor::from_rgba8(
+        channel(srgb.red),
+        channel(srgb.green),
+        channel(srgb.blue),
+        channel(color.opacity),
+    )
+}

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -196,7 +196,10 @@ pub fn resolve_font(fonts: &mut FontContext, family: &str) -> Result<FontData, M
 }
 
 /// Scene content that draws one formula.
-struct MathContent {
+///
+/// [`Math`] wraps this, and a backend that wants to draw a formula into a scene
+/// it already owns can use it directly rather than going through a view.
+pub struct MathContent {
     source: Computed<Str>,
     style: MathStyle,
     font_size: f32,
@@ -205,6 +208,32 @@ struct MathContent {
     fonts: Option<FontContext>,
     font: Option<FontData>,
     invalidator: Option<SceneInvalidator>,
+}
+
+impl MathContent {
+    /// Scene content drawing `source` at `font_size` in `style`.
+    ///
+    /// The family must carry an OpenType `MATH` table;
+    /// [`DEFAULT_MATH_FAMILY`] is the one this crate asks for by default.
+    #[must_use]
+    pub fn new(
+        source: impl IntoComputed<Str>,
+        font_size: f32,
+        style: MathStyle,
+        family: impl Into<Str>,
+        brush: Brush,
+    ) -> Self {
+        Self {
+            source: source.into_computed(),
+            style,
+            font_size,
+            family: family.into(),
+            brush,
+            fonts: None,
+            font: None,
+            invalidator: None,
+        }
+    }
 }
 
 impl core::fmt::Debug for MathContent {
@@ -288,16 +317,7 @@ impl View for Math {
             |signal| Brush::Solid(to_peniko(&signal.get())),
         );
 
-        let content = MathContent {
-            source: self.source,
-            style: self.style,
-            font_size: self.font_size,
-            family: self.family,
-            brush,
-            fonts: None,
-            font: None,
-            invalidator: None,
-        };
+        let content = MathContent::new(self.source, self.font_size, self.style, self.family, brush);
 
         Frame::new(SceneView::new(content))
     }

--- a/components/visual/math/tests/gallery.rs
+++ b/components/visual/math/tests/gallery.rs
@@ -1,0 +1,120 @@
+//! Renders a gallery of formulas for visual review.
+//!
+//! These are not pass/fail assertions about appearance — the two engines
+//! rasterize differently, and no threshold on pixels can tell you whether a
+//! fraction bar is in the right place. The PNGs are written out to be *looked
+//! at*, by a person or by an agent with vision.
+//!
+//! Rendering every formula through both scene engines is the part that is
+//! asserted: a formula that draws on the classic compute pipeline but not on
+//! the CPU/GPU split engine would be broken on the iOS Simulator and on every
+//! adapter without indirect execution, and that is exactly the failure this
+//! crate's `Scene2D` output exists to avoid.
+//!
+//! ```text
+//! WATERUI_MATH_GALLERY_DIR=/tmp/waterui_math_gallery \
+//!   cargo test -p waterui-math --test gallery -- --nocapture
+//! ```
+
+use std::path::{Path, PathBuf};
+
+use peniko::{Brush, Color};
+use waterui_graphics::shared_context::SceneEngine;
+use waterui_graphics::{GpuRuntime, OffscreenRenderConfig, OffscreenSize, SceneView};
+use waterui_math::ast::MathStyle;
+use waterui_math::view::{DEFAULT_MATH_FAMILY, MathContent};
+
+/// Formulas chosen to exercise each construct the layout engine implements,
+/// and the ones an earlier attempt got visibly wrong.
+const GALLERY: &[(&str, &str)] = &[
+    // Spacing: the gaps around `+` and `=` must differ, and differ from none.
+    ("spacing", r"a+b=c"),
+    // Fractions, including a nested one that must shrink.
+    ("fraction", r"\frac{a+b}{c}"),
+    ("fraction_nested", r"\frac{1}{1+\frac{1}{1+x}}"),
+    // Scripts, including one on a slanted base where italic correction shows.
+    ("scripts", r"x^2 + y_i - z_n^2"),
+    ("scripts_nested", r"e^{x^{2}}"),
+    // Radicals: a plain one, one over a fraction (the tall case), and an index.
+    ("radical", r"\sqrt{x}"),
+    ("radical_tall", r"\sqrt{\frac{a+b}{c+d}}"),
+    ("radical_index", r"\sqrt[3]{x}"),
+    // Stretchy fences around something tall.
+    ("fences", r"\left(\frac{a}{b}\right)"),
+    // Greek, including letters an earlier hand-written table was missing.
+    ("greek", r"\alpha\beta\psi\eta\tau\xi\zeta"),
+    // Upright function names next to italic variables.
+    ("functions", r"\sin x + \log y"),
+    // Literal text keeps its spaces and stays upright.
+    ("text", r"\text{if } x > 0"),
+    // Large operators with limits.
+    ("sum", r"\sum_{i=1}^{n} i"),
+    // A formula combining most of the above.
+    ("quadratic", r"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}"),
+];
+
+fn output_directory() -> PathBuf {
+    std::env::var("WATERUI_MATH_GALLERY_DIR").map_or_else(
+        |_| PathBuf::from("/tmp/waterui_math_gallery"),
+        PathBuf::from,
+    )
+}
+
+#[test]
+fn renders_the_formula_gallery_on_both_scene_engines() {
+    let directory = output_directory();
+    std::fs::create_dir_all(&directory).expect("gallery directory must be creatable");
+
+    let runtime = pollster::block_on(GpuRuntime::new())
+        .expect("the formula gallery requires a working GPU runtime");
+    let size = OffscreenSize::try_from_pixels(560, 200).expect("gallery size must be valid");
+
+    let mut written = Vec::new();
+    for (name, source) in GALLERY {
+        for (engine, engine_name) in [
+            (SceneEngine::Classic, "classic"),
+            (SceneEngine::Hybrid, "hybrid"),
+        ] {
+            let content = MathContent::new(
+                waterui_str::Str::from(*source),
+                48.0,
+                MathStyle::Display,
+                DEFAULT_MATH_FAMILY,
+                Brush::Solid(Color::BLACK),
+            );
+            let surface = SceneView::new(content).into_gpu_surface();
+            let config = OffscreenRenderConfig::new(size)
+                .format(wgpu::TextureFormat::Rgba8Unorm)
+                .scene_engine(engine);
+            let mut env = waterui_core::Environment::new();
+            let output = pollster::block_on(surface.render_offscreen(&runtime, config, &mut env))
+                .unwrap_or_else(|error| {
+                    panic!("`{source}` must render on the {engine_name} engine: {error}")
+                });
+
+            let path = directory.join(format!("{name}_{engine_name}.png"));
+            output
+                .save_png(&path)
+                .expect("gallery PNG must be writable");
+            written.push(path);
+        }
+    }
+
+    write_index(&directory);
+    println!(
+        "wrote {} formula renderings to {}",
+        written.len(),
+        directory.display()
+    );
+}
+
+/// A companion index so whoever reviews the images knows what each one is
+/// supposed to be.
+fn write_index(directory: &Path) {
+    let mut lines = Vec::with_capacity(GALLERY.len());
+    for (name, source) in GALLERY {
+        lines.push(format!("{name}: {source}"));
+    }
+    std::fs::write(directory.join("index.txt"), lines.join("\n"))
+        .expect("gallery index must be writable");
+}

--- a/components/visual/math/tests/gallery.rs
+++ b/components/visual/math/tests/gallery.rs
@@ -18,11 +18,42 @@
 
 use std::path::{Path, PathBuf};
 
-use peniko::{Brush, Color};
+use kurbo::{Affine, Rect, Shape};
+use peniko::{Brush, Color, Fill};
 use waterui_graphics::shared_context::SceneEngine;
-use waterui_graphics::{GpuRuntime, OffscreenRenderConfig, OffscreenSize, SceneView};
+use waterui_graphics::{
+    GpuRuntime, OffscreenRenderConfig, OffscreenSize, Scene2D, SceneContent, SceneInvalidator,
+    SceneView,
+};
 use waterui_math::ast::MathStyle;
 use waterui_math::view::{DEFAULT_MATH_FAMILY, MathContent};
+
+/// Paints an opaque ground under the formula.
+///
+/// The renderer leaves the canvas transparent, and a transparent PNG of black
+/// glyphs is invisible in half the viewers someone might open it in. A review
+/// image nobody can see is not a review image.
+struct OnWhite {
+    formula: MathContent,
+}
+
+impl SceneContent for OnWhite {
+    fn build_scene(&mut self, scene: &mut dyn Scene2D, width: f32, height: f32) -> bool {
+        let ground = Rect::new(0.0, 0.0, f64::from(width), f64::from(height));
+        scene.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            &Brush::Solid(Color::WHITE),
+            None,
+            &ground.to_path(0.1),
+        );
+        self.formula.build_scene(scene, width, height)
+    }
+
+    fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
+        self.formula.set_invalidator(invalidator);
+    }
+}
 
 /// Formulas chosen to exercise each construct the layout engine implements,
 /// and the ones an earlier attempt got visibly wrong.
@@ -82,7 +113,7 @@ fn renders_the_formula_gallery_on_both_scene_engines() {
                 DEFAULT_MATH_FAMILY,
                 Brush::Solid(Color::BLACK),
             );
-            let surface = SceneView::new(content).into_gpu_surface();
+            let surface = SceneView::new(OnWhite { formula: content }).into_gpu_surface();
             let config = OffscreenRenderConfig::new(size)
                 .format(wgpu::TextureFormat::Rgba8Unorm)
                 .scene_engine(engine);


### PR DESCRIPTION
Adds `components/visual/math` — `waterui-math`. Fixes #213.

A formula is parsed into a semantic tree, laid out against the chosen face's
OpenType `MATH` table, and drawn through `Scene2D`. There is no GPU dependency
and no engine coupling, so it renders on the classic compute pipeline, on the
CPU/GPU split engine that adapters without compute shaders fall to, and on dew's
CPU scene.

## The two things that make it correct

**Paired constants are resolved by style when they are read.** Several `MATH`
constants come in a display and a non-display flavour, and picking the wrong one
is invisible until someone compares a display fraction against a reference.
`MathFont::constants(size, style)` chooses once, so layout code cannot reach for
the wrong member.

**Growing a glyph is one general facility.** Radicals, parentheses, braces,
brackets and bars all stretch through `MathVariants` — designed variants first,
then a multi-part assembly when none is large enough. Nothing measures a glyph
outline to discover where its parts are.

## Layout

Rows insert the gaps TeX's inter-atom table calls for, which is what makes `a+b`
and `a=b` differ and `f(x)` close up. The table is data, in `src/spacing.toml`,
parsed once per formula into a fixed-size array.

Fractions, scripts, radicals and fences take their positions from `MATH`
constants and their minimums from the named `*GapMin`s. Italic correction keeps
a superscript clear of a slanted base's overhang.

## Accessibility

The semantic tree is kept after layout rather than consumed by it, and
`mathml::to_mathml` publishes it. A formula drawn as anonymous filled paths has
no content at all to a screen reader. The markup goes through an XML writer, so
`a<b` escapes rather than corrupting the document.

## Dependencies

`ttf-parser`, `pulldown-latex`, `quick-xml`. `ttf-parser` is the only crate in
the Rust ecosystem that exposes the `MATH` table: `read-fonts`, `skrifa`,
`harfrust`, `rustybuzz` and `swash` all lack it, and googlefonts/fontations#1269
has been open since 2024-11. It was already in the tree transitively via
`rustybuzz`.

## Verification

`cargo test -p waterui-math --lib` — 32 passed.
`cargo clippy -p waterui-math --all-targets` — clean.
Formatted with `rustfmt --edition 2024` per file.

Several tests pin behaviour the earlier unmerged attempt on `rescue/waterui-math`
got wrong: `\text{if }` keeps its trailing space; `a+b=c` is spaced at three
different widths end to end from source to table; the Greek letters missing from
a hand-written symbol table parse; `\sqrt[3]{x}` keeps its index; an unsupported
construct is refused by name rather than silently dropped; malformed input is an
`Err`, never a panic in `View::body`.

## Not in this PR

- **Rendered output has not been visually verified yet.** The numeric assertions
  above are the half CI can hold. A formula gallery exporting PNGs for review is
  the next piece.
- Matrices, `cases`, multi-line environments, negation and font/style changes
  (`\mathbf`, `\mathbb`) are reported as errors naming the construct.
- MathCAT speech generation. MathML is published, which is the representation
  assistive technology reads; turning it into a spoken string wants the `mathcat`
  crate, whose runtime rules-directory footprint I have not measured, so it
  should be its own change rather than a dependency added on spec.
- The `Math` view builds a `parley::FontContext` per view to resolve the math
  family. That is one system-font enumeration per formula, which wants a shared
  font service in the framework rather than a workaround here.

Depends on #212 for the font to actually be present (PR #220).
