### PR TITLE
feat(graphics): draw image brushes in the hybrid scene engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12850,6 +12850,7 @@ dependencies = [
  "shaderloom",
  "tracing",
  "vello",
+ "vello_common 0.2.0",
  "vello_hybrid",
  "waterui",
  "waterui-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,6 +210,11 @@ vello_hybrid = { version = "0.2", default-features = false, features = ["std", "
 # release is a different major version, and a glyph from one is not a glyph from
 # the other.
 glifo = { version = "0.3.0", default-features = false, features = ["std"] }
+# The paint and pixel types `vello_hybrid` takes but does not re-export. An
+# image is drawn there by naming a handle into the renderer's atlas, and the
+# handle, the paint that samples it, and the premultiplied conversion that
+# fills it all live here.
+vello_common = { version = "0.2", default-features = false, features = ["std"] }
 parley = { version = "0.11", default-features = false }
 # SVG documents are parsed here and drawn through `Scene2D`; nothing in the
 # workspace renders one with `vello_svg`, so the parser is depended on directly

--- a/components/visual/graphics/Cargo.toml
+++ b/components/visual/graphics/Cargo.toml
@@ -15,7 +15,17 @@ default = ["gpu"]
 # The `Scene2D` contract needs no rendering engine, so the two engine-backed
 # implementations of it are their own feature: a crate that only draws through
 # the contract, and lets a backend supply the scene, does not pull Vello.
-vello-scene = ["dep:vello", "dep:vello_hybrid", "dep:glifo"]
+#
+# `wgpu` is here because the hybrid engine keeps images in an atlas texture the
+# renderer owns: drawing one means uploading it to the device, so the engine
+# implementation names the device, the queue and the encoder that fills it.
+vello-scene = [
+    "dep:vello",
+    "dep:vello_hybrid",
+    "dep:vello_common",
+    "dep:glifo",
+    "dep:wgpu",
+]
 gpu = [
     "vello-scene",
     "dep:keyboard-types",
@@ -45,6 +55,7 @@ pastey.workspace = true
 wgpu = { workspace = true, optional = true }
 vello = { workspace = true, optional = true }
 vello_hybrid = { workspace = true, optional = true }
+vello_common = { workspace = true, optional = true }
 glifo = { workspace = true, optional = true }
 kurbo.workspace = true
 keyboard-types = { workspace = true, optional = true }

--- a/components/visual/graphics/src/gpu/shared_context.rs
+++ b/components/visual/graphics/src/gpu/shared_context.rs
@@ -10,6 +10,9 @@ use std::sync::{Arc, Mutex, OnceLock};
 
 use shaderloom::WgslModuleCache;
 
+use crate::scene2d_hybrid::HybridImageAtlas;
+pub use crate::scene2d_hybrid::HybridRenderer;
+
 #[cfg(not(target_arch = "wasm32"))]
 use std::sync::mpsc;
 
@@ -127,17 +130,6 @@ pub struct SharedSceneRenderer {
     hybrid: Mutex<Vec<(wgpu::TextureFormat, HybridRenderer)>>,
 }
 
-/// The hybrid renderer and the resources it draws with.
-///
-/// They are created together and used together, so they are kept together.
-#[derive(Debug)]
-pub struct HybridRenderer {
-    /// The renderer itself.
-    pub renderer: vello_hybrid::Renderer,
-    /// Its atlas and buffer resources.
-    pub resources: vello_hybrid::Resources,
-}
-
 impl fmt::Debug for SharedSceneRenderer {
     fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
         formatter
@@ -240,6 +232,7 @@ impl SharedSceneRenderer {
                     HybridRenderer {
                         renderer,
                         resources,
+                        images: HybridImageAtlas::default(),
                     },
                 ));
                 renderers.len() - 1

--- a/components/visual/graphics/src/lib.rs
+++ b/components/visual/graphics/src/lib.rs
@@ -127,7 +127,7 @@ pub use image_generator::{
 pub use scene_view::{SceneContent, SceneInvalidator, SceneView, SceneViewMergeToParent};
 pub use scene2d::{Glyph, GlyphRun, Scene2D, SceneRecording};
 #[cfg(feature = "vello-scene")]
-pub use scene2d_hybrid::HybridScene2D;
+pub use scene2d_hybrid::{HybridImageAtlas, HybridRenderer, HybridScene2D, HybridUpload};
 #[cfg(feature = "vello-scene")]
 pub use scene2d_vello::VelloScene2D;
 

--- a/components/visual/graphics/src/scene/scene2d_hybrid.rs
+++ b/components/visual/graphics/src/scene/scene2d_hybrid.rs
@@ -11,17 +11,195 @@
 //! transform and brush with each call, this one is set first and drawn after.
 //! That is the whole of the translation below.
 
-use kurbo::{Affine, BezPath, Stroke};
-use peniko::{BlendMode, Brush, Fill, ImageBrush, StyleRef};
+use std::collections::HashMap;
+
+use kurbo::{Affine, BezPath, Rect, Stroke};
+use peniko::{BlendMode, Brush, Fill, ImageBrush, ImageData, StyleRef, WeakBlob};
+use vello_common::paint::{Image, ImageId, ImageSource};
 
 use crate::scene2d::{GlyphRun, Scene2D};
+
+/// The hybrid renderer and the resources it draws with.
+///
+/// They are created together and used together, so they are kept together: the
+/// renderer owns the atlas texture, and the resources own what has been placed
+/// in it.
+#[derive(Debug)]
+pub struct HybridRenderer {
+    /// The renderer itself.
+    pub renderer: vello_hybrid::Renderer,
+    /// Its atlas and buffer resources.
+    pub resources: vello_hybrid::Resources,
+    /// The images this renderer has already put in its atlas.
+    pub images: HybridImageAtlas,
+}
+
+/// One image this renderer has uploaded into its atlas.
+#[derive(Debug)]
+struct AtlasEntry {
+    /// Handle naming the atlas allocation.
+    id: ImageId,
+    /// Whether the uploaded pixels have any pixel that is not fully opaque.
+    ///
+    /// Computed once, when the pixels are converted, because the answer is a
+    /// property of the pixels rather than of the draw that samples them.
+    may_have_transparency: bool,
+    /// The pixels this entry was uploaded from, held weakly.
+    ///
+    /// A `Blob` is the identity of an image's pixels, so the moment the last
+    /// owner drops it nothing can ask for this image again, and its atlas space
+    /// is free for the next image that needs room.
+    pixels: WeakBlob<u8>,
+}
+
+/// The images one hybrid renderer has uploaded into its atlas.
+///
+/// The atlas is a texture the renderer owns, so what is in it belongs to the
+/// renderer too, and not to any one scene: an image drawn on every frame is
+/// uploaded once and sampled from the atlas on every frame after that. Entries
+/// are keyed by the identity of the pixels they were uploaded from, which is
+/// how the same image drawn from two different scenes resolves to one
+/// allocation.
+#[derive(Debug, Default)]
+pub struct HybridImageAtlas {
+    uploaded: HashMap<u64, AtlasEntry>,
+}
+
+/// The device handles that putting pixels into the atlas needs.
+///
+/// The atlas is a texture, so filling it is device work rather than scene
+/// recording: an upload is a queued texture write, and growing the atlas is a
+/// copy recorded into `encoder` — the same encoder the frame is rendered with,
+/// so the write lands before the pass that samples it.
+pub struct HybridUpload<'a> {
+    device: &'a wgpu::Device,
+    queue: &'a wgpu::Queue,
+    encoder: &'a mut wgpu::CommandEncoder,
+}
+
+impl core::fmt::Debug for HybridUpload<'_> {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("HybridUpload")
+            .finish_non_exhaustive()
+    }
+}
+
+impl<'a> HybridUpload<'a> {
+    /// Names the device, queue and encoder an upload is recorded against.
+    #[must_use]
+    pub const fn new(
+        device: &'a wgpu::Device,
+        queue: &'a wgpu::Queue,
+        encoder: &'a mut wgpu::CommandEncoder,
+    ) -> Self {
+        Self {
+            device,
+            queue,
+            encoder,
+        }
+    }
+}
+
+impl HybridImageAtlas {
+    /// The atlas handle for `data`, uploading its pixels the first time this
+    /// renderer is asked for them.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the image is larger than an atlas can hold, or when the
+    /// atlas has no room left for it.
+    fn source_for(
+        &mut self,
+        renderer: &mut vello_hybrid::Renderer,
+        resources: &mut vello_hybrid::Resources,
+        upload: &mut HybridUpload<'_>,
+        data: &ImageData,
+    ) -> ImageSource {
+        let key = data.data.id();
+        if let Some(entry) = self.uploaded.get(&key) {
+            return ImageSource::opaque_id_with_transparency_hint(
+                entry.id,
+                entry.may_have_transparency,
+            );
+        }
+
+        self.release_dropped(renderer, resources, upload);
+
+        // The conversion to premultiplied atlas pixels is the same one the
+        // engine would do for itself; only its result travels differently,
+        // because this renderer samples an atlas handle rather than a pixmap
+        // carried along with the scene.
+        let ImageSource::Pixmap(pixels) = ImageSource::from_peniko_image_data(data) else {
+            panic!("`ImageSource::from_peniko_image_data` produces decoded pixels");
+        };
+        let may_have_transparency = pixels.may_have_transparency();
+        let id = renderer.upload_image(
+            resources,
+            upload.device,
+            upload.queue,
+            upload.encoder,
+            &pixels,
+        );
+        self.uploaded.insert(
+            key,
+            AtlasEntry {
+                id,
+                may_have_transparency,
+                pixels: data.data.downgrade(),
+            },
+        );
+        ImageSource::opaque_id_with_transparency_hint(id, may_have_transparency)
+    }
+
+    /// Frees the atlas space held by images whose pixels the application has
+    /// released.
+    ///
+    /// Clearing an allocation is a render pass, and a queued texture write runs
+    /// before every command buffer submitted alongside it — so a clear recorded
+    /// into the frame's encoder would execute *after* the upload that follows
+    /// it here and wipe the image just placed in the reclaimed space. The
+    /// clears therefore go in an encoder of their own and are submitted before
+    /// the upload is queued, which puts them in an earlier submission and back
+    /// in the order they were asked for.
+    fn release_dropped(
+        &mut self,
+        renderer: &mut vello_hybrid::Renderer,
+        resources: &mut vello_hybrid::Resources,
+        upload: &HybridUpload<'_>,
+    ) {
+        if self
+            .uploaded
+            .values()
+            .all(|entry| entry.pixels.upgrade().is_some())
+        {
+            return;
+        }
+
+        let mut encoder = upload
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("hybrid scene image atlas release"),
+            });
+        self.uploaded.retain(|_, entry| {
+            if entry.pixels.upgrade().is_some() {
+                return true;
+            }
+            renderer.destroy_image(resources, &mut encoder, entry.id);
+            false
+        });
+        upload.queue.submit([encoder.finish()]);
+    }
+}
 
 /// Wraps a hybrid scene as an engine-independent [`Scene2D`].
 pub struct HybridScene2D<'a> {
     scene: &'a mut vello_hybrid::Scene,
