### PR TITLE
feat(mermaid): draw Mermaid diagrams through Scene2D

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1296,6 +1296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytemuck"
 version = "1.25.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2361,6 +2367,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "cssparser"
+version = "0.36.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dae61cf9c0abb83bd659dab65b7e4e38d8236824c85f0f804f173567bda257d2"
+dependencies = [
+ "cssparser-macros",
+ "dtoa-short",
+ "itoa",
+ "phf",
+ "smallvec",
+]
+
+[[package]]
+name = "cssparser-macros"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
+dependencies = [
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "csv"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2895,10 +2924,47 @@ dependencies = [
 ]
 
 [[package]]
+name = "dtoa"
+version = "1.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c3cf4824e2d5f025c7b531afcb2325364084a16806f6d47fbc1f5fbd9960590"
+
+[[package]]
+name = "dtoa-short"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd1511a7b6a56299bd043a9c167a6d2bfb37bf84a6dfceaba651168adfb43c87"
+dependencies = [
+ "dtoa",
+]
+
+[[package]]
 name = "dtor"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edf234dd1594d6dd434a8fb8cada51ddbbc593e40e4a01556a0b31c62da2775b"
+
+[[package]]
+name = "dugong"
+version = "0.8.0-alpha.6"
+source = "git+https://github.com/water-rs/merman?rev=a6f41d47b497c05844003a0e765a3cf78df6678d#a6f41d47b497c05844003a0e765a3cf78df6678d"
+dependencies = [
+ "dugong-graphlib",
+ "rustc-hash 2.1.3",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "dugong-graphlib"
+version = "0.8.0-alpha.6"
+source = "git+https://github.com/water-rs/merman?rev=a6f41d47b497c05844003a0e765a3cf78df6678d#a6f41d47b497c05844003a0e765a3cf78df6678d"
+dependencies = [
+ "hashbrown 0.17.1",
+ "rustc-hash 2.1.3",
+ "serde",
+ "serde_json",
+]
 
 [[package]]
 name = "dunce"
@@ -4467,6 +4533,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "granit-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c60388b03522b86e24b6b45952255279936b08a871775156fc89c94e792d21d8"
+dependencies = [
+ "arraydeque",
+ "smallvec",
+]
+
+[[package]]
 name = "graphene-rs"
 version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4657,6 +4733,8 @@ version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash 0.2.0",
 ]
 
@@ -4724,6 +4802,19 @@ name = "hover-example"
 version = "0.1.0"
 dependencies = [
  "waterui",
+]
+
+[[package]]
+name = "htmlize"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e815d50d9e411ba2690d730e6ec139c08260dddb756df315dbd16d01a587226"
+dependencies = [
+ "memchr",
+ "pastey 0.1.1",
+ "phf",
+ "phf_codegen",
+ "serde_json",
 ]
 
 [[package]]
@@ -5873,6 +5964,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "json5"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "733a844dbd6fef128e98cb4487b887cb55454d92cd9994b1bafe004fabbe670c"
+dependencies = [
+ "serde",
+ "ucd-trie",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6000,7 +6101,7 @@ dependencies = [
  "bit-set 0.8.0",
  "ena",
  "itertools 0.14.0",
- "lalrpop-util",
+ "lalrpop-util 0.22.2",
  "petgraph",
  "regex",
  "regex-syntax",
@@ -6020,6 +6121,12 @@ dependencies = [
  "regex-automata",
  "rustversion",
 ]
+
+[[package]]
+name = "lalrpop-util"
+version = "0.23.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884f3e747ed2dcee867cda1b0c31a048f9e20de2d916a248949319921a2e666e"
 
 [[package]]
 name = "lazy_static"
@@ -6340,6 +6447,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lol_html"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5adbb62638edf7e6bc88835cd3ea388bdd53382af42045da0e414ea78aa0c91a"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if 1.0.4",
+ "cssparser",
+ "encoding_rs",
+ "foldhash 0.2.0",
+ "hashbrown 0.17.1",
+ "memchr",
+ "mime",
+ "precomputed-hash",
+ "selectors",
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "lru"
 version = "0.16.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6589,6 +6715,57 @@ name = "menu-example"
 version = "0.1.0"
 dependencies = [
  "waterui",
+]
+
+[[package]]
+name = "merman-core"
+version = "0.8.0-alpha.6"
+source = "git+https://github.com/water-rs/merman?rev=a6f41d47b497c05844003a0e765a3cf78df6678d#a6f41d47b497c05844003a0e765a3cf78df6678d"
+dependencies = [
+ "euclid",
+ "granit-parser",
+ "htmlize",
+ "indexmap 2.14.0",
+ "json5",
+ "lalrpop-util 0.23.1",
+ "lol_html",
+ "rustc-hash 2.1.3",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.20",
+ "unicode-general-category",
+ "unicode-segmentation",
+ "unicode-width",
+ "url",
+]
+
+[[package]]
+name = "merman-render"
+version = "0.8.0-alpha.6"
+source = "git+https://github.com/water-rs/merman?rev=a6f41d47b497c05844003a0e765a3cf78df6678d#a6f41d47b497c05844003a0e765a3cf78df6678d"
+dependencies = [
+ "base64 0.22.1",
+ "cssparser",
+ "data-url",
+ "dugong",
+ "indexmap 2.14.0",
+ "kurbo 0.13.1",
+ "libm",
+ "merman-core",
+ "pulldown-cmark",
+ "quick-xml",
+ "roughr-merman",
+ "roxmltree 0.21.1",
+ "rustc-hash 2.1.3",
+ "ryu-js",
+ "serde",
+ "serde_json",
+ "svgtypes",
+ "thiserror 2.0.20",
+ "unicode-linebreak",
+ "unicode-segmentation",
+ "unicode-width",
 ]
 
 [[package]]
@@ -8074,6 +8251,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 
 [[package]]
+name = "palette"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddeed8580d347d2abf3dcf06a5f0b3dc020258338526b277847cd4248a70fc64"
+dependencies = [
+ "approx",
+ "palette_derive",
+ "palette_math",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88537020289b719d81be994ccf1bbf4990f477e2f69ee52fe3e45f43a02e56be"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "palette_math"
+version = "0.7.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e6eb142958d64335fb0e345c5b9ead2ecd6fc438c307e9d7d3c4fd428dbaf12"
+
+[[package]]
 name = "pango"
 version = "0.22.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8274,6 +8480,16 @@ dependencies = [
  "phf_macros",
  "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
+dependencies = [
+ "phf_generator",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -9145,6 +9361,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "roughr-merman"
+version = "0.12.3"
+source = "git+https://github.com/water-rs/merman?rev=a6f41d47b497c05844003a0e765a3cf78df6678d#a6f41d47b497c05844003a0e765a3cf78df6678d"
+dependencies = [
+ "euclid",
+ "num-traits",
+ "palette",
+ "svgtypes",
+]
+
+[[package]]
 name = "roxmltree"
 version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9362,6 +9589,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
+name = "ryu-js"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04d056b875a9d2e6cb9a61d127afee9ac5999b9f87bcb32079d1318e505be714"
+
+[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9481,6 +9714,25 @@ checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "selectors"
+version = "0.37.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2cfaaa6035167f0e604e42723c7650d59ee269ef220d7bbe0565602c8a0173b9"
+dependencies = [
+ "bitflags 2.13.1",
+ "cssparser",
+ "derive_more",
+ "log",
+ "new_debug_unreachable",
+ "phf",
+ "phf_codegen",
+ "precomputed-hash",
+ "rustc-hash 2.1.3",
+ "servo_arc",
+ "smallvec",
 ]
 
 [[package]]
@@ -9630,6 +9882,15 @@ dependencies = [
  "scopeguard",
  "unescaper",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "servo_arc"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "170fb83ab34de17dc69aa7c67482b22218ddb85da56546f9bd6b929e32a05930"
+dependencies = [
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -11192,6 +11453,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "uds_windows"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11267,10 +11534,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-linebreak"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
 
 [[package]]
 name = "unicode-properties"
@@ -12930,6 +13209,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "waterui-mermaid"
+version = "0.1.0"
+dependencies = [
+ "hydrolysis-m3",
+ "merman-core",
+ "merman-render",
+ "nami",
+ "parley",
+ "serde_json",
+ "thiserror 2.0.20",
+ "waterui",
+ "waterui-canvas",
+ "waterui-core",
+ "waterui-graphics",
+ "waterui-layout",
+ "waterui-str",
+ "waterui-testing",
+ "waterui-text",
+]
+
+[[package]]
 name = "waterui-navigation"
 version = "0.3.0"
 dependencies = [
@@ -13595,7 +13895,7 @@ dependencies = [
  "derive_more",
  "itertools 0.14.0",
  "lalrpop",
- "lalrpop-util",
+ "lalrpop-util 0.22.2",
  "lexical",
  "logos",
  "thiserror 2.0.20",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -128,6 +128,15 @@ waterui-form = { version = "0.3.0", path = "components/foundation/form" }
 waterui-controls = { version = "0.3.0", path = "components/foundation/controls"}
 waterui-graphics = { version = "0.3.0", path = "components/visual/graphics", default-features = false }
 waterui-canvas = { version = "0.1.0", path = "components/visual/canvas" }
+waterui-mermaid = { version = "0.1.0", path = "components/data/mermaid" }
+# Mermaid parsing, semantic model and diagram layout. Consumed from our fork
+# while `typed-layout-projection` is unreleased upstream: `merman-render`'s only
+# public exit from the layout stage is `layout_json`, whose `#[serde(skip)]`
+# fields drop geometry a self-drawing host needs — a sequence diagram's
+# loop/alt fragment boxes among them. The branch makes the typed projection
+# public and changes nothing else. See water-rs/waterui#217.
+merman-core = { git = "https://github.com/water-rs/merman", rev = "a6f41d47b497c05844003a0e765a3cf78df6678d" }
+merman-render = { git = "https://github.com/water-rs/merman", rev = "a6f41d47b497c05844003a0e765a3cf78df6678d", default-features = false }
 waterui-shape = { version = "0.1.0", path = "components/foundation/shape", default-features = false }
 waterui-svg = { version = "0.1.0", path = "components/visual/svg" }
 waterui-ffi = { version = "0.3.0", path = "ffi" }

--- a/components/codes/barcode/src/lib.rs
+++ b/components/codes/barcode/src/lib.rs
@@ -21,6 +21,12 @@
 //! // Create a Code128 barcode view
 //! Barcode::code128("HELLO-WATERUI")
 //! ```
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 mod effect;
 mod qr;

--- a/components/data/mermaid/Cargo.toml
+++ b/components/data/mermaid/Cargo.toml
@@ -1,0 +1,44 @@
+[package]
+name = "waterui-mermaid"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+readme = "../../../README.md"
+repository.workspace = true
+description = "Mermaid diagram component for WaterUI, drawn through Scene2D"
+keywords = ["mermaid", "diagram", "flowchart", "waterui"]
+categories = ["gui", "visualization"]
+
+[dependencies]
+waterui-core.workspace = true
+waterui-canvas.workspace = true
+waterui-graphics.workspace = true
+waterui-layout.workspace = true
+waterui-text.workspace = true
+waterui-str.workspace = true
+nami.workspace = true
+merman-core.workspace = true
+merman-render.workspace = true
+# Only to read Mermaid's own `fontSize` out of the effective config, which
+# `merman-core` exposes as a JSON value.
+serde_json.workspace = true
+# The host text measurement `merman-render` lays diagrams out with. Same engine
+# and the same `system` font source `waterui-canvas` draws labels with, so the
+# boxes layout reserves are the boxes the glyphs land in.
+parley = { workspace = true, features = ["system"] }
+thiserror.workspace = true
+
+[dev-dependencies]
+waterui = { path = "../../.." }
+waterui-testing = { path = "../../../testing" }
+hydrolysis-m3 = { path = "../../../backends/hydrolysis_m3" }
+
+[lints]
+workspace = true
+
+[package.metadata.cargo-machete]
+# The crate-level example is a doctest, and doctests are the one place
+# `cargo machete` does not look. `waterui` is what its `use waterui::prelude::*`
+# resolves against.
+ignored = ["waterui"]

--- a/components/data/mermaid/src/draw.rs
+++ b/components/data/mermaid/src/draw.rs
@@ -1,0 +1,238 @@
+//! Painting a laid-out diagram into a scene.
+//!
+//! Only the geometry is painted here: boxes, frames, connectors and their
+//! decorations. Every piece of text is a real view placed by [`crate::label`],
+//! so the diagram keeps the platform's own text rendering and shows up in the
+//! accessibility tree as words rather than as one opaque picture.
+//!
+//! Everything is drawn at the diagram's natural size, in the diagram's own
+//! coordinates. Scaling the geometry to fit a container would break the one
+//! guarantee this crate is built on — that the box layout reserved for a label
+//! is the box its glyphs land in — because the glyphs would still be drawn at
+//! their own size. A diagram that does not fit is the container's problem to
+//! solve, by scrolling.
+
+use alloc::vec::Vec;
+
+use waterui_canvas::{DrawingContext, Path};
+use waterui_core::layout::Point;
+
+use crate::layout::{DiagramLayout, Edge, EdgeMarker, EdgeStroke};
+use crate::shape;
+use crate::theme::Palette;
+
+/// Stroke width of a node outline and an ordinary edge.
+const STROKE: f32 = 1.0;
+/// Stroke width of a `==>` edge.
+const THICK_STROKE: f32 = 2.5;
+/// Dash pattern of a `-.->` edge.
+const DASH: [f32; 2] = [6.0, 4.0];
+/// Length of an arrowhead along the edge.
+const ARROW_LENGTH: f32 = 10.0;
+/// Half-width of an arrowhead across the edge.
+const ARROW_HALF_WIDTH: f32 = 4.0;
+/// Radius of a circle edge marker.
+const MARKER_RADIUS: f32 = 4.0;
+/// Half-diagonal of a cross edge marker.
+const CROSS_ARM: f32 = 4.0;
+/// Largest radius a routed corner is rounded by.
+const CORNER_RADIUS: f32 = 8.0;
+
+/// Paints one diagram at its natural size, with its top-left at `origin`.
+pub fn diagram(ctx: &mut DrawingContext, layout: &DiagramLayout, palette: &Palette, origin: Point) {
+    let at = |point: Point| Point::new(point.x + origin.x, point.y + origin.y);
+
+    for cluster in &layout.clusters {
+        let frame = offset_rect(cluster.frame, origin);
+        ctx.set_fill_style(palette.cluster);
+        ctx.fill_rect(frame);
+        ctx.set_stroke_style(palette.border);
+        ctx.set_line_width(STROKE);
+        ctx.stroke_rect(frame);
+    }
+
+    for fragment in &layout.fragments {
+        let frame = offset_rect(fragment.frame, origin);
+        ctx.set_stroke_style(palette.border);
+        ctx.set_line_width(STROKE);
+        ctx.stroke_rect(frame);
+        for divider in &fragment.dividers {
+            let y = divider + origin.y;
+            ctx.set_line_dash(DASH.to_vec());
+            ctx.stroke_line(Point::new(frame.min_x(), y), Point::new(frame.max_x(), y));
+            ctx.set_line_dash(Vec::new());
+        }
+    }
+
+    for lifeline in &layout.lifelines {
+        ctx.set_stroke_style(palette.border);
+        ctx.set_line_width(STROKE);
+        ctx.set_line_dash(DASH.to_vec());
+        ctx.stroke_line(
+            at(Point::new(lifeline.x, lifeline.top)),
+            at(Point::new(lifeline.x, lifeline.bottom)),
+        );
+        ctx.set_line_dash(Vec::new());
+    }
+
+    for edge in &layout.edges {
+        connector(ctx, edge, palette, origin);
+    }
+
+    for node in &layout.nodes {
+        let outline = shape::outline(node.shape, offset_rect(node.frame, origin));
+        if let Some(body) = &outline.body {
+            ctx.set_fill_style(palette.node_fill);
+            ctx.fill_path(body);
+            ctx.set_stroke_style(palette.node_border);
+            ctx.set_line_width(STROKE);
+            ctx.stroke_path(body);
+        }
+        for detail in &outline.details {
+            ctx.set_stroke_style(palette.node_border);
+            ctx.set_line_width(STROKE);
+            ctx.stroke_path(detail);
+        }
+    }
+}
+
+fn offset_rect(rect: waterui_core::layout::Rect, origin: Point) -> waterui_core::layout::Rect {
+    waterui_core::layout::Rect::new(
+        Point::new(rect.x() + origin.x, rect.y() + origin.y),
+        *rect.size(),
+    )
+}
+
+/// Paints one edge: its routed polyline, then a decoration at each end.
+fn connector(ctx: &mut DrawingContext, edge: &Edge, palette: &Palette, origin: Point) {
+    let points: Vec<Point> = edge
+        .points
+        .iter()
+        .map(|point| Point::new(point.x + origin.x, point.y + origin.y))
+        .collect();
+    let [first, rest @ ..] = points.as_slice() else {
+        return;
+    };
+    if rest.is_empty() {
+        return;
+    }
+
+    let mut path = Path::new();
+    path.move_to(*first);
+    route(&mut path, &points);
+
+    ctx.set_stroke_style(palette.edge);
+    ctx.set_line_width(match edge.stroke {
+        EdgeStroke::Thick => THICK_STROKE,
+        EdgeStroke::Normal | EdgeStroke::Dotted => STROKE,
+    });
+    if edge.stroke == EdgeStroke::Dotted {
+        ctx.set_line_dash(DASH.to_vec());
+    }
+    ctx.stroke_path(&path);
+    ctx.set_line_dash(Vec::new());
+
+    marker(ctx, edge.start_marker, points[0], points[1], palette);
+    let last = points.len() - 1;
+    marker(
+        ctx,
+        edge.end_marker,
+        points[last],
+        points[last - 1],
+        palette,
+    );
+}
+
+/// Appends the routed polyline to `path`, rounding each interior corner.
+///
+/// `points` starts with the point `path` was already moved to.
+fn route(path: &mut Path, points: &[Point]) {
+    let [_, interior @ .., last] = points else {
+        if let Some(single) = points.get(1) {
+            path.line_to(*single);
+        }
+        return;
+    };
+
+    let mut previous = points[0];
+    for (index, corner) in interior.iter().enumerate() {
+        let next = interior.get(index + 1).copied().unwrap_or(*last);
+        let radius = corner_radius(previous, *corner, next);
+        path.arc_to(*corner, next, radius);
+        previous = *corner;
+    }
+    path.line_to(*last);
+}
+
+/// The radius a corner can be rounded by without eating either segment.
+fn corner_radius(previous: Point, current: Point, next: Point) -> f32 {
+    let incoming = distance(previous, current);
+    let outgoing = distance(current, next);
+    (incoming.min(outgoing) / 2.0).min(CORNER_RADIUS)
+}
+
+fn distance(from: Point, to: Point) -> f32 {
+    (to.x - from.x).hypot(to.y - from.y)
+}
+
+/// Paints the decoration at one end of an edge.
+///
+/// `tip` is the end point; `from` is the neighbouring point, which is what
+/// gives the decoration its direction.
+fn marker(
+    ctx: &mut DrawingContext,
+    marker: EdgeMarker,
+    tip: Point,
+    from: Point,
+    palette: &Palette,
+) {
+    if marker == EdgeMarker::None {
+        return;
+    }
+    let (dx, dy) = (tip.x - from.x, tip.y - from.y);
+    let length = dx.hypot(dy);
+    if length <= f32::EPSILON {
+        return;
+    }
+    let (ux, uy) = (dx / length, dy / length);
+
+    match marker {
+        EdgeMarker::Arrow => {
+            let back = Point::new(
+                (-ux).mul_add(ARROW_LENGTH, tip.x),
+                (-uy).mul_add(ARROW_LENGTH, tip.y),
+            );
+            let mut head = Path::new();
+            head.move_to(tip);
+            head.line_to(Point::new(
+                (-uy).mul_add(ARROW_HALF_WIDTH, back.x),
+                ux.mul_add(ARROW_HALF_WIDTH, back.y),
+            ));
+            head.line_to(Point::new(
+                uy.mul_add(ARROW_HALF_WIDTH, back.x),
+                (-ux).mul_add(ARROW_HALF_WIDTH, back.y),
+            ));
+            head.close();
+            ctx.set_fill_style(palette.edge);
+            ctx.fill_path(&head);
+        }
+        EdgeMarker::Circle => {
+            ctx.set_stroke_style(palette.edge);
+            ctx.set_line_width(STROKE);
+            ctx.stroke_circle(tip, MARKER_RADIUS);
+        }
+        EdgeMarker::Cross => {
+            ctx.set_stroke_style(palette.edge);
+            ctx.set_line_width(STROKE);
+            ctx.stroke_line(
+                Point::new(tip.x - CROSS_ARM, tip.y - CROSS_ARM),
+                Point::new(tip.x + CROSS_ARM, tip.y + CROSS_ARM),
+            );
+            ctx.stroke_line(
+                Point::new(tip.x - CROSS_ARM, tip.y + CROSS_ARM),
+                Point::new(tip.x + CROSS_ARM, tip.y - CROSS_ARM),
+            );
+        }
+        EdgeMarker::None => {}
+    }
+}

--- a/components/data/mermaid/src/engine.rs
+++ b/components/data/mermaid/src/engine.rs
@@ -1,0 +1,691 @@
+//! Mermaid source in, [`DiagramLayout`] out.
+//!
+//! This is the only module that names a `merman` type. Everything downstream —
+//! the scene, the labels, the accessibility tree — reads [`crate::layout`].
+
+use alloc::string::{String, ToString as _};
+use alloc::vec::Vec;
+
+use merman_core::{Engine, ParseOptions};
+use merman_render::LayoutOptions;
+use merman_render::environment::RenderEnvironment;
+use merman_render::family::{self, LayoutProjection};
+use merman_render::model::{LayoutEdge, LayoutLabel, LayoutNode};
+use waterui_core::layout::{Point, Rect, Size};
+use waterui_str::Str;
+
+use crate::layout::{
+    Cluster, DiagramLayout, Edge, EdgeMarker, EdgeStroke, Emphasis, Fragment, Label, Lifeline,
+    Node, NodeShape, UnsupportedShape,
+};
+use crate::measure;
+
+/// Why a diagram could not be drawn.
+#[derive(Debug, thiserror::Error)]
+pub enum MermaidError {
+    /// The source is not a diagram Mermaid recognises.
+    #[error("the source does not begin with a Mermaid diagram header")]
+    NotADiagram,
+    /// The source is a diagram, but its syntax is wrong.
+    #[error("{0}")]
+    Parse(merman_core::Error),
+    /// The layout runtime refused to start a session.
+    #[error("{0}")]
+    Session(merman_core::runtime::RuntimePolicyError),
+    /// The diagram parsed, but laying it out failed.
+    #[error("{0}")]
+    Layout(merman_render::Error),
+    /// The diagram is a family this crate does not draw yet.
+    #[error(
+        "`{0}` diagrams are not drawn by waterui-mermaid yet; \
+         flowchart and sequence are the families it supports"
+    )]
+    UnsupportedFamily(Str),
+    /// The diagram uses a node shape this crate has no outline for.
+    #[error(transparent)]
+    UnsupportedShape(#[from] UnsupportedShape),
+    /// The layout named a piece of geometry this crate does not know how to
+    /// draw, which means the diagram family grew something since this code
+    /// last read it.
+    #[error(
+        "the layout produced `{0}`, which waterui-mermaid does not know how to draw; \
+         the diagram is not drawn rather than drawn with a piece missing"
+    )]
+    UnknownGeometry(Str),
+}
+
+/// Mermaid's default label font size, used when the source does not set one.
+const DEFAULT_FONT_SIZE: f32 = 16.0;
+
+/// The container width Mermaid families that consult one are laid out against.
+///
+/// Only a handful of families read it, and a diagram is drawn at its natural
+/// size regardless; this is the value Mermaid itself defaults to.
+const LAYOUT_CONTAINER: Size = Size::new(800.0, 600.0);
+
+/// Parses and lays out one diagram.
+///
+/// # Errors
+///
+/// See [`MermaidError`].
+pub fn render(source: &str) -> Result<DiagramLayout, MermaidError> {
+    let container = LAYOUT_CONTAINER;
+    let engine = Engine::new();
+    let parsed = engine
+        .parse_diagram_for_render_model_sync(source, ParseOptions::default())
+        .map_err(MermaidError::Parse)?
+        .ok_or(MermaidError::NotADiagram)?;
+
+    let family = Str::from(parsed.metadata().diagram_type.clone());
+    let font_size = configured_font_size(parsed.metadata());
+    let semantic = parsed.model().clone();
+
+    let session = RenderEnvironment::deterministic()
+        .with_text_measurement_policy(measure::policy())
+        .begin_session()
+        .map_err(MermaidError::Session)?;
+
+    let mut options = LayoutOptions::default();
+    options.container_width = f64::from(container.width);
+    options.container_height = f64::from(container.height);
+
+    let artifact = family::prepare(parsed, &options, session).map_err(MermaidError::Layout)?;
+
+    match artifact.layout() {
+        LayoutProjection::Flowchart(geometry) => {
+            let merman_core::RenderSemanticModel::Flowchart(model) = &semantic else {
+                unreachable!("a flowchart layout is only produced from a flowchart model")
+            };
+            flowchart(model, geometry, font_size)
+        }
+        LayoutProjection::SequenceDiagram(geometry) => {
+            let merman_core::RenderSemanticModel::Sequence(model) = &semantic else {
+                unreachable!("a sequence layout is only produced from a sequence model")
+            };
+            sequence(model, geometry, font_size)
+        }
+        _ => Err(MermaidError::UnsupportedFamily(family)),
+    }
+}
+
+/// Lowers a flowchart's geometry, joined with the semantic model that knows
+/// each node's shape and each edge's decoration.
+fn flowchart(
+    model: &merman_core::diagrams::flowchart::FlowchartModel,
+    geometry: &merman_render::model::FlowchartLayout,
+    font_size: f32,
+) -> Result<DiagramLayout, MermaidError> {
+    use merman_core::diagrams::flowchart::{FlowEdgeStroke, FlowEdgeVisibility};
+
+    let origin = Origin::of(geometry.bounds.as_ref());
+
+    let mut nodes = Vec::with_capacity(geometry.nodes.len());
+    for laid_out in &geometry.nodes {
+        if laid_out.is_cluster {
+            continue;
+        }
+        let authored = model.nodes.iter().find(|node| node.id == laid_out.id);
+        let shape = NodeShape::resolve(
+            authored
+                .and_then(|node| node.layout_shape.as_deref())
+                .unwrap_or("squareRect"),
+        )?;
+        let frame = origin.node(laid_out);
+        nodes.push(Node {
+            id: Str::from(laid_out.id.clone()),
+            frame,
+            shape,
+            label: authored
+                .and_then(|node| node.label.clone())
+                .filter(|text| !text.is_empty())
+                .map(|text| Label {
+                    id: Str::from(alloc::format!("node:{}", laid_out.id)),
+                    // A node's label is centred in its box. The shapes that
+                    // waste corner space — diamond, the parallelograms — had
+                    // that accounted for when layout sized the box.
+                    frame,
+                    text: Str::from(text),
+                    emphasis: Emphasis::Normal,
+                }),
+        });
+    }
+
+    let mut edges = Vec::with_capacity(geometry.edges.len());
+    for laid_out in &geometry.edges {
+        let authored = model.edges.iter().find(|edge| edge.id == laid_out.id);
+        if authored.is_some_and(|edge| edge.visibility == FlowEdgeVisibility::Invisible) {
+            continue;
+        }
+        edges.push(Edge {
+            id: Str::from(laid_out.id.clone()),
+            points: laid_out
+                .points
+                .iter()
+                .map(|point| origin.point(point.x, point.y))
+                .collect(),
+            label: edge_label(
+                laid_out,
+                authored.and_then(|edge| edge.label.as_deref()),
+                origin,
+            ),
+            stroke: match authored.map(|edge| edge.stroke_kind) {
+                Some(FlowEdgeStroke::Dotted) => EdgeStroke::Dotted,
+                Some(FlowEdgeStroke::Thick) => EdgeStroke::Thick,
+                Some(FlowEdgeStroke::Normal) | None => EdgeStroke::Normal,
+            },
+            start_marker: marker(authored.map(|edge| edge.start_marker)),
+            end_marker: marker(authored.map(|edge| edge.end_marker)),
+        });
+    }
+
+    let clusters = geometry
+        .clusters
+        .iter()
+        .map(|cluster| Cluster {
+            id: Str::from(cluster.id.clone()),
+            frame: origin.centred(cluster.x, cluster.y, cluster.width, cluster.height),
+            label: (!cluster.title.is_empty()).then(|| Label {
+                id: Str::from(alloc::format!("cluster:{}", cluster.id)),
+                frame: origin.label(&cluster.title_label),
+                text: Str::from(cluster.title.clone()),
+                emphasis: Emphasis::Title,
+            }),
+        })
+        .collect();
+
+    Ok(DiagramLayout {
+        size: bounds_size(geometry.bounds.as_ref()),
+        clusters,
+        fragments: Vec::new(),
+        nodes,
+        edges,
+        lifelines: Vec::new(),
+        font_size,
+        acc_title: model.acc_title.clone().map(Str::from),
+        acc_description: model.acc_descr.clone().map(Str::from),
+    })
+}
+
+/// The label font size the diagram was laid out with.
+///
+/// `fontSize` is Mermaid's own documented configuration knob, and it is what
+/// `merman` derives the `TextStyle` it measures with from. Reading it here is
+/// what lets a label be drawn at the size its box was measured at.
+fn configured_font_size(metadata: &merman_core::ParseMetadata) -> f32 {
+    metadata
+        .effective_config
+        .as_value()
+        .get("fontSize")
+        .and_then(serde_json::Value::as_f64)
+        .map(|size| {
+            #[expect(
+                clippy::cast_possible_truncation,
+                reason = "a font size is a small positive magnitude that f32 represents exactly enough to draw with"
+            )]
+            let size = size as f32;
+            size
+        })
+        .filter(|size| size.is_finite() && *size > 0.0)
+        .unwrap_or(DEFAULT_FONT_SIZE)
+}
+
+/// Where a diagram's own coordinate space starts.
+///
+/// Mermaid lays a diagram out wherever its algorithm happens to begin, not at
+/// the origin — a sequence diagram's bounds start at `(-50, -10)` — so every
+/// coordinate is shifted to put the diagram's top-left corner at `(0, 0)` and
+/// the geometry the renderer sees is always positive.
+#[derive(Debug, Clone, Copy, Default)]
+struct Origin {
+    x: f64,
+    y: f64,
+}
+
+impl Origin {
+    /// Reads the diagram's origin off its bounds.
+    fn of(bounds: Option<&merman_render::model::Bounds>) -> Self {
+        bounds.map_or(Self { x: 0.0, y: 0.0 }, |bounds| Self {
+            x: bounds.min_x,
+            y: bounds.min_y,
+        })
+    }
+
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "diagram coordinates are screen-scale magnitudes that f32 represents exactly enough to draw"
+    )]
+    fn point(self, x: f64, y: f64) -> Point {
+        Point::new((x - self.x) as f32, (y - self.y) as f32)
+    }
+
+    /// A box Mermaid positions by its centre.
+    fn centred(self, x: f64, y: f64, width: f64, height: f64) -> Rect {
+        Rect::new(
+            self.point(x - width / 2.0, y - height / 2.0),
+            size_of(width, height),
+        )
+    }
+
+    fn node(self, node: &LayoutNode) -> Rect {
+        self.centred(node.x, node.y, node.width, node.height)
+    }
+
+    fn label(self, label: &LayoutLabel) -> Rect {
+        self.centred(label.x, label.y, label.width, label.height)
+    }
+}
+
+/// Translates a Mermaid edge marker into the decoration we draw.
+const fn marker(marker: Option<merman_core::diagrams::flowchart::FlowEdgeMarker>) -> EdgeMarker {
+    use merman_core::diagrams::flowchart::FlowEdgeMarker as Authored;
+    match marker {
+        Some(Authored::Point) => EdgeMarker::Arrow,
+        Some(Authored::Circle) => EdgeMarker::Circle,
+        Some(Authored::Cross) => EdgeMarker::Cross,
+        Some(Authored::None) | None => EdgeMarker::None,
+    }
+}
+
+/// Pairs an edge's laid-out label box with the text that belongs in it.
+fn edge_label(edge: &LayoutEdge, text: Option<&str>, origin: Origin) -> Option<Label> {
+    let frame = edge.label.as_ref()?;
+    let text = text.map(str::trim).filter(|text| !text.is_empty())?;
+    Some(Label {
+        id: Str::from(alloc::format!("edge:{}", edge.id)),
+        frame: origin.label(frame),
+        text: Str::from(text.to_string()),
+        emphasis: Emphasis::Normal,
+    })
+}
+
+/// The diagram's natural size.
+fn bounds_size(bounds: Option<&merman_render::model::Bounds>) -> Size {
+    bounds.map_or_else(Size::default, |bounds| {
+        size_of(bounds.max_x - bounds.min_x, bounds.max_y - bounds.min_y)
+    })
+}
+
+#[expect(
+    clippy::cast_possible_truncation,
+    reason = "diagram coordinates are screen-scale magnitudes that f32 represents exactly enough to draw"
+)]
+const fn size_of(width: f64, height: f64) -> Size {
+    Size::new(width as f32, height as f32)
+}
+
+/// Mermaid's `SequenceDB.LINETYPE` values, which is where a message's arrow and
+/// stroke come from — the laid-out edge carries geometry only.
+mod linetype {
+    pub const DOTTED: i32 = 1;
+    pub const SOLID_CROSS: i32 = 3;
+    pub const DOTTED_CROSS: i32 = 4;
+    pub const SOLID_OPEN: i32 = 5;
+    pub const DOTTED_OPEN: i32 = 6;
+    pub const SOLID_POINT: i32 = 24;
+    pub const DOTTED_POINT: i32 = 25;
+    pub const BIDIRECTIONAL_DOTTED: i32 = 34;
+
+    /// The keyword a block-opening message spells, if it opens one.
+    pub const fn block_keyword(line_type: i32) -> Option<&'static str> {
+        Some(match line_type {
+            10 => "loop",
+            12 => "alt",
+            15 => "opt",
+            19 | 32 => "par",
+            22 => "rect",
+            27 => "critical",
+            30 => "break",
+            _ => return None,
+        })
+    }
+
+    /// Whether the message is drawn with a dashed line.
+    pub const fn is_dotted(line_type: i32) -> bool {
+        matches!(
+            line_type,
+            DOTTED | DOTTED_CROSS | DOTTED_OPEN | DOTTED_POINT | BIDIRECTIONAL_DOTTED
+        )
+    }
+
+    /// The decoration at the arrow's head.
+    pub const fn head(line_type: i32) -> crate::layout::EdgeMarker {
+        use crate::layout::EdgeMarker;
+        match line_type {
+            SOLID_CROSS | DOTTED_CROSS => EdgeMarker::Cross,
+            SOLID_POINT | DOTTED_POINT => EdgeMarker::Circle,
+            SOLID_OPEN | DOTTED_OPEN => EdgeMarker::None,
+            _ => EdgeMarker::Arrow,
+        }
+    }
+}
+
+/// Lowers a sequence diagram.
+///
+/// The layout names what each piece is: `actor-top-<id>` and
+/// `actor-bottom-<id>` are a participant's two headers, `note-<n>` is a note,
+/// `msg-<n>` is a message and `lifeline-<id>` is the vertical line between one
+/// participant's headers. The style of a message — dashed or solid, which
+/// arrowhead — lives in the semantic model rather than the geometry, so the two
+/// are joined here by that index.
+fn sequence(
+    model: &merman_core::diagrams::sequence::SequenceDiagramRenderModel,
+    geometry: &merman_render::model::SequenceDiagramLayout,
+    font_size: f32,
+) -> Result<DiagramLayout, MermaidError> {
+    let origin = Origin::of(geometry.bounds.as_ref());
+
+    let mut nodes = Vec::with_capacity(geometry.nodes.len());
+    for laid_out in &geometry.nodes {
+        nodes.push(sequence_node(model, laid_out, origin)?);
+    }
+
+    let mut edges = Vec::new();
+    let mut lifelines = Vec::new();
+    for laid_out in &geometry.edges {
+        match sequence_connector(model, laid_out, origin) {
+            Connector::Message(edge) => edges.push(edge),
+            Connector::Lifeline(lifeline) => lifelines.push(lifeline),
+            Connector::Degenerate => {}
+        }
+    }
+
+    Ok(DiagramLayout {
+        size: bounds_size(geometry.bounds.as_ref()),
+        clusters: participant_boxes(model, geometry, origin),
+        fragments: fragments(model, geometry, origin, &lifelines),
+        nodes,
+        edges,
+        lifelines,
+        font_size,
+        acc_title: model.acc_title.clone().map(Str::from),
+        acc_description: model.acc_descr.clone().map(Str::from),
+    })
+}
+
+/// One node of a sequence diagram's geometry.
+///
+/// The layout's own id says what the node is; the semantic model says what it
+/// holds. A node whose id matches neither shape is a family feature this crate
+/// has not learned yet, and drawing it as a bare rectangle would hide that.
+fn sequence_node(
+    model: &merman_core::diagrams::sequence::SequenceDiagramRenderModel,
+    laid_out: &LayoutNode,
+    origin: Origin,
+) -> Result<Node, MermaidError> {
+    let frame = origin.node(laid_out);
+    let (shape, text) = if let Some(actor_id) = laid_out
+        .id
+        .strip_prefix("actor-top-")
+        .or_else(|| laid_out.id.strip_prefix("actor-bottom-"))
+    {
+        let actor = model.actors.get(actor_id);
+        let shape = if actor.is_some_and(|actor| actor.actor_type == "actor") {
+            NodeShape::Actor
+        } else {
+            NodeShape::Participant
+        };
+        (shape, actor.map(|actor| actor.description.clone()))
+    } else if let Some(index) = laid_out.id.strip_prefix("note-") {
+        let text = index
+            .parse::<usize>()
+            .ok()
+            .and_then(|index| model.messages.get(index))
+            .map(|message| message.message.as_text().to_owned());
+        (NodeShape::Note, text)
+    } else {
+        return Err(MermaidError::UnknownGeometry(Str::from(
+            laid_out.id.clone(),
+        )));
+    };
+
+    Ok(Node {
+        id: Str::from(laid_out.id.clone()),
+        frame,
+        shape,
+        label: text
+            .map(|text| text.trim().to_owned())
+            .filter(|text| !text.is_empty())
+            .map(|text| Label {
+                id: Str::from(alloc::format!("node:{}", laid_out.id)),
+                frame: crate::shape::label_area(shape, frame),
+                text: Str::from(text),
+                emphasis: if laid_out.id.starts_with("note-") {
+                    Emphasis::Normal
+                } else {
+                    Emphasis::Title
+                },
+            }),
+    })
+}
+
+/// What one of a sequence layout's edges turns out to be.
+enum Connector {
+    /// A message between participants.
+    Message(Edge),
+    /// A participant's vertical line.
+    Lifeline(Lifeline),
+    /// A lifeline with no endpoints, which is nothing to draw.
+    Degenerate,
+}
+
+/// One edge of a sequence diagram's geometry.
+///
+/// A message's style — dashed or solid, and which arrowhead — is not in the
+/// geometry: it comes from Mermaid's `LINETYPE` on the semantic message the
+/// edge's id indexes.
+fn sequence_connector(
+    model: &merman_core::diagrams::sequence::SequenceDiagramRenderModel,
+    laid_out: &LayoutEdge,
+    origin: Origin,
+) -> Connector {
+    if let Some(actor_id) = laid_out.id.strip_prefix("lifeline-") {
+        let (Some(top), Some(bottom)) = (laid_out.points.first(), laid_out.points.last()) else {
+            return Connector::Degenerate;
+        };
+        let top = origin.point(top.x, top.y);
+        let bottom = origin.point(bottom.x, bottom.y);
+        return Connector::Lifeline(Lifeline {
+            id: Str::from(actor_id.to_owned()),
+            x: top.x,
+            top: top.y,
+            bottom: bottom.y,
+        });
+    }
+
+    let message = laid_out
+        .id
+        .strip_prefix("msg-")
+        .and_then(|index| index.parse::<usize>().ok())
+        .and_then(|index| model.messages.get(index));
+    let line_type = message.map_or(0, |message| message.message_type);
+
+    Connector::Message(Edge {
+        id: Str::from(laid_out.id.clone()),
+        points: laid_out
+            .points
+            .iter()
+            .map(|point| origin.point(point.x, point.y))
+            .collect(),
+        label: edge_label(
+            laid_out,
+            message.map(|message| message.message.as_text()),
+            origin,
+        ),
+        stroke: if linetype::is_dotted(line_type) {
+            EdgeStroke::Dotted
+        } else {
+            EdgeStroke::Normal
+        },
+        start_marker: EdgeMarker::None,
+        end_marker: linetype::head(line_type),
+    })
+}
+
+/// The `box ... end` groupings a sequence diagram can put around participants.
+fn participant_boxes(
+    model: &merman_core::diagrams::sequence::SequenceDiagramRenderModel,
+    geometry: &merman_render::model::SequenceDiagramLayout,
+    origin: Origin,
+) -> Vec<Cluster> {
+    let _ = model;
+    geometry
+        .clusters
+        .iter()
+        .map(|cluster| Cluster {
+            id: Str::from(cluster.id.clone()),
+            frame: origin.centred(cluster.x, cluster.y, cluster.width, cluster.height),
+            label: (!cluster.title.is_empty()).then(|| Label {
+                id: Str::from(alloc::format!("cluster:{}", cluster.id)),
+                frame: origin.label(&cluster.title_label),
+                text: Str::from(cluster.title.clone()),
+                emphasis: Emphasis::Title,
+            }),
+        })
+        .collect()
+}
+
+/// The `loop` / `alt` / `opt` frames.
+///
+/// The layout supplies each fragment's vertical extent, keyed by the index of
+/// the message that opened it. Its horizontal extent is not given and is not
+/// guessed: it is the span of the lifelines belonging to the participants the
+/// fragment's own messages touch, which is what Mermaid draws the frame around.
+/// A fragment enclosing no messages spans every lifeline, as Mermaid draws it.
+fn fragments(
+    model: &merman_core::diagrams::sequence::SequenceDiagramRenderModel,
+    geometry: &merman_render::model::SequenceDiagramLayout,
+    origin: Origin,
+    lifelines: &[Lifeline],
+) -> Vec<Fragment> {
+    /// How far a fragment's frame sits outside the lifelines it encloses.
+    const MARGIN: f32 = 24.0;
+    /// Height of the keyword tab in the fragment's top-left corner.
+    const TAB_HEIGHT: f32 = 20.0;
+    /// Width of the keyword tab.
+    const TAB_WIDTH: f32 = 52.0;
+
+    let mut fragments = Vec::with_capacity(geometry.block_layouts_by_id.len());
+    for (id, block) in &geometry.block_layouts_by_id {
+        let opener = id
+            .parse::<usize>()
+            .ok()
+            .and_then(|index| model.messages.get(index));
+        let Some(keyword) = opener
+            .map(|message| message.message_type)
+            .and_then(linetype::block_keyword)
+        else {
+            continue;
+        };
+
+        let enclosed = enclosed_actors(model, geometry, block);
+        let (left, right) = lifeline_span(lifelines, &enclosed);
+        let top = origin.point(0.0, block.start_y).y;
+        let bottom = origin.point(0.0, block.stop_y).y;
+        let (left, right) = (left - MARGIN, right + MARGIN);
+
+        let mut labels = Vec::with_capacity(2);
+        labels.push(Label {
+            id: Str::from(alloc::format!("fragment:{id}:keyword")),
+            frame: Rect::new(
+                Point::new(left, top),
+                Size::new(TAB_WIDTH.min(right - left), TAB_HEIGHT),
+            ),
+            text: Str::from(keyword),
+            emphasis: Emphasis::Title,
+        });
+        if let Some(guard) = opener
+            .map(|message| message.message.as_text().trim().to_owned())
+            .filter(|guard| !guard.is_empty())
+        {
+            labels.push(Label {
+                id: Str::from(alloc::format!("fragment:{id}:guard")),
+                frame: Rect::new(
+                    Point::new(left + TAB_WIDTH, top),
+                    Size::new((right - left - TAB_WIDTH).max(0.0), TAB_HEIGHT),
+                ),
+                text: Str::from(guard),
+                emphasis: Emphasis::Muted,
+            });
+        }
+
+        fragments.push(Fragment {
+            id: Str::from(id.clone()),
+            frame: Rect::new(Point::new(left, top), Size::new(right - left, bottom - top)),
+            dividers: block
+                .section_ys_by_id
+                .values()
+                .map(|y| origin.point(0.0, *y).y)
+                .collect(),
+            labels,
+        });
+    }
+    // `block_layouts_by_id` is a hash map, and a frame drawn under another has
+    // to be drawn first, so order them outermost-first by height.
+    fragments.sort_by(|left, right| {
+        right
+            .frame
+            .height()
+            .total_cmp(&left.frame.height())
+            .then_with(|| left.frame.y().total_cmp(&right.frame.y()))
+    });
+    fragments
+}
+
+/// The participants whose messages fall inside one fragment.
+///
+/// Membership is decided by the laid-out message's own `y`, which is the only
+/// thing that relates a message to a fragment: the semantic model nests nothing.
+fn enclosed_actors(
+    model: &merman_core::diagrams::sequence::SequenceDiagramRenderModel,
+    geometry: &merman_render::model::SequenceDiagramLayout,
+    block: &merman_render::model::SequenceBlockLayout,
+) -> Vec<String> {
+    let mut actors = Vec::new();
+    for edge in &geometry.edges {
+        let Some(index) = edge
+            .id
+            .strip_prefix("msg-")
+            .and_then(|index| index.parse::<usize>().ok())
+        else {
+            continue;
+        };
+        let Some(y) = edge.points.first().map(|point| point.y) else {
+            continue;
+        };
+        if y < block.start_y || y > block.stop_y {
+            continue;
+        }
+        let Some(message) = model.messages.get(index) else {
+            continue;
+        };
+        for actor in [message.from.as_ref(), message.to.as_ref()]
+            .into_iter()
+            .flatten()
+        {
+            if !actors.iter().any(|known| known == actor) {
+                actors.push(actor.clone());
+            }
+        }
+    }
+    actors
+}
+
+/// The horizontal extent of the named lifelines, or of every lifeline when the
+/// list is empty.
+fn lifeline_span(lifelines: &[Lifeline], actors: &[String]) -> (f32, f32) {
+    let mut left = f32::INFINITY;
+    let mut right = f32::NEG_INFINITY;
+    for lifeline in lifelines {
+        let id: &str = &lifeline.id;
+        let selected = actors.is_empty() || actors.iter().any(|actor| actor == id);
+        if selected {
+            left = left.min(lifeline.x);
+            right = right.max(lifeline.x);
+        }
+    }
+    if left.is_finite() && right.is_finite() {
+        (left, right)
+    } else {
+        (0.0, 0.0)
+    }
+}

