### PR TITLE
Typeset Markdown math instead of dropping it

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12790,6 +12790,7 @@ dependencies = [
  "waterui-layout",
  "waterui-locale",
  "waterui-macros",
+ "waterui-math",
  "waterui-media",
  "waterui-navigation",
  "waterui-shape",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -130,6 +130,7 @@ waterui-graphics = { version = "0.3.0", path = "components/visual/graphics", def
 waterui-canvas = { version = "0.1.0", path = "components/visual/canvas" }
 waterui-shape = { version = "0.1.0", path = "components/foundation/shape", default-features = false }
 waterui-svg = { version = "0.1.0", path = "components/visual/svg" }
+waterui-math = { version = "0.1.0", path = "components/visual/math" }
 waterui-ffi = { version = "0.3.0", path = "ffi" }
 waterui-layout = { version = "0.3.0", path = "components/foundation/layout" }
 waterui-navigation = { version = "0.3.0", path = "components/foundation/navigation" }

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -44,6 +44,7 @@ waterui-graphics = { workspace = true, default-features = false }
 waterui-icon.workspace = true
 waterui-shape = { workspace = true, default-features = false }
 waterui-svg = { workspace = true, optional = true }
+waterui-math = { workspace = true, optional = true }
 waterui-assets = { workspace = true, optional = true }
 waterui-assets-macros = { workspace = true, optional = true }
 waterui-inspector-protocol = { workspace = true, optional = true }
@@ -171,6 +172,15 @@ flow-markdown = [
     "dep:tree-sitter-bash",
     "dep:tree-sitter-sequel",
 ]
+# Mathematical formulas in Markdown: `$…$` and `$$…$$` are parsed and typeset
+# through `waterui-math`. Off by default, and deliberately so — it brings a
+# layout engine, an OpenType `MATH` table reader and a LaTeX parser, and the
+# component declares a math font for the asset pipeline to bundle. An
+# application that shows no formulas should pay none of that.
+#
+# With this off the Markdown parser is built without `ENABLE_MATH`, so a dollar
+# sign in prose stays a dollar sign, exactly as it does today.
+markdown-math = ["flow-markdown", "dep:waterui-math"]
 std = ["dep:waterkit-haptic"]
 all = [
     "std",
@@ -182,6 +192,7 @@ all = [
     "media",
     "webview",
     "flow-markdown",
+    "markdown-math",
     "video-gpu",
     "navigation-restoration",
     "snackbar",

--- a/src/widget/flow_markdown.rs
+++ b/src/widget/flow_markdown.rs
@@ -1547,6 +1547,10 @@ fn rich_text_element_text_len(element: &RichTextElement) -> usize {
         RichTextElement::Group { elements, .. } => {
             elements.iter().map(rich_text_element_text_len).sum()
         }
+        // A formula's LaTeX source is not prose, so it does not count toward
+        // the visible character budget the streaming renderer meters.
+        #[cfg(feature = "markdown-math")]
+        RichTextElement::Math { .. } => 0,
         RichTextElement::Divider => 0,
     }
 }
@@ -1644,6 +1648,11 @@ fn truncate_rich_text_element(
                 Some(RichTextElement::Quote { content: kept })
             }
         }
+        // A formula reveals whole or not at all: there is no meaningful way to
+        // show the first few characters of one, and typing out its LaTeX would
+        // show the reader the source rather than the formula.
+        #[cfg(feature = "markdown-math")]
+        RichTextElement::Math { .. } => (*remaining > 0).then_some(element.clone()),
         // For non-textual structures we only show them after at least one text character
         // from this typewriter window has been revealed.
         RichTextElement::Divider

--- a/src/widget/rich_text.rs
+++ b/src/widget/rich_text.rs
@@ -80,6 +80,17 @@ pub enum RichTextElement {
     Text(StyledStr),
     /// A horizontal divider.
     Divider,
+    /// A mathematical formula, as LaTeX source.
+    ///
+    /// Only produced when the `markdown-math` feature is on, because that is
+    /// what enables the parser extension that recognises `$…$`.
+    #[cfg(feature = "markdown-math")]
+    Math {
+        /// The LaTeX between the delimiters.
+        source: Str,
+        /// `$$…$$` is set on its own line in display style; `$…$` is inline.
+        block: bool,
+    },
     /// A hyperlink.
     Link {
         /// The link label.
@@ -155,6 +166,8 @@ impl View for RichTextElement {
                 AnyView::new(crate::component::link::link(text(label), url))
             }
             Self::Image { src, alt: _ } => AnyView::new(render_image(&src)),
+            #[cfg(feature = "markdown-math")]
+            Self::Math { source, block } => AnyView::new(render_math(source, block)),
             Self::Table {
                 headers,
                 rows,
@@ -179,6 +192,33 @@ impl View for RichTextElement {
             Self::Divider => AnyView::new(Divider),
         }
     }
+}
+
+/// Recognising `$…$` is only correct when something can typeset the result.
+///
+/// Left on in a build with no math renderer, every dollar sign in prose would
+/// start a formula that nothing could draw — so the extension is enabled with
+/// the renderer and not otherwise.
+#[cfg(feature = "markdown-math")]
+const MATH_OPTIONS: Options = Options::ENABLE_MATH;
+
+/// The Markdown parser recognises no math without a renderer for it.
+#[cfg(not(feature = "markdown-math"))]
+const MATH_OPTIONS: Options = Options::empty();
+
+/// Typesets a formula parsed out of Markdown.
+///
+/// `$$…$$` is set in display style, which is what gives a summation its
+/// full-height limits and a fraction its wider spacing; `$…$` is set inline so
+/// it sits at the size of the surrounding prose.
+#[cfg(feature = "markdown-math")]
+fn render_math(source: Str, block: bool) -> AnyView {
+    let formula = waterui_math::view::Math::new(source);
+    AnyView::new(if block {
+        formula.display()
+    } else {
+        formula.inline()
+    })
 }
 
 fn render_image(src: &Str) -> AnyView {
@@ -493,7 +533,8 @@ fn parse_markdown(markdown: &str) -> Vec<RichTextElement> {
     let options = Options::ENABLE_TABLES
         | Options::ENABLE_FOOTNOTES
         | Options::ENABLE_STRIKETHROUGH
-        | Options::ENABLE_TASKLISTS;
+        | Options::ENABLE_TASKLISTS
+        | MATH_OPTIONS;
     let parser = Parser::new_ext(markdown, options);
 
     let mut stack = vec![Container::Root(Vec::new())];
@@ -769,11 +810,41 @@ fn parse_markdown(markdown: &str) -> Vec<RichTextElement> {
                     push_to_parent(&mut stack, RichTextElement::Text(styled));
                 }
             }
-            Event::Html(text)
-            | Event::FootnoteReference(text)
-            | Event::InlineMath(text)
-            | Event::DisplayMath(text)
-            | Event::InlineHtml(text) => {
+            // `$…$` and `$$…$$`. These only arrive when the parser is built
+            // with `ENABLE_MATH`, which happens only under this feature, so
+            // without it a dollar sign stays ordinary text.
+            #[cfg(feature = "markdown-math")]
+            Event::InlineMath(source) => {
+                push_inline_element(
+                    &mut stack,
+                    RichTextElement::Math {
+                        source: Str::from(source.as_ref().to_string()),
+                        block: false,
+                    },
+                );
+            }
+            #[cfg(feature = "markdown-math")]
+            Event::DisplayMath(source) => {
+                push_inline_element(
+                    &mut stack,
+                    RichTextElement::Math {
+                        source: Str::from(source.as_ref().to_string()),
+                        block: true,
+                    },
+                );
+            }
+            // Without the feature the parser is built without `ENABLE_MATH`,
+            // so these cannot be produced. Saying so is better than a silent
+            // arm that would quietly render a formula as its own source if the
+            // options above ever changed.
+            #[cfg(not(feature = "markdown-math"))]
+            Event::InlineMath(_) | Event::DisplayMath(_) => {
+                unreachable!(
+                    "pulldown-cmark emitted a math event, but the parser is built without \
+                     ENABLE_MATH; enable the `markdown-math` feature to render formulas"
+                )
+            }
+            Event::Html(text) | Event::FootnoteReference(text) | Event::InlineHtml(text) => {
                 if let Some(mut sink) = current_inline_sink(&mut stack) {
                     sink.push_text(text.as_ref());
                 } else {
@@ -1123,6 +1194,64 @@ impl Default for InlineGroup {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Collects a document's elements into a shape that is easy to assert on.
+    fn plain_text_of(elements: &[RichTextElement]) -> String {
+        elements.iter().map(element_to_plain_text).collect()
+    }
+
+    /// With the renderer present, `$…$` becomes a formula rather than prose.
+    #[cfg(feature = "markdown-math")]
+    #[test]
+    fn inline_and_display_math_become_math_elements() {
+        let elements = parse_markdown("before $e^{i\\pi}+1=0$ after\n\n$$\\frac{a}{b}$$");
+
+        let mut inline = 0;
+        let mut block = 0;
+        fn count(elements: &[RichTextElement], inline: &mut usize, block: &mut usize) {
+            for element in elements {
+                match element {
+                    RichTextElement::Math { block: true, .. } => *block += 1,
+                    RichTextElement::Math { block: false, .. } => *inline += 1,
+                    RichTextElement::Group { elements, .. }
+                    | RichTextElement::Quote { content: elements } => {
+                        count(elements, inline, block);
+                    }
+                    _ => {}
+                }
+            }
+        }
+        count(&elements, &mut inline, &mut block);
+
+        assert_eq!(inline, 1, "expected one inline formula in {elements:?}");
+        assert_eq!(block, 1, "expected one display formula in {elements:?}");
+    }
+
+    /// The formula's LaTeX must not also appear as prose. Rendering the source
+    /// alongside, or instead of, the formula is the defect this replaces.
+    #[cfg(feature = "markdown-math")]
+    #[test]
+    fn math_source_does_not_leak_into_the_text() {
+        let elements = parse_markdown("value $x^2$ end");
+        let prose = plain_text_of(&elements);
+        assert!(
+            !prose.contains("x^2"),
+            "the LaTeX source must not be rendered as text, got {prose:?}"
+        );
+    }
+
+    /// Without the renderer the parser has no math extension, so a dollar sign
+    /// is an ordinary character and nothing panics on prose that contains one.
+    #[cfg(not(feature = "markdown-math"))]
+    #[test]
+    fn a_dollar_sign_is_ordinary_text_without_the_math_feature() {
+        let elements = parse_markdown("it costs $5 and $10, or $x$ if you prefer");
+        let prose = plain_text_of(&elements);
+        assert!(
+            prose.contains("$5") && prose.contains("$10"),
+            "prices must survive as written, got {prose:?}"
+        );
+    }
 
     struct MockTableCell {
         size: Size,


### PR DESCRIPTION
`$…$` and `$$…$$` in Markdown now become typeset formulas, behind a new
`markdown-math` feature. Fixes #214.

## A correction to the issue

I filed #214 saying markdown math was being rendered as literal LaTeX source.
That was wrong, and I've [corrected it on the issue](https://github.com/water-rs/waterui/issues/214#issuecomment-5505207694).

`parse_markdown` never set `Options::ENABLE_MATH`, so pulldown-cmark could not
emit `InlineMath` or `DisplayMath` at all. Nothing was being mis-rendered. What
existed was an arm matching both events *alongside* `Event::Html` — unreachable
code that read as though Markdown math were handled, which is exactly what
misled me. The next person would have read it the same way.

So this PR adds the capability and deletes the misleading arm.

## Off by default, and why

`markdown-math` brings a layout engine, an OpenType `MATH` table reader and a
LaTeX parser, and `waterui-math` declares a math font for the asset pipeline to
bundle. An application that shows no formulas should pay none of that — the same
reasoning `flow-markdown` already applies to a CommonMark parser and a dozen
tree-sitter grammars.

With the feature off the parser is built without `ENABLE_MATH`, so behaviour is
byte-for-byte what it is today: a dollar sign in prose stays a dollar sign, a
price list does not become a formula, and nothing panics. The math events are
then impossible to receive, and the arm covering them says so with
`unreachable!` rather than silently falling back to rendering source text if
those parser options are ever changed.

## The bug my first attempt hit

Formulas are pushed with `push_inline_element`, the path inline images take —
not `push_to_parent`, which silently discards anything pushed while an inline
container is open (its `_ => {}`). My first version used the latter and the
formulas vanished: the `$…$` was consumed from the text but no element replaced
it, leaving `"before  after"` with a double space. Worth knowing that function
drops rather than errors.

`$$…$$` renders in display style, `$…$` inline — the difference between a
summation with full-height limits and one sized to sit in running text.

## Verification

Three feature configurations build clean (`cargo check -p waterui-internal` at
default, `--no-default-features --features flow-markdown`, and
`--features markdown-math`), and clippy is clean on the touched files in both
the default and math configurations.

Tests pin both halves of the contract:

- with the feature — an inline and a display formula each become a `Math`
  element, and the LaTeX source does not also leak into the prose;
- without it — `$5` and `$10` survive as written.

The second test is the one that matters for existing users: it is what proves
this change is invisible to every application that does not ask for it.

## Not in this PR

An inline formula is laid out as a sibling in the paragraph's horizontal stack,
so it aligns on the stack's baseline rather than being fitted to the surrounding
text's baseline and x-height. That is good enough to read and is how inline
images already behave, but true inline math wants the formula's baseline to meet
the text's. Worth its own issue once someone has looked at a paragraph of it.