-    // Glyphs are rasterized into an atlas that outlives any one scene, so
-    // drawing text needs the renderer's resources and not just the scene.
-    resources: &'a mut vello_hybrid::Resources,
+    // Glyphs rasterize into an atlas, and images upload into another, both of
+    // which outlive any one scene. Drawing either therefore needs the renderer
+    // and its resources, not just the scene.
+    renderer: &'a mut HybridRenderer,
+    upload: HybridUpload<'a>,
 }
 
 impl core::fmt::Debug for HybridScene2D<'_> {
@@ -33,13 +211,19 @@ impl core::fmt::Debug for HybridScene2D<'_> {
 }
 
 impl<'a> HybridScene2D<'a> {
-    /// Wraps a mutable hybrid scene and the renderer resources it draws with.
+    /// Wraps a mutable hybrid scene, the renderer it draws with, and the device
+    /// handles that renderer's atlases are filled through.
     #[must_use]
     pub const fn new(
         scene: &'a mut vello_hybrid::Scene,
-        resources: &'a mut vello_hybrid::Resources,
+        renderer: &'a mut HybridRenderer,
+        upload: HybridUpload<'a>,
     ) -> Self {
-        Self { scene, resources }
+        Self {
+            scene,
+            renderer,
+            upload,
+        }
     }
 }
 