--- a/components/data/mermaid/src/label.rs
+++ b/components/data/mermaid/src/label.rs
@@ -1,0 +1,91 @@
+//! Diagram text, as real views.
+//!
+//! Labels are the reason this crate lays diagrams out with `WaterUI`'s own text
+//! engine instead of accepting `merman`'s built-in metrics. Painting them into
+//! the scene as glyphs would throw that away again: the diagram would be one
+//! opaque picture to the accessibility tree, would not honour the platform's
+//! text rendering, and could not be selected. So every label is a `text()` view,
+//! placed into the box layout reserved for it.
+
+use waterui_core::layout::{Layout, Point, ProposalSize, Rect, Size, StretchAxis, SubView};
+use waterui_core::{Environment, View};
+use waterui_text::text;
+
+use crate::layout::{Emphasis, Label};
+
+/// Places one label centred in the box the diagram reserved for it.
+///
+/// The reserved box and the measured text agree by construction — the same
+/// engine produced both — so the centring here only ever absorbs the
+/// sub-pixel difference between a measurement taken during layout and one taken
+/// during placement.
+#[derive(Debug)]
+pub struct Placement {
+    frame: Rect,
+}
+
+impl Placement {
+    /// Places a label in `frame`, in diagram coordinates.
+    #[must_use]
+    pub const fn new(frame: Rect) -> Self {
+        Self { frame }
+    }
+}
+
+impl Layout for Placement {
+    fn size_that_fits(&self, _proposal: ProposalSize, _children: &[&dyn SubView]) -> Size {
+        *self.frame.size()
+    }
+
+    fn place(&self, bounds: Rect, children: &[&dyn SubView]) -> Vec<Rect> {
+        let [child] = children else {
+            panic!("a diagram label must contain exactly one text view");
+        };
+        let size = child.measure(ProposalSize::UNSPECIFIED).size;
+        vec![Rect::new(
+            Point::new(
+                bounds.mid_x() - size.width / 2.0,
+                bounds.mid_y() - size.height / 2.0,
+            ),
+            size,
+        )]
+    }
+
+    fn stretch_axis(&self, _children: &[StretchAxis]) -> StretchAxis {
+        StretchAxis::None
+    }
+}
+
+/// The view for one label.
+#[derive(Debug)]
+pub struct LabelView {
+    label: Label,
+    font_size: f32,
+}
+
+impl LabelView {
+    /// Builds the view for `label`, drawn at the diagram's font size.
+    #[must_use]
+    pub const fn new(label: Label, font_size: f32) -> Self {
+        Self { label, font_size }
+    }
+}
+
+impl View for LabelView {
+    fn body(self, _env: &Environment) -> impl View {
+        let view = text(self.label.text).size(match self.label.emphasis {
+            // A fragment keyword or subgraph title is drawn a step down from
+            // the body text, as Mermaid draws it.
+            Emphasis::Title | Emphasis::Muted => self.font_size * 0.875,
+            Emphasis::Normal => self.font_size,
+        });
+        match self.label.emphasis {
+            Emphasis::Title => view.bold(),
+            Emphasis::Normal | Emphasis::Muted => view,
+        }
+    }
+
+    fn stretch_axis(&self) -> StretchAxis {
+        StretchAxis::None
+    }
+}

