### PR TITLE
fix(hydrolysis): choose the scene engine from the adapter

### DIFF
--- a/backends/hydrolysis/src/gpu_view.rs
+++ b/backends/hydrolysis/src/gpu_view.rs
@@ -48,7 +48,7 @@ where
 {
     async fn setup(&mut self, ctx: &GpuContext<'_>, env: &mut Environment) {
         let scoped_env = env.extending(SceneViewMergeToParent);
-        let mut renderer = HydrolysisRenderer::new(ctx.device);
+        let mut renderer = HydrolysisRenderer::new(ctx.adapter, ctx.device);
         renderer.set_host_redraw_handle(ctx.redraw_handle.clone());
         renderer.prepare_window_tree(AnyView::new(self.view.clone()), &scoped_env);
         renderer.setup_embedded_gpu_surfaces(ctx).await;

--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -149,7 +149,8 @@ use waterui_graphics::view_effect::{
 };
 use waterui_graphics::{
     AppliedFilter, GpuContext, GpuFrame, GpuSurface, GradientType, PointerState, RedrawHandle,
-    ResolvedGradient, ResolvedGradientStop, SceneView, VelloScene2D,
+    ResolvedGradient, ResolvedGradientStop, SceneEngine, SceneView, SharedSceneRenderer,
+    VelloScene2D,
 };
 
 use waterui_icon::SystemIcon;
@@ -232,7 +233,7 @@ pub struct HydrolysisRenderer {
     shader_cache: Arc<WgslModuleCache>,
     /// The scene renderer embedded GPU surfaces share, for the same reason: its
     /// pipelines belong to the device rather than to any one scene.
-    scene_renderer: Arc<waterui_graphics::SharedSceneRenderer>,
+    scene_renderer: Arc<SharedSceneRenderer>,
     lifecycle: LifecycleState,
     animation_controller: AnimationController,
     frame_instant: Instant,
@@ -308,9 +309,16 @@ impl HydrolysisRenderer {
         core::mem::take(&mut self.subview_structural_change)
     }
 
+    /// A renderer for `device`, which `adapter` produced.
+    ///
+    /// The adapter is not a formality: the scene renderer that embedded GPU
+    /// surfaces share is built for the engine `adapter` can actually run, and
+    /// an adapter without indirect execution aborts inside wgpu rather than
+    /// degrading when asked to run the classic compute pipeline.
     #[must_use]
-    pub fn new(device: &wgpu::Device) -> Self {
+    pub fn new(adapter: &wgpu::Adapter, device: &wgpu::Device) -> Self {
         Self::new_with_options(
+            adapter,
             device,
             vello::RendererOptions {
                 use_cpu: false,
@@ -324,8 +332,13 @@ impl HydrolysisRenderer {
         )
     }
 
+    /// As [`Self::new`], with the window renderer's Vello options spelled out.
     #[must_use]
-    pub fn new_with_options(device: &wgpu::Device, options: vello::RendererOptions) -> Self {
+    pub fn new_with_options(
+        adapter: &wgpu::Adapter,
+        device: &wgpu::Device,
+        options: vello::RendererOptions,
+    ) -> Self {
         let vello_renderer =
             vello::Renderer::new(device, options).expect("failed to create hydrolysis renderer");
         let frame_instant = Instant::now();
@@ -346,7 +359,7 @@ impl HydrolysisRenderer {
             signals: FrameSignals::new(frame_instant),
             host_redraw_handle: None,
             shader_cache: Arc::new(WgslModuleCache::new()),
-            scene_renderer: Arc::default(),
+            scene_renderer: Arc::new(SharedSceneRenderer::new(SceneEngine::for_adapter(adapter))),
             lifecycle: LifecycleState::default(),
             animation_controller: AnimationController::default(),
             frame_instant,

--- a/backends/hydrolysis/src/renderer/tests/mod.rs
+++ b/backends/hydrolysis/src/renderer/tests/mod.rs
@@ -52,7 +52,7 @@ fn test_renderer() -> HydrolysisRenderer {
     let mut platform =
         crate::platform::OffscreenWindow::new_for_tests(160, 160, wgpu::TextureFormat::Rgba8Unorm);
     let surface = platform.surface();
-    let mut renderer = HydrolysisRenderer::new(surface.device());
+    let mut renderer = HydrolysisRenderer::new(surface.adapter(), surface.device());
     renderer.set_frame_resources(surface.adapter(), surface.device(), surface.queue());
     renderer
 }
@@ -785,7 +785,7 @@ fn renderer_magnification_targets_outer_observer_in_stacked_gesture_chain() {
         crate::platform::OffscreenWindow::new_for_tests(160, 160, wgpu::TextureFormat::Rgba8Unorm);
     let mut renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     let env = test_environment();
     let bounds = vello::kurbo::Rect::new(0.0, 0.0, 160.0, 160.0);

--- a/backends/hydrolysis/src/runner/headless.rs
+++ b/backends/hydrolysis/src/runner/headless.rs
@@ -403,7 +403,7 @@ impl HeadlessRuntime {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         install_fonts(&mut renderer);
 
@@ -442,7 +442,7 @@ impl HeadlessRuntime {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         (self.install_fonts)(&mut renderer);
         RuntimeWindow::new(

--- a/backends/hydrolysis/src/runner/mod.rs
+++ b/backends/hydrolysis/src/runner/mod.rs
@@ -189,7 +189,7 @@ pub fn run(app: App) {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         load_native_resource_fonts(&mut renderer);
         let mut runtime = RuntimeWindow::new(window, platform, renderer, render_diagnostics_config);

--- a/backends/hydrolysis/src/runner/tests.rs
+++ b/backends/hydrolysis/src/runner/tests.rs
@@ -329,7 +329,7 @@ fn runtime_window_sized(
     platform.apply_properties(&window);
     let renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     RuntimeWindow::new(
         window,
@@ -434,7 +434,7 @@ fn test_runtime_window() -> RuntimeWindow<HeadlessPlatformWindow> {
     platform.apply_properties(&window);
     let renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     RuntimeWindow::new(
         window,

--- a/backends/hydrolysis/src/runner/web_runner.rs
+++ b/backends/hydrolysis/src/runner/web_runner.rs
@@ -288,7 +288,7 @@ pub fn run(app: App, inspector: Option<waterui::inspector::InspectorRuntime>) {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         load_web_fonts(&mut renderer).await;
         let runtime = RuntimeWindow::new(window, platform, renderer, render_diagnostics_config);

--- a/backends/hydrolysis/src/runner/winit_runner.rs
+++ b/backends/hydrolysis/src/runner/winit_runner.rs
@@ -430,7 +430,7 @@ impl WinitRunner {
         platform.apply_properties(&window);
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         super::load_native_resource_fonts(&mut renderer);
         let mut runtime =

--- a/backends/hydrolysis/src/view_renderer.rs
+++ b/backends/hydrolysis/src/view_renderer.rs
@@ -78,7 +78,7 @@ impl CustomViewRenderer for HydrolysisViewRenderer {
             let rgba_data = {
                 let device = surface.device();
                 let queue = surface.queue();
-                let mut renderer = HydrolysisRenderer::new(device);
+                let mut renderer = HydrolysisRenderer::new(surface.adapter(), device);
                 renderer.set_frame_resources(surface.adapter(), device, queue);
                 renderer.reset_scene();
                 renderer.begin_rebuild_frame();

--- a/components/visual/graphics/src/gpu/shared_context.rs
+++ b/components/visual/graphics/src/gpu/shared_context.rs
@@ -138,12 +138,6 @@ pub struct HybridRenderer {
     pub resources: vello_hybrid::Resources,
 }
 
-impl Default for SharedSceneRenderer {
-    fn default() -> Self {
-        Self::new(SceneEngine::Classic)
-    }
-}
-
 impl fmt::Debug for SharedSceneRenderer {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter

--- a/testing/src/snapshot.rs
+++ b/testing/src/snapshot.rs
@@ -77,7 +77,7 @@ impl TestHost {
         );
         let mut renderer = {
             let surface = platform.surface();
-            HydrolysisRenderer::new(surface.device())
+            HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
         let bounds = vello::kurbo::Rect::new(
             0.0,

--- a/testing/src/tests.rs
+++ b/testing/src/tests.rs
@@ -559,7 +559,7 @@ fn smoke_scene_view_snapshot_runs_build_scene_and_returns_buffer() {
     );
     let mut renderer = {
         let surface = platform.surface();
-        HydrolysisRenderer::new(surface.device())
+        HydrolysisRenderer::new(surface.adapter(), surface.device())
     };
     let bounds = vello::kurbo::Rect::new(0.0, 0.0, 96.0, 72.0);
     let env = Environment::new().extending(SceneViewMergeToParent);


### PR DESCRIPTION
## Choose the scene engine from the adapter (#211)

Hydrolysis built the scene renderer its embedded GPU surfaces share with
`Arc::default()` (`backends/hydrolysis/src/renderer.rs:349`), and
`SharedSceneRenderer::default()` was hardcoded to `SceneEngine::Classic`
(`components/visual/graphics/src/gpu/shared_context.rs:141-145`). On an adapter
missing `INDIRECT_EXECUTION` + `SHADER_F16_IN_F32` — the iOS Simulator's Metal,
the Android emulator's SwiftShader Vulkan — that builds a classic compute
pipeline the device aborts on inside wgpu, which is precisely what
`SceneEngine::for_adapter` exists to prevent. GTK already consulted it
(`backends/gtk/src/components/graphics/gpu_surface.rs:146`).

`HydrolysisRenderer::new` / `new_with_options` now take the adapter alongside
the device and build `SharedSceneRenderer::new(SceneEngine::for_adapter(adapter))`.
Every construction site already had an adapter in hand: the runners, the
offscreen view renderer and the crate's tests through `PlatformSurface::adapter()`,
the hosted `GpuView` through `GpuContext::adapter`.

The `Default` impl of `SharedSceneRenderer` is removed rather than fixed. It
silently assumed Classic, which is what made this reachable at all, and the two
real call sites disagreeing about the engine is the argument for making every
construction site state it. There is no compatibility shim.

A Hydrolysis window on a hybrid-only adapter now reaches
`HybridScene2D::draw_image`; #196 has since landed on `dev`, so that call is no
longer `unimplemented!` once this branch is rebased.

## Keep materialized views out of the address-keyed measure cache (#238)

The first push was red on `Test / macos-latest`, on
`hydrolysis-m3::e2e_semantics material_list_exposes_list_item_semantics_and_actions`,
3/3 retries. The defect is **pre-existing and unrelated to the change above**;
it is fixed here because the macOS leg cannot go green without it.

Hydrolysis memoizes intrinsic measurements under `AnyView::stable_ptr` — the
boxed view's heap address — and clears the map once per frame, which its comment
claims is what keeps the key sound. It is not: a measurement that materializes
the view it is about to size (a list row pulled from its collection, a control's
label re-erased into an `AnyView`, a tab's content, a navigation view built for
a size) drops it as soon as it has the answer, and the allocator hands that
address to the next one *within the same frame*, which reads the previous view's
size back as its own.

That is exactly what the macOS failure was: the list answered the window's
minimum-height probe with 144 and its maximum-height probe with 112 — two 72dp
rows against two 56dp rows — although `measure_list_node` ignores the proposal
and cannot depend on it.

```
hydrolysis window layout reported maximum Size { width: 3.4028235e38, height: 160.0 }
below minimum Size { width: 267.32, height: 192.0 }.
Offending nodes (deepest first):
    Widget height: minimum 144 exceeds maximum 112
```

Measurements that build their own subject now run in a transient scope where the
cache is neither read nor written. The scope covers the subtree, because a view
materialized there owns its children and their addresses die with it; views the
retained tree owns keep their memoization, their addresses being theirs for the
whole frame.

## Verification

Reproduced and fixed by hammering the test binary directly on this Apple Silicon
host:

- before: 3 failures in 80 runs (and 1 in 60 on an earlier pass), same numbers as CI
- cache reads disabled (diagnostic only): 0 in 150
- with the transient scope: **0 in 200**, and 0 in 25 runs of the whole
  `e2e_semantics` binary

Suites, all on `cargo +stable`:

- `check -p hydrolysis -p waterui-graphics -p hydrolysis-m3` — clean
- `check --workspace --all-targets` (before the disk limit) — clean, which is how
  every `SharedSceneRenderer` caller was found
- `clippy -p hydrolysis -p waterui-graphics --all-targets -- -D warnings` — clean
- `nextest run -p waterui-graphics` — 38 passed
- `nextest run -p hydrolysis-m3` — 191 passed
- `nextest run -p hydrolysis -E 'test(renderer::tests) + test(runner::tests)'` —
  127 passed, in 6.35s against 9.94s before the change, so nothing that
  legitimately hit the measurement cache lost it
- `nextest run -p waterui-testing` — 40 passed

Fixes #211
Fixes #238