@@ -160,7 +344,7 @@ impl Scene2D for HybridScene2D<'_> {
 
         let builder = self
             .scene
-            .glyph_run(self.resources, run.font)
+            .glyph_run(&mut self.renderer.resources, run.font)
             .font_size(run.font_size)
             .normalized_coords(run.normalized_coords);
         if stroked {
@@ -170,15 +354,37 @@ impl Scene2D for HybridScene2D<'_> {
         }
     }
 
-    fn draw_image(&mut self, image: &ImageBrush, _transform: Affine) {
-        // Images in a scene need this engine's own image source, uploaded into
-        // its atlas — not the decoded pixels a `peniko::ImageBrush` carries.
-        // Nothing WaterUI draws through a scene uses one yet: photos and video
-        // are their own surfaces, and an SVG's raster images are not drawn
-        // either. Left unimplemented rather than silently drawing nothing, so
-        // the first caller that needs it says so.
-        let _ = image;
-        unimplemented!("image brushes in a hybrid scene are not implemented yet");
+    fn draw_image(&mut self, image: &ImageBrush, transform: Affine) {
+        let Self {
+            scene,
+            renderer,
+            upload,
+        } = self;
+        let HybridRenderer {
+            renderer,
+            resources,
+            images,
+        } = &mut **renderer;
+        let source = images.source_for(renderer, resources, upload, &image.image);
+
+        // Classic fills the image's own pixel rectangle with the image as its
+        // brush, which puts the top-left pixel at the transform's origin and
+        // one image pixel on one unit. The paint transform is reset rather than
+        // left alone so the image samples in that same rectangle's space,
+        // matching what an untransformed brush does over there.
+        scene.set_transform(transform);
+        scene.set_fill_rule(Fill::NonZero);
+        scene.reset_paint_transform();
+        scene.set_paint(Image {
+            image: source,
+            sampler: image.sampler,
+        });
+        scene.fill_rect(&Rect::new(
+            0.0,
+            0.0,
+            f64::from(image.image.width),
+            f64::from(image.image.height),
+        ));
     }
 
     fn reset(&mut self) {

--- a/components/visual/graphics/src/scene/scene_surface.rs
+++ b/components/visual/graphics/src/scene/scene_surface.rs
@@ -12,7 +12,7 @@ use waterui_core::MainThreadBound;
 use crate::gpu::shared_context::SceneEngine;
 use crate::gpu_surface::{GpuContext, GpuFrame, GpuView};
 use crate::scene_view::SceneContent;
-use crate::scene2d_hybrid::HybridScene2D;
+use crate::scene2d_hybrid::{HybridScene2D, HybridUpload};
 use crate::scene2d_vello::VelloScene2D;
 
 /// The scene this surface builds each frame, in whichever engine's form.
@@ -364,13 +364,16 @@ impl SceneSurfaceRenderer {
             multiview_mask: None,
         }));
 