--- a/components/data/mermaid/src/layout.rs
+++ b/components/data/mermaid/src/layout.rs
@@ -1,0 +1,262 @@
+//! The geometry this crate draws, in `WaterUI` units.
+//!
+//! Nothing outside [`crate::engine`] names a `merman` type. Everything the
+//! renderer and the label layer read is defined here, so the crate that
+//! produces the geometry can change — and it will, once the typed layout
+//! projection is released upstream — without the drawing code noticing.
+
+use alloc::vec::Vec;
+
+use waterui_core::layout::{Point, Rect, Size};
+use waterui_str::Str;
+
+/// One laid-out diagram.
+#[derive(Debug, Clone, Default)]
+pub struct DiagramLayout {
+    /// The diagram's natural size, before any scaling to fit its container.
+    pub size: Size,
+    /// Subgraph and participant-box frames, drawn beneath everything else.
+    pub clusters: Vec<Cluster>,
+    /// Sequence-diagram `loop` / `alt` / `opt` frames, drawn beneath messages.
+    pub fragments: Vec<Fragment>,
+    /// Node boxes.
+    pub nodes: Vec<Node>,
+    /// Connections between nodes.
+    pub edges: Vec<Edge>,
+    /// Vertical participant lines, empty for every diagram but `sequence`.
+    pub lifelines: Vec<Lifeline>,
+    /// The font size the diagram's labels were laid out at, from Mermaid's
+    /// `fontSize` configuration. Labels must be drawn at this size: it is the
+    /// size their boxes were measured with.
+    pub font_size: f32,
+    /// The diagram's accessible name, from `accTitle`.
+    pub acc_title: Option<Str>,
+    /// The diagram's accessible description, from `accDescr`.
+    pub acc_description: Option<Str>,
+}
+
+impl DiagramLayout {
+    /// Every label the diagram draws, in the order they should be placed.
+    ///
+    /// Labels are not painted into the scene: they are real text views, and
+    /// this is what the label layer iterates.
+    pub fn labels(&self) -> impl Iterator<Item = &Label> {
+        self.clusters
+            .iter()
+            .filter_map(|cluster| cluster.label.as_ref())
+            .chain(
+                self.fragments
+                    .iter()
+                    .flat_map(|fragment| fragment.labels.iter()),
+            )
+            .chain(self.nodes.iter().filter_map(|node| node.label.as_ref()))
+            .chain(self.edges.iter().filter_map(|edge| edge.label.as_ref()))
+    }
+}
+
+/// A piece of text the diagram draws as a real view rather than as glyphs
+/// painted into the scene.
+#[derive(Debug, Clone)]
+pub struct Label {
+    /// Stable identity, so a membership change diffs instead of rebuilding.
+    pub id: Str,
+    /// The box layout reserved for this text, in diagram coordinates.
+    pub frame: Rect,
+    /// The text itself.
+    pub text: Str,
+    /// How prominent the text is, which decides its font weight.
+    pub emphasis: Emphasis,
+}
+
+/// How prominent a label is.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Emphasis {
+    /// Ordinary label text.
+    #[default]
+    Normal,
+    /// A title: a subgraph name, a fragment keyword, a participant name.
+    Title,
+    /// Secondary text, such as a fragment's guard condition.
+    Muted,
+}
+
+/// A node box.
+#[derive(Debug, Clone)]
+pub struct Node {
+    /// The node's id in the source.
+    pub id: Str,
+    /// The box the node occupies.
+    pub frame: Rect,
+    /// The outline to stroke and fill.
+    pub shape: NodeShape,
+    /// The node's label, if it has one.
+    pub label: Option<Label>,
+}
+
+/// The outline of a node.
+///
+/// This is the geometric shape, which is what Mermaid calls a node's
+/// `layout_shape` — the thing that decided how much room layout reserved. The
+/// authored spelling (`[]`, `()`, `{{}}`, `shape: cyl`) is a source detail that
+/// has already been resolved by the time geometry exists.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NodeShape {
+    /// `A[text]` — a plain rectangle.
+    Rectangle,
+    /// `A(text)` — a rectangle with rounded corners.
+    RoundedRectangle,
+    /// `A([text])` — fully rounded ends.
+    Stadium,
+    /// `A[[text]]` — a rectangle with an inner vertical rule at each end.
+    Subroutine,
+    /// `A[(text)]` — a database cylinder.
+    Cylinder,
+    /// `A((text))` — a circle.
+    Circle,
+    /// `A(((text)))` — a circle inside a circle.
+    DoubleCircle,
+    /// `A>text]` — a flag with one notched edge.
+    Asymmetric,
+    /// `A{text}` — a decision diamond.
+    Diamond,
+    /// `A{{text}}` — a hexagon.
+    Hexagon,
+    /// `A[/text/]` — a parallelogram leaning right.
+    ParallelogramRight,
+    /// `A[\text\]` — a parallelogram leaning left.
+    ParallelogramLeft,
+    /// `A[/text\]` — a trapezoid, wide at the bottom.
+    Trapezoid,
+    /// `A[\text/]` — a trapezoid, wide at the top.
+    TrapezoidInverted,
+    /// A label with no outline at all.
+    Text,
+    /// A sequence-diagram participant header.
+    Participant,
+    /// A sequence-diagram actor stick figure.
+    Actor,
+    /// A sequence-diagram note.
+    Note,
+}
+
+impl NodeShape {
+    /// Resolves Mermaid's geometric shape name.
+    ///
+    /// The names are Mermaid's own `layout_shape` vocabulary, including the
+    /// aliases its shape catalogue accepts. An unrecognised name is an error
+    /// rather than a silently substituted rectangle: a diagram drawn with the
+    /// wrong outline is a wrong diagram, and saying so is the only way the gap
+    /// ever gets closed.
+    ///
+    /// # Errors
+    ///
+    /// Returns the unrecognised name when this crate has no outline for it.
+    pub fn resolve(name: &str) -> Result<Self, UnsupportedShape> {
+        Ok(match name {
+            "squareRect" | "rect" | "proc" | "process" | "rectangle" => Self::Rectangle,
+            "roundedRect" | "rounded" | "event" => Self::RoundedRectangle,
+            "stadium" | "terminal" | "pill" => Self::Stadium,
+            "subroutine" | "subprocess" | "framed-rectangle" | "subproc" => Self::Subroutine,
+            "cylinder" | "db" | "database" | "cyl" | "disk" => Self::Cylinder,
+            "circle" | "circ" => Self::Circle,
+            "doublecircle" | "double-circle" | "dbl-circ" => Self::DoubleCircle,
+            "odd" | "flag" | "rect_left_inv_arrow" => Self::Asymmetric,
+            "diamond" | "question" | "diam" | "decision" => Self::Diamond,
+            "hexagon" | "hex" | "prepare" => Self::Hexagon,
+            "lean_right" | "lean-r" | "in-out" => Self::ParallelogramRight,
+            "lean_left" | "lean-l" | "out-in" => Self::ParallelogramLeft,
+            "trapezoid" | "trap-b" | "priority" => Self::Trapezoid,
+            "inv_trapezoid" | "trap-t" | "manual" => Self::TrapezoidInverted,
+            "text" => Self::Text,
+            other => return Err(UnsupportedShape(Str::from(other.to_owned()))),
+        })
+    }
+}
+
+/// A node shape this crate cannot draw.
+#[derive(Debug, Clone, thiserror::Error)]
+#[error(
+    "Mermaid node shape `{0}` has no outline in waterui-mermaid yet; \
+     the diagram is not drawn rather than drawn with the wrong shape"
+)]
+pub struct UnsupportedShape(pub Str);
+
+/// A connection between two nodes.
+#[derive(Debug, Clone)]
+pub struct Edge {
+    /// The edge's id in the layout.
+    pub id: Str,
+    /// The polyline the edge follows, already routed around the nodes.
+    pub points: Vec<Point>,
+    /// The edge's label, if it has one.
+    pub label: Option<Label>,
+    /// The stroke pattern.
+    pub stroke: EdgeStroke,
+    /// The decoration at the first point.
+    pub start_marker: EdgeMarker,
+    /// The decoration at the last point.
+    pub end_marker: EdgeMarker,
+}
+
+/// How an edge's line is stroked.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EdgeStroke {
+    /// A solid line at the normal weight.
+    #[default]
+    Normal,
+    /// A dashed line.
+    Dotted,
+    /// A solid line at twice the normal weight.
+    Thick,
+}
+
+/// The decoration at one end of an edge.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum EdgeMarker {
+    /// A bare line end.
+    #[default]
+    None,
+    /// A filled arrowhead.
+    Arrow,
+    /// An open circle.
+    Circle,
+    /// A cross.
+    Cross,
+}
+
+/// A subgraph frame, or a sequence diagram's participant box.
+#[derive(Debug, Clone)]
+pub struct Cluster {
+    /// The cluster's id in the source.
+    pub id: Str,
+    /// The frame the cluster occupies.
+    pub frame: Rect,
+    /// The cluster's title.
+    pub label: Option<Label>,
+}
+
+/// A sequence diagram's `loop` / `alt` / `opt` / `par` frame.
+#[derive(Debug, Clone)]
+pub struct Fragment {
+    /// The fragment's id in the layout.
+    pub id: Str,
+    /// The frame the fragment encloses.
+    pub frame: Rect,
+    /// The `y` of each divider inside the frame, such as an `else` boundary.
+    pub dividers: Vec<f32>,
+    /// The keyword tab and any guard conditions.
+    pub labels: Vec<Label>,
+}
+
+/// A sequence diagram participant's vertical line.
+#[derive(Debug, Clone)]
+pub struct Lifeline {
+    /// The participant this line belongs to.
+    pub id: Str,
+    /// The line's `x`, in diagram coordinates.
+    pub x: f32,
+    /// Where the line starts.
+    pub top: f32,
+    /// Where the line ends.
+    pub bottom: f32,
+}

