### PR TITLE
build: pin the repository to stable with a rust-toolchain.toml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,8 +207,12 @@ jobs:
           shared-key: ffi-header-macos
           cache-targets: false
           cache-on-failure: true
+      # `+nightly` is named rather than inherited: `rust-toolchain.toml` pins the
+      # repository to stable and overrides what the action above sets, so an
+      # ambient `cargo run` here would generate the header with the wrong
+      # channel and cbindgen would lose the macro expansion.
       - name: Regenerate the header
-        run: cargo run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
+        run: cargo +nightly run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
       - name: Verify the committed header matches
         run: |
           set -euo pipefail

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,18 @@
+# The toolchain is a property of this repository, not of whoever checked it out.
+#
+# CI lints and tests on `dtolnay/rust-toolchain@stable`, and clippy's findings
+# differ between channels in both directions: `match_same_arms` and
+# `too_many_lines` fire on stable and are silent on nightly, while the
+# `Send`-solver `overflow evaluating the requirement` diagnostic fires on
+# nightly and is silent on stable. Without this file, a contributor whose
+# rustup default is nightly gets a green local run and a red CI.
+#
+# One task genuinely needs nightly: FFI header generation, because cbindgen
+# expands the macro-generated exports through `-Zunpretty=expanded`. It names
+# the channel explicitly, and an explicit `+toolchain` always wins over this
+# file:
+#
+#     cargo +nightly run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
+[toolchain]
+channel = "stable"
+components = ["clippy", "rustfmt"]


### PR DESCRIPTION
Fixes #236.

Without a `rust-toolchain.toml`, the toolchain a build uses is the checkout's active rustup default, while CI lints and
tests on `dtolnay/rust-toolchain@stable`. Clippy's findings differ between the channels in
both directions:

| lint | stable | nightly |
| --- | --- | --- |
| `clippy::match_same_arms` | fires | silent |
| `clippy::too_many_lines` | fires | silent |
| `overflow evaluating the requirement ...: Send` | silent | fires (#223) |

So a nightly default produces a green local run and a red CI — and reading the nightly-only
diagnostic makes it look like CI is broken when it is not. Three consecutive CI failures on
 #231 and #232 were exactly this, and #223 carries the misdiagnosis it caused.

**The FFI Header job has to name its channel now.** It installs nightly with
`dtolnay/rust-toolchain@nightly` and then ran the generator through the *ambient* toolchain,
which this file overrides. cbindgen needs nightly because it expands the macro-generated
exports through `-Zunpretty=expanded`, so the step becomes `cargo +nightly run ...` — which
is exactly what the job's own error message already tells contributors to run locally. An
explicit `+toolchain` always wins over `rust-toolchain.toml`, so nothing else changes.

Verified in a clean checkout:

```
$ rustup show active-toolchain
stable-aarch64-apple-darwin (overridden by '.../rust-toolchain.toml')
$ cargo +nightly --version
cargo 1.100.0-nightly
```

`components = ["clippy", "rustfmt"]` so a fresh checkout can run the lint gate without a
separate rustup step.