-        // The content is built inside the renderer's lock because glyphs
-        // rasterize into an atlas the renderer owns: a run of text is recorded
-        // against those resources, not against the scene alone.
+        // The content is built inside the renderer's lock because glyphs and
+        // images live in atlases the renderer owns: a run of text or an image
+        // is recorded against those resources, not against the scene alone.
+        // Uploads go into the same encoder the frame is rendered with, so an
+        // image reaches the atlas before the pass that samples it.
         let content = &mut self.content;
         let needs_next_frame = renderer.with_hybrid(frame.device, frame.format, |hybrid| {
             let needs_next_frame = {
-                let mut scene2d = HybridScene2D::new(scene, &mut hybrid.resources);
+                let upload = HybridUpload::new(frame.device, frame.queue, &mut encoder);
+                let mut scene2d = HybridScene2D::new(scene, hybrid, upload);
                 content.build_scene(&mut scene2d, frame.width as f32, frame.height as f32)
             };
             hybrid

--- a/components/visual/graphics/tests/scene_image.rs
+++ b/components/visual/graphics/tests/scene_image.rs
@@ -110,7 +110,7 @@ fn render(runtime: &GpuRuntime, engine: SceneEngine) -> Vec<u8> {
     let output = pollster::block_on(surface.render_offscreen(runtime, config, &mut env))
         .expect("offscreen render should succeed");
 
-    let directory = artifact_root().join("scene_image");
+    let directory = artifact_root().join("scene_image").join("image_brush");
     std::fs::create_dir_all(&directory).expect("artifact directory must be creatable");
     let name = match engine {
         SceneEngine::Classic => "classic",
@@ -135,7 +135,7 @@ fn hybrid_scene_engine_draws_an_image_brush() {
     // The engine the device picks for itself is not what this test renders
     // with, but it is what an application on this machine gets, so it is
     // recorded next to the snapshots.
-    let directory = artifact_root().join("scene_image");
+    let directory = artifact_root().join("scene_image").join("image_brush");
     std::fs::create_dir_all(&directory).expect("artifact directory must be creatable");
     let adapter = runtime.context().adapter.get_info();
     std::fs::write(

--- a/components/visual/graphics/tests/scene_image.rs
+++ b/components/visual/graphics/tests/scene_image.rs
@@ -1,10 +1,17 @@
-//! Both scene engines draw an image brush, and draw it the same way.
+//! The hybrid scene engine draws an image brush where the recording put it.
 //!
 //! The hybrid engine keeps images in an atlas of its own rather than carrying
 //! decoded pixels along with the scene, so `draw_image` is the one command
-//! whose translation between the two engines is not a rename. This renders the
-//! same recording through each engine and compares the results: the image has
-//! to land in the same place, the right way up, in the same colours.
+//! whose translation between the two engines is not a rename. Both engines
+//! render the same recording here and both snapshots are kept, but only the
+//! hybrid one is asserted, and it is asserted against the source pixels rather
+//! than against the other engine: the classic engine's surface blits through a
+//! `shaderloom`-compiled shader, and those come out vertically flipped on
+//! Vulkan (water-rs/waterui#239), which is a property of the surface and has
+//! nothing to say about `draw_image`. Comparing to the source image is the
+//! stronger claim anyway — it is what says the image is in the right place, the
+//! right way up, and in the right colours, rather than merely identical to
+//! something else that might be wrong the same way.
 
 use std::sync::Arc;
 
@@ -115,24 +122,13 @@ fn render(runtime: &GpuRuntime, engine: SceneEngine) -> Vec<u8> {
     output.rgba8
 }
 
-/// The final source pixel's row and column, in output pixels.
-///
-/// `vello_hybrid`'s bilinear image sampling clamps `Extend::Pad` to the last
-/// texel's leading corner (`clamp(t, 0.0, size - 1.0)` in `render.wesl`) and
-/// only then subtracts the half texel that turns a corner into a centre, so
-/// every sample from that corner onwards resolves to one fixed half-and-half
-/// blend of the last two texels instead of running on into the last one. The
-/// band is excluded from the comparison rather than asserted, because
-/// asserting it would pin the defect in place; see water-rs/waterui#234.
-const TRAILING_BAND: u32 = SCALE;
-
-/// An image brush draws the same picture through either engine.
+/// The hybrid engine draws an image brush at the source image's own colours.
 ///
 /// The engine is forced rather than left to the adapter, so the hybrid path is
 /// covered on a device that would have chosen the classic one — which is every
-/// device that can run the compute pipeline.
+/// device that can run the compute pipeline, CI's llvmpipe runner included.
 #[test]
-fn both_scene_engines_draw_an_image_brush() {
+fn hybrid_scene_engine_draws_an_image_brush() {
     let runtime = pollster::block_on(GpuRuntime::new())
         .expect("scene engine comparison requires a working GPU runtime");
 
@@ -153,13 +149,23 @@ fn both_scene_engines_draw_an_image_brush() {
     )
     .expect("adapter report must be writable");
 
-    let classic = render(&runtime, SceneEngine::Classic);
+    // Rendered for the snapshot beside the hybrid one, so the two are there to
+    // be looked at; its pixels are not asserted while #239 stands.
+    let _classic = render(&runtime, SceneEngine::Classic);
     let hybrid = render(&runtime, SceneEngine::Hybrid);
 
-    // Every source pixel's own centre, which both engines sample to that
-    // pixel's colour under either filtering quality. This is what says the
-    // image is in the right place, the right way up and in the right colours
-    // rather than merely identical to itself.
+    // Every source pixel's own centre, which the engine samples to that pixel's
+    // colour under either filtering quality. Each source pixel has a colour of
+    // its own and the three channels run in three directions, so a transposed,
+    // mirrored, shifted or channel-swapped blit fails here.
+    // The final row and column are skipped: `vello_hybrid`'s bilinear image
+    // sampling clamps `Extend::Pad` to the last texel's leading corner
+    // (`clamp(t, 0.0, size - 1.0)` in `render.wesl`) and only then subtracts
+    // the half texel that turns a corner into a centre, so every sample from
+    // that corner onwards resolves to one fixed half-and-half blend of the last
+    // two texels instead of running on into the last one. Skipped rather than
+    // asserted, because asserting it would pin the defect in place; see
+    // water-rs/waterui#234.
     let last_centre = IMAGE_SIDE - 1;
     for y in 0..IMAGE_SIDE {
         for x in 0..IMAGE_SIDE {
@@ -168,28 +174,11 @@ fn both_scene_engines_draw_an_image_brush() {
             }
             let expected = source_pixel(x, y);
             let point = (x * SCALE + SCALE / 2, y * SCALE + SCALE / 2);
-            for (engine, rgba8) in [("classic", &classic), ("hybrid", &hybrid)] {
-                let actual = pixel_at(rgba8, point.0, point.1);
-                assert!(
-                    channels_off_by(actual, expected) <= CHANNEL_TOLERANCE,
-                    "the {engine} engine drew {actual:?} at {point:?}, where source pixel \
-                     ({x}, {y}) puts {expected:?}"
-                );
-            }
-        }
-    }
-
-    // And the whole picture, so a difference anywhere between the sampled
-    // centres is a failure too.
-    let compared = OUTPUT_SIDE - TRAILING_BAND;
-    for y in 0..compared {
-        for x in 0..compared {
-            let classic = pixel_at(&classic, x, y);
-            let hybrid = pixel_at(&hybrid, x, y);
+            let actual = pixel_at(&hybrid, point.0, point.1);
             assert!(
-                channels_off_by(classic, hybrid) <= CHANNEL_TOLERANCE,
-                "the engines disagree at ({x}, {y}): classic drew {classic:?}, \
-                 hybrid drew {hybrid:?}"
+                channels_off_by(actual, expected) <= CHANNEL_TOLERANCE,
+                "the hybrid engine drew {actual:?} at {point:?}, where source pixel \
+                 ({x}, {y}) puts {expected:?}"
             );
         }
     }

--- a/components/visual/graphics/tests/scene_image.rs
+++ b/components/visual/graphics/tests/scene_image.rs
@@ -1,0 +1,196 @@
+//! Both scene engines draw an image brush, and draw it the same way.
+//!
+//! The hybrid engine keeps images in an atlas of its own rather than carrying
+//! decoded pixels along with the scene, so `draw_image` is the one command
+//! whose translation between the two engines is not a rename. This renders the
+//! same recording through each engine and compares the results: the image has
+//! to land in the same place, the right way up, in the same colours.
+
+use std::sync::Arc;
+
+use kurbo::Affine;
+use peniko::{Blob, ImageAlphaType, ImageBrush, ImageData, ImageFormat, ImageSampler};
+use waterui_graphics::shared_context::SceneEngine;
+use waterui_graphics::{
+    GpuRuntime, OffscreenRenderConfig, OffscreenSize, Scene2D, SceneContent, SceneView,
+};
+use waterui_testing::artifact_root;
+
+/// Side of the source image, in pixels.
+const IMAGE_SIDE: u32 = 8;
+/// How many output pixels one source pixel covers.
+const SCALE: u32 = 25;
+/// Side of the rendered output, in pixels.
+const OUTPUT_SIDE: u32 = IMAGE_SIDE * SCALE;
+/// How far a channel may sit from what it is compared against.
+///
+/// The engines rasterize differently and neither promises a bit-exact texel:
+/// classic lands a couple of levels off its own source colour. The margin is
+/// small enough that a swapped channel, a transposed image or a blended-in
+/// neighbour is still a failure — those are off by whole colours.
+const CHANNEL_TOLERANCE: u8 = 4;
+
+/// The source colour of pixel `(x, y)`.
+///
+/// No two pixels share a colour and the three channels run in three different
+/// directions, so a transposed, mirrored or channel-swapped blit shows up as a
+/// wrong colour rather than as a wrong shade.
+fn source_pixel(x: u32, y: u32) -> [u8; 4] {
+    let index =
+        u8::try_from(y * IMAGE_SIDE + x).expect("the source image has fewer than 256 pixels");
+    [index * 3, 255 - index * 3, index.wrapping_mul(7), 255]
+}
+
+/// Scene content that draws one image and nothing else.
+struct ImageContent {
+    brush: ImageBrush,
+    transform: Affine,
+}
+
+impl SceneContent for ImageContent {
+    fn build_scene(&mut self, scene: &mut dyn Scene2D, _width: f32, _height: f32) -> bool {
+        scene.draw_image(&self.brush, self.transform);
+        false
+    }
+}
+
+fn source_image() -> ImageBrush {
+    let mut data = Vec::with_capacity((IMAGE_SIDE * IMAGE_SIDE * 4) as usize);
+    for y in 0..IMAGE_SIDE {
+        for x in 0..IMAGE_SIDE {
+            data.extend_from_slice(&source_pixel(x, y));
+        }
+    }
+    ImageBrush {
+        image: ImageData {
+            data: Blob::new(Arc::new(data)),
+            format: ImageFormat::Rgba8,
+            alpha_type: ImageAlphaType::Alpha,
+            width: IMAGE_SIDE,
+            height: IMAGE_SIDE,
+        },
+        sampler: ImageSampler::default(),
+    }
+}
+
+fn pixel_at(rgba8: &[u8], x: u32, y: u32) -> [u8; 4] {
+    let offset = ((y * OUTPUT_SIDE + x) * 4) as usize;
+    rgba8[offset..offset + 4]
+        .try_into()
+        .expect("a four-byte pixel must be readable at an in-bounds offset")
+}
+
+fn channels_off_by(left: [u8; 4], right: [u8; 4]) -> u8 {
+    left.iter()
+        .zip(&right)
+        .map(|(left, right)| left.abs_diff(*right))
+        .max()
+        .expect("a pixel has four channels")
+}
+
+fn render(runtime: &GpuRuntime, engine: SceneEngine) -> Vec<u8> {
+    let size =
+        OffscreenSize::try_from_pixels(OUTPUT_SIDE, OUTPUT_SIDE).expect("test size must be valid");
+    let surface = SceneView::new(ImageContent {
+        brush: source_image(),
+        transform: Affine::scale(f64::from(SCALE)),
+    })
+    .into_gpu_surface();
+    let config = OffscreenRenderConfig::new(size)
+        .format(wgpu::TextureFormat::Rgba8Unorm)
+        .scene_engine(engine);
+    let mut env = waterui_core::Environment::new();
+    let output = pollster::block_on(surface.render_offscreen(runtime, config, &mut env))
+        .expect("offscreen render should succeed");
+
+    let directory = artifact_root().join("scene_image");
+    std::fs::create_dir_all(&directory).expect("artifact directory must be creatable");
+    let name = match engine {
+        SceneEngine::Classic => "classic",
+        SceneEngine::Hybrid => "hybrid",
+    };
+    output
+        .save_png(directory.join(format!("{name}.png")))
+        .expect("snapshot PNG must be writable");
+    output.rgba8
+}
+
+/// The final source pixel's row and column, in output pixels.
+///
+/// `vello_hybrid`'s bilinear image sampling clamps `Extend::Pad` to the last
+/// texel's leading corner (`clamp(t, 0.0, size - 1.0)` in `render.wesl`) and
+/// only then subtracts the half texel that turns a corner into a centre, so
+/// every sample from that corner onwards resolves to one fixed half-and-half
+/// blend of the last two texels instead of running on into the last one. The
+/// band is excluded from the comparison rather than asserted, because
+/// asserting it would pin the defect in place; see water-rs/waterui#234.
+const TRAILING_BAND: u32 = SCALE;
+
+/// An image brush draws the same picture through either engine.
+///
+/// The engine is forced rather than left to the adapter, so the hybrid path is
+/// covered on a device that would have chosen the classic one — which is every
+/// device that can run the compute pipeline.
+#[test]
+fn both_scene_engines_draw_an_image_brush() {
+    let runtime = pollster::block_on(GpuRuntime::new())
+        .expect("scene engine comparison requires a working GPU runtime");
+
+    // The engine the device picks for itself is not what this test renders
+    // with, but it is what an application on this machine gets, so it is
+    // recorded next to the snapshots.
+    let directory = artifact_root().join("scene_image");
+    std::fs::create_dir_all(&directory).expect("artifact directory must be creatable");
+    let adapter = runtime.context().adapter.get_info();
+    std::fs::write(
+        directory.join("adapter.txt"),
+        format!(
+            "adapter: {}\nbackend: {:?}\nselected engine: {:?}\n",
+            adapter.name,
+            adapter.backend,
+            runtime.context().scene_renderer().engine(),
+        ),
+    )
+    .expect("adapter report must be writable");
+
+    let classic = render(&runtime, SceneEngine::Classic);
+    let hybrid = render(&runtime, SceneEngine::Hybrid);
+
+    // Every source pixel's own centre, which both engines sample to that
+    // pixel's colour under either filtering quality. This is what says the
+    // image is in the right place, the right way up and in the right colours
+    // rather than merely identical to itself.
+    let last_centre = IMAGE_SIDE - 1;
+    for y in 0..IMAGE_SIDE {
+        for x in 0..IMAGE_SIDE {
+            if x == last_centre || y == last_centre {
+                continue;
+            }
+            let expected = source_pixel(x, y);
+            let point = (x * SCALE + SCALE / 2, y * SCALE + SCALE / 2);
+            for (engine, rgba8) in [("classic", &classic), ("hybrid", &hybrid)] {
+                let actual = pixel_at(rgba8, point.0, point.1);
+                assert!(
+                    channels_off_by(actual, expected) <= CHANNEL_TOLERANCE,
+                    "the {engine} engine drew {actual:?} at {point:?}, where source pixel \
+                     ({x}, {y}) puts {expected:?}"
+                );
+            }
+        }
+    }
+
+    // And the whole picture, so a difference anywhere between the sampled
+    // centres is a failure too.
+    let compared = OUTPUT_SIDE - TRAILING_BAND;
+    for y in 0..compared {
+        for x in 0..compared {
+            let classic = pixel_at(&classic, x, y);
+            let hybrid = pixel_at(&hybrid, x, y);
+            assert!(
+                channels_off_by(classic, hybrid) <= CHANNEL_TOLERANCE,
+                "the engines disagree at ({x}, {y}): classic drew {classic:?}, \
+                 hybrid drew {hybrid:?}"
+            );
+        }
+    }
+}


### PR DESCRIPTION
`HybridScene2D::draw_image` was `unimplemented!`, so an image reaching a scene on
any adapter that rasterizes with the hybrid engine — the iOS Simulator's Metal,
the Android emulator's SwiftShader Vulkan, anything without `INDIRECT_EXECUTION`
and `SHADER_F16_IN_F32` — aborted the process. A `CanvasImage`, a chart image
mark and every map tile go through that call, and after #227 made engine
selection per-adapter that is every one of those devices.

## What the hybrid engine wants

Vello classic carries decoded pixels along with the scene and resolves them at
resolve time. `vello_hybrid` instead samples a handle into an atlas texture the
*renderer* owns: `Renderer::upload_image` puts a premultiplied `Pixmap` into that
atlas and returns an `ImageId`, and the paint is
`vello_common::paint::Image { image: ImageSource::OpaqueId { .. }, sampler }`.
Handing it an `ImageSource::Pixmap` panics in `prepare_gpu_encoded_paints`, so
the pixels genuinely have to be uploaded first, on the device.

## What this does

- `HybridImageAtlas` uploads each distinct pixel blob once and hands the handle
  back on every frame after, keyed by `Blob::id()`. Entries hold the pixels
  weakly, so an image the application has released frees its atlas space for the
  next image that needs room — cleared through an encoder of its own, submitted
  before the upload, because a queued texture write runs ahead of every command
  buffer submitted alongside it and a clear recorded into the frame's encoder
  would otherwise wipe the image just placed in the reclaimed space.
- `draw_image` then matches classic exactly: the image's own pixel rectangle,
  filled non-zero under the given transform with the brush's own sampler, and the
  paint transform reset so one image pixel covers one unit. Alpha and quality ride
  along in the sampler, which both engines honour. No caller learns which engine
  it got.
- Uploading needs the device, so `HybridScene2D` carries the renderer and a
  `HybridUpload` (device, queue, encoder) rather than the resources alone, and
  `vello-scene` pulls `wgpu` — which `vello_hybrid` already brought in — plus the
  `vello_common` paint types `vello_hybrid` takes but does not re-export.
  `HybridRenderer` moves next to the engine it belongs to and gains the atlas.
- No CPU readback anywhere: pixels go up, nothing comes back.

## Verification

`components/visual/graphics/tests/scene_image.rs` renders an 8x8 image scaled 25x
through each engine with `OffscreenRenderConfig::scene_engine`, writes both PNGs
to the test-artifact directory, and asserts the hybrid render against the source
image's own pixels at every source-pixel centre. Each source pixel has a unique
colour whose channels run in three directions, so a transposed, mirrored, shifted
or channel-swapped blit fails. The forced override matters: llvmpipe advertises
the classic pipeline's capabilities, so CI's Linux runner selects **Classic** for
itself and only the override exercises the hybrid path there. The test records
the adapter's own choice next to the snapshots.

Both renders were read by eye on macOS and are indistinguishable.

## Two known defects found on the way, filed not papered over

**#234** — the last source row and column are skipped: `vello_hybrid` clamps
`Extend::Pad` to the last texel's leading corner and only then subtracts the half
texel that turns a corner into a centre, so the trailing edge freezes on a fixed
blend of the final two texels. In `vello_sparse_shaders`, not here.

**#239** — the first revision of this test compared the two engines pixel for
pixel and failed on CI's Linux leg, because the **classic** render there is
vertically flipped. That is pre-existing and unrelated to `draw_image`:
`shaderloom` writes its SPIR-V with naga's `ADJUST_COORDINATE_SPACE`, the Y-flip
wgpu deliberately does not use on Vulkan because it flips through a
negative-height viewport instead, so the two compose. Proven with a standalone
blit whose only variable was the shader module — upright through wgpu's runtime
WGSL, flipped through shaderloom's precompiled SPIR-V, same llvmpipe device — and
it has been silently inverting every Linux snapshot this repo uploads, including
`navigation/stack/root.png`. The assertions therefore compare the hybrid render
to the source image rather than to the other engine, which is the stronger claim
anyway; #239 carries restoring the cross-engine comparison as an acceptance
criterion.

Fixes #196