--- a/components/data/mermaid/src/lib.rs
+++ b/components/data/mermaid/src/lib.rs
@@ -1,0 +1,184 @@
+//! Mermaid diagrams, drawn by `WaterUI`.
+//!
+//! ```rust
+//! use waterui::prelude::*;
+//! use waterui_mermaid::mermaid;
+//!
+//! # fn diagram() -> impl View {
+//! mermaid(
+//!     "flowchart TD\n  A[Start] --> B{Ready?}\n  B -->|yes| C[Go]\n  B -->|no| A",
+//! )
+//! # }
+//! ```
+//!
+//! # How a diagram gets on screen
+//!
+//! Mermaid source is parsed and laid out by [`merman`](https://github.com/Latias94/merman),
+//! which tracks upstream Mermaid's own grammar and geometry. Everything after
+//! that is this crate's:
+//!
+//! - **Layout is measured with `WaterUI`'s text engine.** `merman` sizes every
+//!   node and every label through a host-supplied measurer, and this crate
+//!   supplies one backed by the same `parley` engine and the same system fonts
+//!   that draw the labels. Without it, boxes would be sized from a browser
+//!   compatibility profile and the glyphs inside them drawn from ours, and the
+//!   text would not fit.
+//! - **Geometry is drawn through `Scene2D`.** Node outlines, subgraph frames and
+//!   routed connectors are vector paths on the shared scene contract, so one
+//!   drawing path serves every backend.
+//! - **Text is not drawn into the scene.** Labels are real `text()` views placed
+//!   into the boxes layout reserved for them, which is what gives a diagram a
+//!   meaningful accessibility tree and the platform's own text rendering.
+//! - **Colours come from theme tokens.** A diagram follows a light/dark switch
+//!   and a custom accent because it reads the same tokens every other component
+//!   reads, never Mermaid's CSS themes.
+//!
+//! A diagram is drawn at its natural size. Scaling it to fit would break the
+//! agreement between a reserved box and the glyphs in it, so a diagram larger
+//! than its container is the container's to scroll.
+
+#![doc(html_logo_url = "https://raw.githubusercontent.com/water-rs/waterui/main/assets/logo.svg")]
+
+extern crate alloc;
+
+use alloc::format;
+use alloc::vec::Vec;
+
+use nami::SignalExt as _;
+use waterui_canvas::Canvas;
+use waterui_core::layout::{Layout, Point, ProposalSize, Rect, Size, StretchAxis, SubView};
+use waterui_core::{AnyView, Environment, View, resolve::Resolvable as _};
+use waterui_layout::container::FixedContainer;
+use waterui_str::Str;
+use waterui_text::text;
+
+mod draw;
+mod engine;
+mod label;
+mod layout;
+mod measure;
+mod shape;
+mod theme;
+
+pub use engine::MermaidError;
+pub use layout::{
+    Cluster, DiagramLayout, Edge, EdgeMarker, EdgeStroke, Emphasis, Fragment, Label, Lifeline,
+    Node, NodeShape, UnsupportedShape,
+};
+pub use theme::{DiagramPalette, Palette};
+
+/// A Mermaid diagram.
+///
+/// See the [crate documentation](crate) for what the rendering pipeline does
+/// and does not do.
+#[derive(Debug, Clone)]
+pub struct Mermaid {
+    source: Str,
+}
+
+impl Mermaid {
+    /// Creates a diagram from Mermaid source.
+    ///
+    /// The source carries its own diagram type in its first line, so a
+    /// `flowchart` and a `sequenceDiagram` are both just source here.
+    #[must_use]
+    pub fn new(source: impl Into<Str>) -> Self {
+        Self {
+            source: source.into(),
+        }
+    }
+}
+
+/// Convenience constructor for [`Mermaid`]. Equivalent to [`Mermaid::new`].
+#[must_use]
+pub fn mermaid(source: impl Into<Str>) -> Mermaid {
+    Mermaid::new(source)
+}
+
+impl View for Mermaid {
+    fn body(self, env: &Environment) -> impl View {
+        match engine::render(&self.source) {
+            Ok(diagram) => AnyView::new(drawn(&diagram, env)),
+            Err(error) => AnyView::new(undrawable(&error)),
+        }
+    }
+
+    fn stretch_axis(&self) -> StretchAxis {
+        StretchAxis::None
+    }
+}
+
+/// The scene and the labels of a diagram that laid out successfully.
+fn drawn(diagram: &DiagramLayout, env: &Environment) -> impl View + use<> {
+    let palette = DiagramPalette.resolve(env).computed();
+    let scene = {
+        let diagram = diagram.clone();
+        Canvas::with_signal(palette, move |ctx, palette| {
+            draw::diagram(ctx, &diagram, &palette, Point::zero());
+        })
+    };
+
+    let mut cells: Vec<AnyView> = Vec::with_capacity(diagram.nodes.len() + 1);
+    cells.push(AnyView::new(scene));
+    cells.extend(diagram.labels().map(|label| {
+        AnyView::new(FixedContainer::new(
+            label::Placement::new(label.frame),
+            (label::LabelView::new(label.clone(), diagram.font_size),),
+        ))
+    }));
+
+    FixedContainer::new(Placement::new(diagram), cells)
+}
+
+/// What is shown when a diagram cannot be drawn.
+///
+/// Mermaid itself renders a broken diagram as a visible error, and so does this:
+/// a fence that silently disappears is a worse outcome than one that says what
+/// is wrong with it.
+fn undrawable(error: &MermaidError) -> impl View + use<> {
+    text(Str::from(format!("Mermaid: {error}")))
+}
+
+/// Places a diagram's scene and its labels.
+///
+/// The scene fills the diagram's natural size, and each label sits in the box
+/// the diagram reserved for it. Both are positioned in the same coordinates the
+/// geometry was laid out in, so nothing has to be scaled or corrected.
+#[derive(Debug)]
+struct Placement {
+    size: Size,
+    labels: Vec<Rect>,
+}
+
+impl Placement {
+    fn new(diagram: &DiagramLayout) -> Self {
+        Self {
+            size: diagram.size,
+            labels: diagram.labels().map(|label| label.frame).collect(),
+        }
+    }
+}
+
+impl Layout for Placement {
+    fn size_that_fits(&self, _proposal: ProposalSize, _children: &[&dyn SubView]) -> Size {
+        self.size
+    }
+
+    fn place(&self, bounds: Rect, children: &[&dyn SubView]) -> Vec<Rect> {
+        let origin = bounds.origin();
+        let mut frames = Vec::with_capacity(children.len());
+        // The scene, covering the whole diagram.
+        frames.push(Rect::new(origin, self.size));
+        frames.extend(self.labels.iter().map(|frame| {
+            Rect::new(
+                Point::new(frame.x() + origin.x, frame.y() + origin.y),
+                *frame.size(),
+            )
+        }));
+        frames
+    }
+
+    fn stretch_axis(&self, _children: &[StretchAxis]) -> StretchAxis {
+        StretchAxis::None
+    }
+}

--- a/components/data/mermaid/src/measure.rs
+++ b/components/data/mermaid/src/measure.rs
@@ -1,0 +1,204 @@
+//! Diagram layout measured with the same text engine that draws the labels.
+//!
+//! `merman-render` sizes every node, every edge label and every participant box
+//! from a [`TextMeasurer`], and ships built-in profiles that approximate a
+//! browser's metrics. Those profiles are the right default for a headless SVG
+//! writer, which has no font stack to ask. We do have one — the labels in a
+//! rendered diagram are `WaterUI` text views shaped by `parley` — so leaving the
+//! built-in profile installed would size boxes from one set of metrics and paint
+//! glyphs with another, and the text would not fit the box that was reserved
+//! for it.
+//!
+//! So the measurer here is the same `parley` engine, reading the same system
+//! font source `waterui-canvas` reads.
+
+use alloc::sync::Arc;
+use std::sync::Mutex;
+
+use merman_render::environment::{
+    MeasurementProfileId, TextMeasurementPolicy, TextMeasurementProfile,
+    TextMeasurementProfileIdentity,
+};
+use merman_render::text::{TextMeasurer, TextMetrics, TextStyle};
+use parley::{
+    Alignment, AlignmentOptions, FontContext, FontFamily, FontStyle, FontWeight, LayoutContext,
+    StyleProperty,
+};
+
+/// The identity `merman-render` records against measurements taken here.
+///
+/// It is provenance, not configuration: a layout carries the name of whatever
+/// measured it, so a diagram laid out with our metrics is never mistaken for one
+/// laid out against a browser-compatibility profile.
+const PROFILE: &str = "waterui-parley";
+
+/// Text measurement backed by `parley` and the system font source.
+///
+/// # Threading
+///
+/// `merman-render` takes its measurer as `Arc<dyn TextMeasurer + Send + Sync>`,
+/// while `parley`'s contexts are `Send` but not `Sync`. The mutex here is what
+/// bridges the two. It is never contended: layout runs on the thread that owns
+/// the view, one diagram at a time, and the lock is taken and released inside a
+/// single `measure` call.
+struct ParleyMeasurer {
+    contexts: Mutex<Contexts>,
+}
+
+#[derive(Default)]
+struct Contexts {
+    font: FontContext,
+    layout: LayoutContext<[u8; 4]>,
+}
+
+impl core::fmt::Debug for ParleyMeasurer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("ParleyMeasurer")
+    }
+}
+
+impl TextMeasurer for ParleyMeasurer {
+    #[expect(
+        clippy::significant_drop_tightening,
+        reason = "the guard is already as tight as it can be: `font` and `layout` are borrowed out of it and stay borrowed for as long as the builder exists, so dropping it earlier does not compile"
+    )]
+    fn measure(&self, text: &str, style: &TextStyle) -> TextMetrics {
+        if text.is_empty() {
+            return TextMetrics {
+                width: 0.0,
+                height: 0.0,
+                line_count: 0,
+            };
+        }
+
+        // The guard is scoped to shaping alone. `Layout` is owned once it is
+        // built, so line breaking and measurement need no access to the shared
+        // contexts and the lock is released before them.
+        let mut built = {
+            let mut contexts = self
+                .contexts
+                .lock()
+                .expect("mermaid text measurement mutex was poisoned by a panic while measuring");
+            let Contexts { font, layout } = &mut *contexts;
+
+            let mut builder = layout.ranged_builder(font, text, 1.0, true);
+            builder.push_default(StyleProperty::FontSize(f32::from_f64_lossless(
+                style.font_size,
+            )));
+            if let Some(family) = style.font_family.as_deref() {
+                // Mermaid spells its font family as a CSS stack. `parley`
+                // resolves one family at a time, so the first entry that names
+                // a family is what we ask for and the system source falls back
+                // from there.
+                if let Some(first) = css_font_stack_head(family) {
+                    builder.push_default(StyleProperty::FontFamily(FontFamily::named(first)));
+                }
+            }
+            if let Some(weight) = style.font_weight.as_deref() {
+                builder.push_default(StyleProperty::FontWeight(parse_weight(weight)));
+            }
+            if let Some(font_style) = style.font_style.as_deref() {
+                builder.push_default(StyleProperty::FontStyle(parse_style(font_style)));
+            }
+
+            builder.build(text)
+        };
+        built.break_all_lines(None);
+        built.align(Alignment::Start, AlignmentOptions::default());
+
+        TextMetrics {
+            width: f64::from(built.full_width()),
+            height: f64::from(built.height()),
+            line_count: built.len().max(1),
+        }
+    }
+}
+
+/// The first named family in a CSS font stack.
+///
+/// Generic families (`sans-serif` and friends) are not names `parley` can look
+/// up, so they are skipped in favour of whatever concrete family follows — and
+/// if the stack is nothing but generics, the system default is the right answer
+/// anyway.
+fn css_font_stack_head(stack: &str) -> Option<&str> {
+    stack
+        .split(',')
+        .map(|family| family.trim().trim_matches(['"', '\'']))
+        .find(|family| {
+            !family.is_empty()
+                && !matches!(
+                    *family,
+                    "serif"
+                        | "sans-serif"
+                        | "monospace"
+                        | "cursive"
+                        | "fantasy"
+                        | "system-ui"
+                        | "ui-serif"
+                        | "ui-sans-serif"
+                        | "ui-monospace"
+                        | "ui-rounded"
+                )
+        })
+}
+
+/// Parses a CSS font weight the way Mermaid's style strings spell it.
+///
+/// An unrecognised spelling is `normal`, matching CSS: a weight is a
+/// presentation hint, and refusing to draw a diagram because a stylesheet said
+/// `font-weight: bolder` would be the wrong trade.
+fn parse_weight(weight: &str) -> FontWeight {
+    match weight.trim() {
+        "bold" => FontWeight::BOLD,
+        "lighter" => FontWeight::LIGHT,
+        "bolder" => FontWeight::EXTRA_BOLD,
+        numeric => numeric
+            .parse::<f32>()
+            .map_or(FontWeight::NORMAL, FontWeight::new),
+    }
+}
+
+/// Parses a CSS font style, defaulting to upright for the same reason as
+/// [`parse_weight`].
+fn parse_style(style: &str) -> FontStyle {
+    match style.trim() {
+        "italic" => FontStyle::Italic,
+        "oblique" => FontStyle::Oblique(None),
+        _ => FontStyle::Normal,
+    }
+}
+
+/// Lossless `f64` -> `f32` for the font sizes Mermaid deals in.
+trait FromF64Lossless {
+    fn from_f64_lossless(value: f64) -> Self;
+}
+
+impl FromF64Lossless for f32 {
+    #[expect(
+        clippy::cast_possible_truncation,
+        reason = "font sizes are small positive magnitudes; f32 represents every one Mermaid emits"
+    )]
+    fn from_f64_lossless(value: f64) -> Self {
+        value as Self
+    }
+}
+
+/// The measurement policy a diagram is laid out under.
+///
+/// Installed on the render environment for every family, so a flowchart's node
+/// boxes and a sequence diagram's participant boxes are sized by the same
+/// engine that will draw their labels.
+pub fn policy() -> TextMeasurementPolicy {
+    let identity = TextMeasurementProfileIdentity::new(
+        MeasurementProfileId::new(PROFILE).expect("the profile id is a valid identifier"),
+        env!("CARGO_PKG_VERSION"),
+    )
+    .expect("the profile identity is well formed");
+
+    TextMeasurementPolicy::uniform(TextMeasurementProfile::new(
+        identity,
+        Arc::new(ParleyMeasurer {
+            contexts: Mutex::new(Contexts::default()),
+        }),
+    ))
+}

--- a/components/data/mermaid/src/shape.rs
+++ b/components/data/mermaid/src/shape.rs
@@ -1,0 +1,337 @@
+//! Node outlines.
+//!
+//! Every outline is built from the node's laid-out frame, so the shape that
+//! gets drawn is exactly the box Mermaid reserved for it. The proportions that
+//! are not derivable from the frame — a stadium's end radius, a cylinder's cap
+//! depth, a hexagon's slant — follow Mermaid's own renderer, because the box was
+//! sized on that assumption and a different slant would put the label outside
+//! its shape.
+
+use alloc::vec;
+use alloc::vec::Vec;
+
+use waterui_canvas::Path;
+use waterui_core::layout::{Point, Rect, Size};
+
+use crate::layout::NodeShape;
+
+/// Corner radius of a rounded rectangle, as Mermaid draws it.
+const CORNER_RADIUS: f32 = 5.0;
+/// Inset of a subroutine's inner vertical rules from each end.
+const SUBROUTINE_INSET: f32 = 8.0;
+/// Horizontal slant of a hexagon and the parallelograms, as a fraction of the
+/// frame's height.
+const SLANT_RATIO: f32 = 0.5;
+/// A cylinder's cap height, as a fraction of the frame's height.
+const CYLINDER_CAP_RATIO: f32 = 0.12;
+/// The gap between the two rings of a double circle.
+const DOUBLE_CIRCLE_GAP: f32 = 5.0;
+/// How deep the notch of an asymmetric node cuts in, relative to its height.
+const ASYMMETRIC_NOTCH_RATIO: f32 = 0.35;
+/// The share of an actor's box its stick figure occupies, leaving the rest for
+/// the participant's name written underneath.
+const ACTOR_FIGURE_SHARE: f32 = 0.62;
+
+/// A node's drawable outline.
+pub struct Outline {
+    /// The shape to fill and then stroke. `None` for a node that has no
+    /// outline of its own, such as a bare text node.
+    pub body: Option<Path>,
+    /// Strokes drawn over the filled body.
+    pub details: Vec<Path>,
+}
+
+impl Outline {
+    /// An outline that is filled and stroked, with nothing drawn over it.
+    const fn plain(body: Path) -> Self {
+        Self {
+            body: Some(body),
+            details: Vec::new(),
+        }
+    }
+}
+
+/// Where a shape leaves room for its label.
+///
+/// Most shapes centre their label in their whole box. An actor does not: its box
+/// holds a stick figure with the participant's name written underneath, so
+/// centring would write the name across the figure's chest.
+#[must_use]
+pub fn label_area(shape: NodeShape, frame: Rect) -> Rect {
+    if shape == NodeShape::Actor {
+        let figure = frame.height() * ACTOR_FIGURE_SHARE;
+        Rect::new(
+            Point::new(frame.x(), frame.y() + figure),
+            Size::new(frame.width(), frame.height() - figure),
+        )
+    } else {
+        frame
+    }
+}
+
+/// Builds the outline of one node.
+///
+/// Returns the outline to fill and stroke, plus any inner strokes the shape
+/// draws on top of its own fill — a subroutine's two rules, a cylinder's rim,
+/// the inner ring of a double circle.
+#[must_use]
+pub fn outline(shape: NodeShape, frame: Rect) -> Outline {
+    match shape {
+        NodeShape::Rectangle | NodeShape::Participant | NodeShape::Note => {
+            let mut path = Path::new();
+            path.rect(frame);
+            Outline::plain(path)
+        }
+        NodeShape::RoundedRectangle => Outline::plain(rounded_rect(frame, CORNER_RADIUS)),
+        NodeShape::Stadium => Outline::plain(rounded_rect(frame, frame.height() / 2.0)),
+        NodeShape::Subroutine => subroutine(frame),
+        NodeShape::Cylinder => cylinder(frame),
+        NodeShape::Circle | NodeShape::DoubleCircle => {
+            round(frame, shape == NodeShape::DoubleCircle)
+        }
+        NodeShape::Asymmetric
+        | NodeShape::Diamond
+        | NodeShape::Hexagon
+        | NodeShape::ParallelogramRight
+        | NodeShape::ParallelogramLeft
+        | NodeShape::Trapezoid
+        | NodeShape::TrapezoidInverted => Outline::plain(polygon(&angular(shape, frame))),
+        NodeShape::Text => Outline {
+            body: None,
+            details: Vec::new(),
+        },
+        NodeShape::Actor => actor(frame),
+    }
+}
+
+/// `A[[text]]` — a rectangle with a vertical rule inset from each end.
+fn subroutine(frame: Rect) -> Outline {
+    let mut path = Path::new();
+    path.rect(frame);
+
+    let details = [SUBROUTINE_INSET, frame.width() - SUBROUTINE_INSET]
+        .into_iter()
+        .map(|inset| {
+            let mut rule = Path::new();
+            rule.move_to(Point::new(frame.x() + inset, frame.y()));
+            rule.line_to(Point::new(frame.x() + inset, frame.max_y()));
+            rule
+        })
+        .collect();
+
+    Outline {
+        body: Some(path),
+        details,
+    }
+}
+
+/// `A[(text)]` — a database cylinder, drawn as a body with a visible top rim.
+fn cylinder(frame: Rect) -> Outline {
+    let (x, y) = (frame.x(), frame.y());
+    let (right, bottom) = (frame.max_x(), frame.max_y());
+    let cap = frame.height() * CYLINDER_CAP_RATIO;
+
+    let mut path = Path::new();
+    path.move_to(Point::new(x, y + cap));
+    path.line_to(Point::new(x, bottom - cap));
+    path.bezier_to(
+        Point::new(x, bottom),
+        Point::new(right, bottom),
+        Point::new(right, bottom - cap),
+    );
+    path.line_to(Point::new(right, y + cap));
+    path.bezier_to(
+        Point::new(right, y),
+        Point::new(x, y),
+        Point::new(x, y + cap),
+    );
+    path.close();
+
+    // The rim is the far edge of the top cap, drawn over the fill.
+    let far_edge = cap.mul_add(2.0, y);
+    let mut rim = Path::new();
+    rim.move_to(Point::new(x, y + cap));
+    rim.bezier_to(
+        Point::new(x, far_edge),
+        Point::new(right, far_edge),
+        Point::new(right, y + cap),
+    );
+
+    Outline {
+        body: Some(path),
+        details: vec![rim],
+    }
+}
+
+/// `A((text))` and `A(((text)))`.
+fn round(frame: Rect, doubled: bool) -> Outline {
+    let radius = frame.width().min(frame.height()) / 2.0;
+    let mut path = Path::new();
+    circle(&mut path, frame.center(), radius);
+
+    let details = if doubled {
+        let mut inner = Path::new();
+        circle(&mut inner, frame.center(), radius - DOUBLE_CIRCLE_GAP);
+        vec![inner]
+    } else {
+        Vec::new()
+    };
+
+    Outline {
+        body: Some(path),
+        details,
+    }
+}
+
+/// The corners of the straight-edged shapes, each a closed polygon over the
+/// frame.
+fn angular(shape: NodeShape, frame: Rect) -> Vec<Point> {
+    let (x, y) = (frame.x(), frame.y());
+    let (right, bottom) = (frame.max_x(), frame.max_y());
+    let slant = frame.height() * SLANT_RATIO;
+    let (mid_x, mid_y) = (frame.mid_x(), frame.mid_y());
+
+    match shape {
+        NodeShape::Asymmetric => {
+            let notch = frame.height() * ASYMMETRIC_NOTCH_RATIO;
+            vec![
+                Point::new(x, y),
+                Point::new(right, y),
+                Point::new(right, bottom),
+                Point::new(x, bottom),
+                Point::new(x + notch, mid_y),
+            ]
+        }
+        NodeShape::Diamond => vec![
+            Point::new(mid_x, y),
+            Point::new(right, mid_y),
+            Point::new(mid_x, bottom),
+            Point::new(x, mid_y),
+        ],
+        NodeShape::Hexagon => vec![
+            Point::new(x + slant, y),
+            Point::new(right - slant, y),
+            Point::new(right, mid_y),
+            Point::new(right - slant, bottom),
+            Point::new(x + slant, bottom),
+            Point::new(x, mid_y),
+        ],
+        NodeShape::ParallelogramRight => vec![
+            Point::new(x + slant, y),
+            Point::new(right, y),
+            Point::new(right - slant, bottom),
+            Point::new(x, bottom),
+        ],
+        NodeShape::ParallelogramLeft => vec![
+            Point::new(x, y),
+            Point::new(right - slant, y),
+            Point::new(right, bottom),
+            Point::new(x + slant, bottom),
+        ],
+        NodeShape::Trapezoid => vec![
+            Point::new(x + slant, y),
+            Point::new(right - slant, y),
+            Point::new(right, bottom),
+            Point::new(x, bottom),
+        ],
+        NodeShape::TrapezoidInverted => vec![
+            Point::new(x, y),
+            Point::new(right, y),
+            Point::new(right - slant, bottom),
+            Point::new(x + slant, bottom),
+        ],
+        other => unreachable!("{other:?} is not a straight-edged shape"),
+    }
+}
+
+/// A closed path through `points`.
+fn polygon(points: &[Point]) -> Path {
+    let mut path = Path::new();
+    let Some((first, rest)) = points.split_first() else {
+        return path;
+    };
+    path.move_to(*first);
+    for point in rest {
+        path.line_to(*point);
+    }
+    path.close();
+    path
+}
+
+/// A full circle of `radius` centred on `centre`.
+fn circle(path: &mut Path, centre: Point, radius: f32) {
+    path.ellipse(
+        centre,
+        Size::new(radius, radius),
+        0.0,
+        0.0,
+        core::f32::consts::TAU,
+        false,
+    );
+}
+
+/// A rectangle whose corners are rounded by `radius`, clamped so a radius
+/// larger than half the shorter side degenerates into a stadium rather than
+/// self-intersecting.
+fn rounded_rect(frame: Rect, radius: f32) -> Path {
+    let radius = radius.min(frame.width() / 2.0).min(frame.height() / 2.0);
+    let (x, y) = (frame.x(), frame.y());
+    let (right, bottom) = (frame.max_x(), frame.max_y());
+
+    let mut path = Path::new();
+    path.move_to(Point::new(x + radius, y));
+    path.line_to(Point::new(right - radius, y));
+    path.arc_to(Point::new(right, y), Point::new(right, y + radius), radius);
+    path.line_to(Point::new(right, bottom - radius));
+    path.arc_to(
+        Point::new(right, bottom),
+        Point::new(right - radius, bottom),
+        radius,
+    );
+    path.line_to(Point::new(x + radius, bottom));
+    path.arc_to(
+        Point::new(x, bottom),
+        Point::new(x, bottom - radius),
+        radius,
+    );
+    path.line_to(Point::new(x, y + radius));
+    path.arc_to(Point::new(x, y), Point::new(x + radius, y), radius);
+    path.close();
+    path
+}
+
+/// The stick figure a sequence diagram draws for an `actor`.
+///
+/// The figure takes the upper part of the box; [`label_area`] hands the rest to
+/// the participant's name, which is how Mermaid draws it.
+fn actor(frame: Rect) -> Outline {
+    let (x, y) = (frame.x(), frame.y());
+    let (w, h) = (frame.width(), frame.height() * ACTOR_FIGURE_SHARE);
+    let head_radius = (w.min(h) * 0.18).max(1.0);
+    let centre_x = frame.mid_x();
+    let shoulders = head_radius.mul_add(2.0, y);
+    let hips = h.mul_add(0.62, y);
+    let arms = (hips - shoulders).mul_add(0.3, shoulders);
+
+    let mut head = Path::new();
+    circle(
+        &mut head,
+        Point::new(centre_x, y + head_radius),
+        head_radius,
+    );
+
+    let mut body = Path::new();
+    body.move_to(Point::new(centre_x, shoulders));
+    body.line_to(Point::new(centre_x, hips));
+    body.move_to(Point::new(w.mul_add(0.2, x), arms));
+    body.line_to(Point::new(w.mul_add(0.8, x), arms));
+    body.move_to(Point::new(centre_x, hips));
+    body.line_to(Point::new(w.mul_add(0.25, x), y + h));
+    body.move_to(Point::new(centre_x, hips));
+    body.line_to(Point::new(w.mul_add(0.75, x), y + h));
+
+    Outline {
+        body: Some(head),
+        details: vec![body],
+    }
+}

--- a/components/data/mermaid/src/theme.rs
+++ b/components/data/mermaid/src/theme.rs
@@ -1,0 +1,59 @@
+//! The colours a diagram is drawn in.
+//!
+//! Mermaid carries its own theme, expressed as CSS. We do not use it. A diagram
+//! embedded in a `WaterUI` application is part of that application's surface,
+//! and it reads the same theme tokens every other component reads, so it
+//! follows a light/dark switch and a custom accent without knowing either
+//! happened. This is Principle 6: the framework owns default appearance, and a
+//! component that hard-codes its own colours is a bug.
+
+use nami::{Signal, SignalExt as _};
+use waterui_core::{Environment, resolve::Resolvable};
+use waterui_graphics::color::{
+    BorderColor, ForegroundColor, MutedForegroundColor, ResolvedColor, SurfaceColor,
+    SurfaceVariantColor,
+};
+
+/// The colours one diagram is drawn with.
+#[derive(Debug, Clone, Copy)]
+pub struct Palette {
+    /// Fill of a node box.
+    pub node_fill: ResolvedColor,
+    /// Outline of a node box.
+    pub node_border: ResolvedColor,
+    /// Connectors and their decorations.
+    pub edge: ResolvedColor,
+    /// Fill of a subgraph or participant frame.
+    pub cluster: ResolvedColor,
+    /// Frame outlines and dividers.
+    pub border: ResolvedColor,
+    /// Label text, for the rare label the scene draws itself.
+    pub foreground: ResolvedColor,
+}
+
+/// The environment key that resolves a [`Palette`].
+#[derive(Debug, Clone, Copy)]
+pub struct DiagramPalette;
+
+impl Resolvable for DiagramPalette {
+    type Resolved = Palette;
+
+    fn resolve(&self, env: &Environment) -> impl Signal<Output = Self::Resolved> {
+        SurfaceColor
+            .resolve(env)
+            .zip(&BorderColor.resolve(env))
+            .zip(&MutedForegroundColor.resolve(env))
+            .zip(&SurfaceVariantColor.resolve(env))
+            .zip(&ForegroundColor.resolve(env))
+            .map(
+                |((((surface, border), muted), surface_variant), foreground)| Palette {
+                    node_fill: surface,
+                    node_border: border,
+                    edge: muted,
+                    cluster: surface_variant,
+                    border,
+                    foreground,
+                },
+            )
+    }
+}

--- a/components/data/mermaid/tests/e2e_flowchart.rs
+++ b/components/data/mermaid/tests/e2e_flowchart.rs
@@ -1,0 +1,172 @@
+//! What a rendered flowchart owes its reader.
+//!
+//! The assertions here are all about text, which is the point: a Mermaid
+//! diagram drawn as one opaque picture would pass a "did anything get painted"
+//! check and fail every one of these. Each node label, each edge label and each
+//! subgraph title has to reach the accessibility tree as its own node, at the
+//! position the geometry put it.
+
+use hydrolysis_m3::install;
+use waterui_mermaid::mermaid;
+use waterui_testing::{OffscreenApp, Role, ui as test_ui};
+
+const DECISION: &str = "\
+flowchart TD
+    A[Start] --> B{Ready?}
+    B -->|yes| C([Go])
+    B -->|no| D[(Wait)]
+    D --> A
+";
+
+const SUBGRAPHS: &str = "\
+flowchart LR
+    subgraph Ingest
+        A[Read] --> B[Parse]
+    end
+    subgraph Serve
+        C[Render]
+    end
+    B --> C
+";
+
+fn app(source: &'static str) -> OffscreenApp {
+    test_ui()
+        .viewport(800, 600)
+        .theme(install)
+        .mount_offscreen(move || mermaid(source))
+}
+
+#[core::prelude::v1::test]
+fn every_node_label_is_its_own_accessible_node() {
+    let mut app = app(DECISION);
+    for label in ["Start", "Ready?", "Go", "Wait"] {
+        app.query().role(Role::LABEL).label(label).assert_exists();
+    }
+}
+
+#[core::prelude::v1::test]
+fn edge_labels_are_accessible_too() {
+    let mut app = app(DECISION);
+    for label in ["yes", "no"] {
+        app.query().role(Role::LABEL).label(label).assert_exists();
+    }
+}
+
+#[core::prelude::v1::test]
+fn subgraph_titles_are_accessible() {
+    let mut app = app(SUBGRAPHS);
+    for label in ["Ingest", "Serve", "Read", "Parse", "Render"] {
+        app.query().role(Role::LABEL).label(label).assert_exists();
+    }
+}
+
+/// A `flowchart TD` puts its first node above the ones it points at, and a
+/// `flowchart LR` puts it to their left. Asserting on the labels' own bounds is
+/// how we know the geometry reached the views rather than every label piling up
+/// at the origin.
+#[core::prelude::v1::test]
+fn layout_direction_reaches_the_placed_labels() {
+    let mut down = app(DECISION);
+    let start = down
+        .query()
+        .role(Role::LABEL)
+        .label("Start")
+        .single()
+        .bounds();
+    let ready = down
+        .query()
+        .role(Role::LABEL)
+        .label("Ready?")
+        .single()
+        .bounds();
+    assert!(
+        start.y() + start.height() <= ready.y(),
+        "`flowchart TD` must stack downward: Start {start:?} is not above Ready? {ready:?}"
+    );
+
+    let mut across = app(SUBGRAPHS);
+    let read = across
+        .query()
+        .role(Role::LABEL)
+        .label("Read")
+        .single()
+        .bounds();
+    let parse = across
+        .query()
+        .role(Role::LABEL)
+        .label("Parse")
+        .single()
+        .bounds();
+    assert!(
+        read.x() + read.width() <= parse.x(),
+        "`flowchart LR` must flow rightward: Read {read:?} is not left of Parse {parse:?}"
+    );
+}
+
+/// The whole reason this crate installs its own text measurer: a label has to
+/// fit inside the box layout reserved for it. If the two disagreed — boxes sized
+/// from one set of font metrics, glyphs drawn from another — the longer a label
+/// is, the further its bounds would spill past its node.
+#[core::prelude::v1::test]
+fn labels_fit_the_boxes_that_were_measured_for_them() {
+    const WIDTHS: &str = "\
+flowchart TD
+    A[i] --> B[a considerably longer label than the one above it]
+";
+    let mut app = test_ui()
+        .viewport(900, 400)
+        .theme(install)
+        .mount_offscreen(|| mermaid(WIDTHS));
+
+    let short = app.query().role(Role::LABEL).label("i").single().bounds();
+    let long = app
+        .query()
+        .role(Role::LABEL)
+        .label("a considerably longer label than the one above it")
+        .single()
+        .bounds();
+
+    assert!(
+        long.width() > short.width(),
+        "the longer label should measure wider: {long:?} vs {short:?}"
+    );
+    // Both labels are centred in their node, and both nodes are centred on the
+    // same column, so their centres agree to within rounding.
+    assert!(
+        (long.center().0 - short.center().0).abs() < 1.0,
+        "labels on one column should share a centre: {long:?} vs {short:?}"
+    );
+}
+
+/// A diagram that cannot be laid out says so, in words, rather than rendering
+/// as an empty box.
+#[core::prelude::v1::test]
+fn a_broken_diagram_reports_itself() {
+    let mut app = test_ui()
+        .viewport(600, 200)
+        .theme(install)
+        .mount_offscreen(|| mermaid("this is not a diagram"));
+
+    assert!(
+        !app.query().role(Role::LABEL).all().is_empty(),
+        "an undrawable diagram must render its error, not nothing"
+    );
+}
+
+/// Exports the diagrams as PNGs so a person — or an agent with eyes — can look
+/// at them. The assertions above cover the semantics; only a picture covers
+/// whether the arrowheads point the right way and the diamond is a diamond.
+///
+/// Run with `--no-capture` to see where the files landed.
+#[core::prelude::v1::test]
+fn export_flowchart_images_for_visual_review() {
+    for (case, source) in [("decision", DECISION), ("subgraphs", SUBGRAPHS)] {
+        let mut app = test_ui()
+            .viewport(800, 600)
+            .theme(install)
+            .mount_offscreen(move || mermaid(source));
+        let captured = app.capture_snapshot("mermaid", case, "rendered");
+        assert!(captured.path().is_file());
+        println!("{}: {}", case, captured.path().display());
+    }
+}

--- a/components/data/mermaid/tests/e2e_sequence.rs
+++ b/components/data/mermaid/tests/e2e_sequence.rs
@@ -1,0 +1,178 @@
+//! What a rendered sequence diagram owes its reader.
+//!
+//! A sequence diagram is mostly text — participant names, message labels,
+//! fragment keywords and their guards — so almost everything worth asserting is
+//! an accessibility node. The geometry assertions are the ones that catch a
+//! label placed at the origin instead of on its message.
+
+use hydrolysis_m3::install;
+use waterui_mermaid::mermaid;
+use waterui_testing::{OffscreenApp, Role, ui as test_ui};
+
+const CONVERSATION: &str = "\
+sequenceDiagram
+    participant Alice
+    actor Bob
+    Alice->>Bob: hello
+    Bob-->>Alice: hi
+    Note right of Bob: thinking
+";
+
+const FRAGMENTS: &str = "\
+sequenceDiagram
+    participant Alice
+    participant Bob
+    loop every minute
+        Alice->>Bob: poll
+    end
+    alt is ready
+        Bob-->>Alice: yes
+    else is not
+        Bob-->>Alice: no
+    end
+";
+
+fn app(source: &'static str) -> OffscreenApp {
+    test_ui()
+        .viewport(900, 700)
+        .theme(install)
+        .mount_offscreen(move || mermaid(source))
+}
+
+#[core::prelude::v1::test]
+fn participants_and_messages_are_accessible() {
+    let mut app = app(CONVERSATION);
+    for label in ["Alice", "Bob", "hello", "hi", "thinking"] {
+        app.query().role(Role::LABEL).label(label).assert_exists();
+    }
+}
+
+/// A participant is drawn twice — a header at the top and one at the bottom —
+/// so its name appears twice, and the two must be at the same `x` and different
+/// `y`. Getting one of the two headers wrong is invisible to a "does the name
+/// exist" check.
+#[core::prelude::v1::test]
+fn a_participant_has_a_header_at_each_end_of_its_lifeline() {
+    let mut app = app(CONVERSATION);
+    let headers: Vec<_> = app
+        .query()
+        .role(Role::LABEL)
+        .label("Alice")
+        .all()
+        .iter()
+        .map(waterui_testing::ElementRef::bounds)
+        .collect();
+
+    assert_eq!(
+        headers.len(),
+        2,
+        "a participant should be labelled at both ends of its lifeline, got {headers:?}"
+    );
+    assert!(
+        (headers[0].center().0 - headers[1].center().0).abs() < 1.0,
+        "the two headers should share a column: {headers:?}"
+    );
+    assert!(
+        (headers[0].y() - headers[1].y()).abs() > 10.0,
+        "the two headers should be at opposite ends: {headers:?}"
+    );
+}
+
+/// Messages run down the page in source order.
+#[core::prelude::v1::test]
+fn messages_are_ordered_down_the_page() {
+    let mut app = app(CONVERSATION);
+    let hello = app
+        .query()
+        .role(Role::LABEL)
+        .label("hello")
+        .single()
+        .bounds();
+    let hi = app.query().role(Role::LABEL).label("hi").single().bounds();
+    assert!(
+        hello.y() < hi.y(),
+        "`hello` is sent before `hi`, so it belongs above it: {hello:?} vs {hi:?}"
+    );
+}
+
+/// A message label sits between the two participants it runs between, not at
+/// the diagram's origin.
+#[core::prelude::v1::test]
+fn a_message_label_sits_between_its_participants() {
+    let mut app = app(CONVERSATION);
+    let alice = app
+        .query()
+        .role(Role::LABEL)
+        .label("Alice")
+        .all()
+        .iter()
+        .next()
+        .expect("Alice is labelled")
+        .bounds();
+    let bob = app
+        .query()
+        .role(Role::LABEL)
+        .label("Bob")
+        .all()
+        .iter()
+        .next()
+        .expect("Bob is labelled")
+        .bounds();
+    let hello = app
+        .query()
+        .role(Role::LABEL)
+        .label("hello")
+        .single()
+        .bounds();
+
+    let (left, right) = if alice.center().0 < bob.center().0 {
+        (alice, bob)
+    } else {
+        (bob, alice)
+    };
+    assert!(
+        hello.center().0 > left.center().0 && hello.center().0 < right.center().0,
+        "the message label should sit between its participants: {hello:?} between {left:?} and {right:?}"
+    );
+}
+
+/// `loop` and `alt` frames carry their keyword and their guard.
+#[core::prelude::v1::test]
+fn fragment_keywords_and_guards_are_accessible() {
+    let mut app = app(FRAGMENTS);
+    for label in ["loop", "every minute", "alt", "is ready"] {
+        app.query().role(Role::LABEL).label(label).assert_exists();
+    }
+}
+
+/// The `alt` frame opens below the `loop` frame closes, because that is the
+/// order they are written in. A fragment whose vertical extent was dropped
+/// would put both at the same place.
+#[core::prelude::v1::test]
+fn fragments_are_stacked_in_source_order() {
+    let mut app = app(FRAGMENTS);
+    let loop_keyword = app
+        .query()
+        .role(Role::LABEL)
+        .label("loop")
+        .single()
+        .bounds();
+    let alt_keyword = app.query().role(Role::LABEL).label("alt").single().bounds();
+    assert!(
+        loop_keyword.y() < alt_keyword.y(),
+        "`loop` is written before `alt`, so its frame opens above: {loop_keyword:?} vs {alt_keyword:?}"
+    );
+}
+
+/// Exports the diagrams as PNGs for visual review. The assertions above cover
+/// the semantics; only a picture covers whether the lifelines are dashed, the
+/// actor is a stick figure and the fragment frames enclose what they should.
+#[core::prelude::v1::test]
+fn export_sequence_images_for_visual_review() {
+    for (case, source) in [("conversation", CONVERSATION), ("fragments", FRAGMENTS)] {
+        let mut app = app(source);
+        let captured = app.capture_snapshot("mermaid", case, "rendered");
+        assert!(captured.path().is_file());
+        println!("{}: {}", case, captured.path().display());
+    }
+}

--- a/components/multimedia/visualizer/src/lib.rs
+++ b/components/multimedia/visualizer/src/lib.rs
@@ -16,6 +16,12 @@
 //!     .sensitivity(1.5)
 //!     .glow(0.8)
 //! ```
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 mod audio;
 mod theme;

--- a/components/visual/canvas/src/path.rs
+++ b/components/visual/canvas/src/path.rs
@@ -117,80 +117,106 @@ impl Path {
         }
     }
 
-    /// Draws an arc between two points with a given radius.
+    /// Draws a circular arc tangent to the two lines `current -> point1` and
+    /// `point1 -> point2`, joined to the current point by a straight line.
     ///
-    /// This is equivalent to HTML5 Canvas `arcTo()`.
+    /// This is HTML5 Canvas `arcTo()`: `point1` is the corner being rounded and
+    /// `point2` only supplies the outgoing direction — the path never reaches
+    /// it. When the three points are collinear, or `radius` is zero, or the
+    /// corner coincides with a neighbour, the arc degenerates and a straight
+    /// line is drawn to `point1`, as the platform does.
+    ///
+    /// `radius` is clamped so the fillet fits inside both segments; a radius
+    /// larger than the corner can accommodate rounds it as much as it can
+    /// rather than overshooting into the neighbouring corner.
+    ///
+    /// Does nothing if the path has no current point.
     ///
     /// # Arguments
-    /// * `point1` - First control point
-    /// * `point2` - Second control point
-    /// * `radius` - Radius of the arc
+    /// * `point1` - The corner to round
+    /// * `point2` - The point the outgoing edge heads towards
+    /// * `radius` - Radius of the fillet
     pub fn arc_to(&mut self, point1: Point, point2: Point, radius: f32) {
-        // Get current point
-        let current = self.inner.elements().last().and_then(|el| match el {
-            kurbo::PathEl::MoveTo(p)
-            | kurbo::PathEl::LineTo(p)
-            | kurbo::PathEl::CurveTo(_, _, p)
-            | kurbo::PathEl::QuadTo(_, p) => Some(*p),
-            kurbo::PathEl::ClosePath => None,
-        });
+        let Some(current) = self.current_point() else {
+            return;
+        };
 
-        if let Some(current_pt) = current {
-            let p0 = current_pt;
-            let p1 = point_to_kurbo(point1);
-            let p2 = point_to_kurbo(point2);
-            let r = f64::from(radius);
+        let corner = point_to_kurbo(point1);
+        let p0 = current;
+        let p2 = point_to_kurbo(point2);
 
-            // Calculate tangent arc between two lines
-            let v0 = kurbo::Vec2::new(p1.x - p0.x, p1.y - p0.y);
-            let v1 = kurbo::Vec2::new(p2.x - p1.x, p2.y - p1.y);
+        // Both vectors point away from the corner: that is the frame a fillet
+        // is defined in, and using the travel directions instead is what makes
+        // the angle come out as the supplement of the one that is wanted.
+        let back = p0 - corner;
+        let forward = p2 - corner;
+        let (back_len, forward_len) = (back.hypot(), forward.hypot());
 
-            let len0 = v0.hypot();
-            let len1 = v1.hypot();
-
-            if len0 > 0.0 && len1 > 0.0 {
-                let v0_norm = v0 / len0;
-                let v1_norm = v1 / len1;
-
-                // Angle between vectors
-                let cos_angle = v0_norm.dot(v1_norm).clamp(-1.0, 1.0);
-                let angle = cos_angle.acos();
-
-                if angle > 0.01 {
-                    // Not parallel
-                    let tan_half = (angle / 2.0).tan();
-                    let dist = r / tan_half;
-
-                    let start_pt = p1 - v0_norm * dist;
-                    let end_pt = p1 + v1_norm * dist;
-
-                    // Draw line to arc start
-                    self.inner.line_to(start_pt);
-
-                    // Calculate arc center and angles
-                    let bisector = (v0_norm + v1_norm).normalize();
-                    let center_dist = r / (angle / 2.0).sin();
-                    let center = p1 + bisector * center_dist;
-
-                    let start_angle = (start_pt.y - center.y).atan2(start_pt.x - center.x);
-                    let end_angle = (end_pt.y - center.y).atan2(end_pt.x - center.x);
-                    let mut sweep = end_angle - start_angle;
-
-                    // Normalize sweep to be in correct direction
-                    if sweep > core::f64::consts::PI {
-                        sweep -= core::f64::consts::TAU;
-                    } else if sweep < -core::f64::consts::PI {
-                        sweep += core::f64::consts::TAU;
-                    }
-
-                    let arc = kurbo::Arc::new(center, (r, r), start_angle, sweep, 0.0);
-                    let arc_path = arc.to_path(0.1);
-                    for el in arc_path.elements() {
-                        self.inner.push(*el);
-                    }
-                }
-            }
+        let degenerate = radius <= 0.0 || back_len == 0.0 || forward_len == 0.0;
+        if degenerate {
+            self.inner.line_to(corner);
+            return;
         }
+
+        let back = back / back_len;
+        let forward = forward / forward_len;
+        let interior = back.dot(forward).clamp(-1.0, 1.0).acos();
+        // Collinear in either sense: nothing to round.
+        if !interior.is_finite() || interior < 1e-4 || (core::f64::consts::PI - interior) < 1e-4 {
+            self.inner.line_to(corner);
+            return;
+        }
+
+        let half = interior / 2.0;
+        // Distance from the corner to each tangent point, clamped so the fillet
+        // cannot eat past either neighbour, with the radius reduced to match.
+        let tangent = (f64::from(radius) / half.tan())
+            .min(back_len)
+            .min(forward_len);
+        let effective_radius = tangent * half.tan();
+
+        let start = corner + back * tangent;
+        let end = corner + forward * tangent;
+        let center = corner + (back + forward).normalize() * (effective_radius / half.sin());
+
+        self.inner.line_to(start);
+
+        let start_angle = (start - center).atan2();
+        let end_angle = (end - center).atan2();
+        let mut sweep = end_angle - start_angle;
+        if sweep > core::f64::consts::PI {
+            sweep -= core::f64::consts::TAU;
+        } else if sweep < -core::f64::consts::PI {
+            sweep += core::f64::consts::TAU;
+        }
+
+        let arc = kurbo::Arc::new(
+            center,
+            (effective_radius, effective_radius),
+            start_angle,
+            sweep,
+            0.0,
+        );
+        // `Arc::to_path` opens with a `MoveTo` to the arc's start. Appending it
+        // would lift the pen and start a new contour, breaking the outline into
+        // fragments and leaving `close` to close the wrong one.
+        for element in arc.to_path(0.1).elements().iter().skip(1) {
+            self.inner.push(*element);
+        }
+    }
+
+    /// The point the pen is currently at, if the path has been started.
+    fn current_point(&self) -> Option<kurbo::Point> {
+        self.inner
+            .elements()
+            .last()
+            .and_then(|element| match element {
+                kurbo::PathEl::MoveTo(point)
+                | kurbo::PathEl::LineTo(point)
+                | kurbo::PathEl::CurveTo(_, _, point)
+                | kurbo::PathEl::QuadTo(_, point) => Some(*point),
+                kurbo::PathEl::ClosePath => None,
+            })
     }
 
     /// Draws an elliptical arc.
@@ -274,5 +300,124 @@ impl fmt::Debug for Path {
         f.debug_struct("Path")
             .field("elements", &self.inner.elements().len())
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod arc_to_tests {
+    use super::{Path, Point};
+
+    /// Every element after the first `MoveTo` must continue the same contour.
+    /// An interior `MoveTo` lifts the pen, which is what turns a rounded outline
+    /// into loose fragments and leaves `close` closing the wrong one.
+    fn interior_move_tos(path: &Path) -> usize {
+        path.inner()
+            .elements()
+            .iter()
+            .skip(1)
+            .filter(|element| matches!(element, kurbo::PathEl::MoveTo(_)))
+            .count()
+    }
+
+    /// How far the path strays from the box its three points span. A fillet
+    /// lives inside the corner, so it can never leave that box.
+    fn overshoot(path: &Path, min: Point, max: Point) -> f64 {
+        path.inner()
+            .elements()
+            .iter()
+            .filter_map(|element| match element {
+                kurbo::PathEl::MoveTo(p)
+                | kurbo::PathEl::LineTo(p)
+                | kurbo::PathEl::CurveTo(_, _, p)
+                | kurbo::PathEl::QuadTo(_, p) => Some(*p),
+                kurbo::PathEl::ClosePath => None,
+            })
+            .map(|p| {
+                let dx = (f64::from(min.x) - p.x)
+                    .max(p.x - f64::from(max.x))
+                    .max(0.0);
+                let dy = (f64::from(min.y) - p.y)
+                    .max(p.y - f64::from(max.y))
+                    .max(0.0);
+                dx.max(dy)
+            })
+            .fold(0.0_f64, f64::max)
+    }
+
+    #[test]
+    fn a_rounded_corner_stays_one_contour() {
+        let mut path = Path::new();
+        path.move_to(Point::new(0.0, 0.0));
+        path.arc_to(Point::new(100.0, 0.0), Point::new(100.0, 100.0), 20.0);
+        assert_eq!(interior_move_tos(&path), 0);
+    }
+
+    /// The bug this replaced put the arc centre 90 degrees off and computed the
+    /// tangent distance from the supplement of the interior angle, so the path
+    /// wandered outside the corner it was meant to round.
+    #[test]
+    fn a_right_angle_fillet_stays_inside_its_corner() {
+        let mut path = Path::new();
+        path.move_to(Point::new(0.0, 0.0));
+        path.arc_to(Point::new(100.0, 0.0), Point::new(100.0, 100.0), 20.0);
+        assert!(
+            overshoot(&path, Point::new(0.0, 0.0), Point::new(100.0, 100.0)) < 0.5,
+            "the fillet left the box its own points span: {path:?}"
+        );
+    }
+
+    /// A nearly straight turn rounds by almost nothing. Computing the angle the
+    /// wrong way round inverted this: the shallower the turn, the further the
+    /// path shot away from it.
+    #[test]
+    fn a_shallow_turn_rounds_by_a_little_not_a_lot() {
+        let mut path = Path::new();
+        path.move_to(Point::new(0.0, 0.0));
+        path.arc_to(Point::new(100.0, 0.0), Point::new(200.0, 10.0), 8.0);
+        assert!(
+            overshoot(&path, Point::new(0.0, -1.0), Point::new(200.0, 11.0)) < 0.5,
+            "a 6-degree turn threw the path off the polyline it follows: {path:?}"
+        );
+    }
+
+    #[test]
+    fn collinear_points_draw_a_straight_line_to_the_corner() {
+        let mut path = Path::new();
+        path.move_to(Point::new(0.0, 0.0));
+        path.arc_to(Point::new(50.0, 0.0), Point::new(100.0, 0.0), 10.0);
+        let last = path.inner().elements().last().copied();
+        assert!(
+            matches!(last, Some(kurbo::PathEl::LineTo(p)) if (p.x - 50.0).abs() < 1e-6),
+            "collinear input should degenerate to a line to the corner, got {last:?}"
+        );
+    }
+
+    #[test]
+    fn a_zero_radius_draws_a_straight_line_to_the_corner() {
+        let mut path = Path::new();
+        path.move_to(Point::new(0.0, 0.0));
+        path.arc_to(Point::new(50.0, 0.0), Point::new(50.0, 50.0), 0.0);
+        let last = path.inner().elements().last().copied();
+        assert!(matches!(last, Some(kurbo::PathEl::LineTo(_))), "{last:?}");
+    }
+
+    /// A radius larger than either segment is clamped rather than allowed to
+    /// overshoot into the neighbouring corner.
+    #[test]
+    fn an_oversized_radius_is_clamped_to_the_segments() {
+        let mut path = Path::new();
+        path.move_to(Point::new(0.0, 0.0));
+        path.arc_to(Point::new(10.0, 0.0), Point::new(10.0, 10.0), 1000.0);
+        assert!(
+            overshoot(&path, Point::new(0.0, 0.0), Point::new(10.0, 10.0)) < 0.5,
+            "an oversized radius escaped its corner: {path:?}"
+        );
+    }
+
+    #[test]
+    fn arc_to_without_a_current_point_does_nothing() {
+        let mut path = Path::new();
+        path.arc_to(Point::new(10.0, 0.0), Point::new(10.0, 10.0), 5.0);
+        assert_eq!(path.inner().elements().len(), 0);
     }
 }

--- a/components/visual/graphics/src/lib.rs
+++ b/components/visual/graphics/src/lib.rs
@@ -1,4 +1,10 @@
 #![doc = "Graphics primitives for `WaterUI`."]
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 extern crate alloc;
 

--- a/components/visual/image/src/lib.rs
+++ b/components/visual/image/src/lib.rs
@@ -1,4 +1,10 @@
 //! Image primitives and decode helpers for `WaterUI`.
+// Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
+// default recursion limit of 128 on the workspace's nightly toolchain, which
+// reports `overflow evaluating the requirement ...: Send` — a hard error under
+// `-D warnings`. The bound genuinely holds; the solver just needs room to say
+// so. Harmless on stable, where the limit is never reached.
+#![recursion_limit = "256"]
 
 extern crate alloc;
 


### PR DESCRIPTION
Fixes #215.

A fenced ` ```mermaid ` block has only ever been able to become syntax-highlighted source,
because there was no Mermaid component in the workspace at all. This adds one:
`waterui-mermaid`, a sibling of `waterui-chart` under `components/data/`.

### Why a sibling crate rather than part of `waterui-chart`

Only ~7 of Mermaid's ~34 diagram families are charts. The rest are node-link diagrams
needing Sugiyama layout, which `waterui-chart` does not have and should not grow — putting a
DSL parser and a graph layout engine inside it would make every bar-chart user carry them.
The chart vocabulary is still reused rather than duplicated: the chart-shaped families will
lower onto the existing chart views behind an optional feature, leaving `waterui-chart`'s own
dependency closure untouched.

### Pipeline

```
mermaid source
  -> merman-core     parse -> typed semantic model
  -> merman-render   layout geometry, measured by OUR TextMeasurer
  -> layout.rs       DiagramLayout, the boundary nothing upstream crosses
  -> draw.rs         Scene2D geometry through waterui-canvas
  +  label.rs        real text() views in the boxes layout reserved
```

Four properties follow from that shape, none of which a render-to-SVG-and-rasterise pipeline
offers:

- **Boxes are sized by the engine that draws the glyphs.** `merman` sizes every node and
  label through a host-supplied `TextMeasurer`; this crate supplies one backed by the same
  `parley` engine and system fonts the labels are drawn with. Leaving `merman`'s built-in
  browser-compatibility profile installed would size boxes from one set of metrics and paint
  glyphs from another, and the text would not fit. (Zed, which uses the same crate through
  its SVG output, installs no measurer and documents the resulting overflow.)
- **The diagram has a real accessibility tree.** Labels are `text()` views, not glyphs
  painted into the scene, so each is its own node.
- **Colours are theme tokens**, so a diagram follows a light/dark switch and a custom accent.
- **Text is vector**, at the platform's own rendering.

A diagram is drawn at its natural size. Scaling would break the first property, so one larger
than its container is the container's to scroll.

### Scope

Flowchart and sequence, which covers the great majority of Mermaid in the wild. Node shapes,
subgraph frames, routed edges with Mermaid's four arrowheads and three stroke weights;
participants, actors, lifelines, notes, and `loop`/`alt`/`opt` fragments with their guards.
Remaining families are their own issues.

### Verification

`cargo clippy -p waterui-mermaid --all-targets -- -D warnings` is clean and
`cargo nextest run -p waterui-mermaid` runs 14 tests green. The tests assert on the
accessibility tree and on placed label bounds — that a `flowchart TD` really does stack
downward, that a `LR` flows rightward, that a participant is labelled at both ends of its
lifeline at the same `x`, that fragments stack in source order, and that a longer label
measures wider while sharing its column's centre.

Two defects only the rendered images could catch were fixed on the way, and both are called
out in the commits: an actor's name was being centred in its box and landing across the stick
figure's chest, and Mermaid lays a diagram out wherever its algorithm begins rather than at
the origin — a sequence diagram's bounds start at `(-50, -10)` — so every coordinate is now
shifted to put the top-left at `(0, 0)`.

### Stacked

This branch sits on #224 (the `Send`-solver recursion limit) and #231 (`Path::arc_to`, which
this work found broken — without it a `([stadium])` node renders as four loose strokes and a
routed edge as a stray diagonal). Both are independent fixes with their own issues; this
diff shrinks to the crate alone once they merge.

`merman` is consumed from `water-rs/merman` while `typed-layout-projection` is unreleased
upstream — see #217 for what that branch changes and why the alternative loses a sequence
diagram's fragment boxes entirely.