### PR TITLE
fix(hydrolysis): keep materialized views out of the address-keyed measure cache

### DIFF
--- a/backends/hydrolysis/src/renderer/render/measurement.rs
+++ b/backends/hydrolysis/src/renderer/render/measurement.rs
@@ -101,18 +101,38 @@ pub(crate) fn measure_view_intrinsic(
     measure_view_dimensions(view, state, env).size
 }
 
+/// Measures a view this measurement materialized rather than one the retained
+/// tree owns.
+///
+/// The intrinsic-measurement cache is keyed by heap address, which names a view
+/// only while that view is allocated, so a view built in order to be measured —
+/// and dropped the moment it has been — must not reach that cache: the next one
+/// materialized in the same frame is handed its address and reads its size back
+/// as its own. Use this at every site that measures a view it just built. See
+/// [`begin_transient_measurement`](MeasurementCaches::begin_transient_measurement).
+pub(crate) fn measure_transient_view_intrinsic(
+    view: &AnyView,
+    state: &mut HydroState,
+    env: &Environment,
+) -> LayoutSize {
+    state.measurement.begin_transient_measurement();
+    let size = measure_view_intrinsic(view, state, env);
+    state.measurement.end_transient_measurement();
+    size
+}
+
 /// Measures the intrinsic visual size of a control's [`Label`].
 ///
-/// Hydrolysis caches intrinsic measurements by `AnyView` identity, so the
-/// label is type-erased at this single boundary rather than at every call
-/// site. The semantic identity of the label remains typed inside the
-/// control's config.
+/// The label is type-erased at this single boundary rather than at every call
+/// site. The `AnyView` exists only for the measurement, so this goes through
+/// [`measure_transient_view_intrinsic`]. The semantic identity of the label
+/// remains typed inside the control's config.
 pub(crate) fn measure_label_intrinsic(
     label: &waterui_controls::label::Label,
     state: &mut HydroState,
     env: &Environment,
 ) -> LayoutSize {
-    measure_view_intrinsic(&AnyView::new(label.clone()), state, env)
+    measure_transient_view_intrinsic(&AnyView::new(label.clone()), state, env)
 }
 
 pub(crate) fn measure_view_dimensions(
@@ -579,7 +599,7 @@ pub(crate) fn measure_navigation_view_intrinsic(
             .prompt(search.prompt.clone());
         let search_body =
             normalize_layout_view(AnyView::new(search_field.body(&body_env)), &body_env);
-        measure_view_intrinsic(&search_body, state, &body_env)
+        measure_transient_view_intrinsic(&search_body, state, &body_env)
     } else {
         LayoutSize::zero()
     };
@@ -610,7 +630,13 @@ pub(crate) fn measure_owned_navigation_view_intrinsic(
         item.content = normalize_layout_view(core::mem::take(&mut item.content), env);
     }
     navigation.content = normalize_layout_view(navigation.content, env);
-    measure_navigation_view_intrinsic(&navigation, state, env)
+    // The whole `NavigationView` was built here, so its bar, toolbar and
+    // content die with this call: measure it as transient so none of them
+    // leave an entry under an address the next build is handed.
+    state.measurement.begin_transient_measurement();
+    let size = measure_navigation_view_intrinsic(&navigation, state, env);
+    state.measurement.end_transient_measurement();
+    size
 }
 
 pub(crate) fn measure_tabs_intrinsic(
@@ -633,7 +659,7 @@ pub(crate) fn measure_tabs_intrinsic(
             .max(metrics.button_min_width);
 
         let content = normalize_layout_view(AnyView::new(tab.content.build()), env);
-        let content_size = measure_view_intrinsic(&content, state, env);
+        let content_size = measure_transient_view_intrinsic(&content, state, env);
         max_content_width = max_content_width.max(f64::from(content_size.width));
         max_content_height = max_content_height.max(f64::from(content_size.height));
     }
@@ -731,7 +757,7 @@ pub(crate) fn measure_list_intrinsic(
         .get_view(0)
         .unwrap_or_else(|| panic!("ListConfig failed to materialize item at index 0"));
     first_item.content = normalize_layout_view(first_item.content, env);
-    let content_size = measure_view_intrinsic(&first_item.content, state, env);
+    let content_size = measure_transient_view_intrinsic(&first_item.content, state, env);
     let metrics = widget_theme(env).list_metrics();
     let row_height = (f64::from(content_size.height) + metrics.vertical_inset * 2.0)
         .max(metrics.one_line_row_height);
@@ -788,7 +814,7 @@ pub(crate) fn measure_list_item_row_height(
     state: &mut HydroState,
     env: &Environment,
 ) -> f64 {
-    let intrinsic = measure_view_intrinsic(&item.content, state, env);
+    let intrinsic = measure_transient_view_intrinsic(&item.content, state, env);
     let metrics = widget_theme(env).list_metrics();
     (f64::from(intrinsic.height) + metrics.vertical_inset * 2.0).max(metrics.one_line_row_height)
 }
@@ -938,7 +964,7 @@ pub(crate) fn measure_table_metrics(
     for column in columns {
         let mut width = metrics.min_column_width;
         let label_view = normalize_layout_view(AnyView::new(column.label()), env);
-        let label_size = measure_view_intrinsic(&label_view, state, env);
+        let label_size = measure_transient_view_intrinsic(&label_view, state, env);
         width = width.max(f64::from(label_size.width) + metrics.cell_horizontal_padding);
 
         let rows = column.rows();
@@ -966,7 +992,7 @@ pub(crate) fn refresh_table_slot_baseline(
     slot.max_rows = 0;
     for (index, column) in columns.iter().enumerate() {
         let label_view = normalize_layout_view(AnyView::new(column.label()), env);
-        let label_size = measure_view_intrinsic(&label_view, state, env);
+        let label_size = measure_transient_view_intrinsic(&label_view, state, env);
         let width = (f64::from(label_size.width) + metrics.cell_horizontal_padding)
             .max(metrics.min_column_width);
         if slot.column_widths[index] < width {
@@ -995,7 +1021,7 @@ pub(crate) fn update_table_slot_visible_cell_widths(
         for row_index in row_window.start..row_window.end {
             if let Some(cell) = rows.get_view(row_index) {
                 let cell_view = normalize_layout_view(AnyView::new(cell), env);
-                let size = measure_view_intrinsic(&cell_view, state, env);
+                let size = measure_transient_view_intrinsic(&cell_view, state, env);
                 let width = (f64::from(size.width) + metrics.cell_horizontal_padding)
                     .max(metrics.min_column_width);
                 if slot.column_widths[column_index] < width {

--- a/backends/hydrolysis/src/renderer/render/measurement_cache.rs
+++ b/backends/hydrolysis/src/renderer/render/measurement_cache.rs
@@ -46,6 +46,9 @@ pub(crate) struct MeasurementCaches {
     dynamic_proposal: FxHashMap<(usize, ProposalKey), ViewDimensions>,
     /// Re-entrancy guard: `Dynamic` nodes currently being measured.
     dynamic_measurement_stack: Vec<(usize, ProposalSize)>,
+    /// Depth of the transient-measurement scopes currently open; see
+    /// [`MeasurementCaches::begin_transient_measurement`].
+    transient_depth: u32,
     hits: u32,
     misses: u32,
 }
@@ -53,12 +56,19 @@ pub(crate) struct MeasurementCaches {
 impl MeasurementCaches {
     /// Cached dimensions for a concrete view under a proposal, counting the
     /// lookup in the per-frame hit/miss statistics.
+    ///
+    /// Answers `None` inside a transient scope, where an address does not
+    /// identify a view.
     pub(crate) fn view_dimensions(
         &mut self,
         view_identity: usize,
         env_identity: usize,
         proposal: ProposalSize,
     ) -> Option<ViewDimensions> {
+        if self.transient_depth > 0 {
+            self.misses += 1;
+            return None;
+        }
         let key = ViewMeasurementKey {
             view_identity,
             env_identity,
@@ -73,6 +83,9 @@ impl MeasurementCaches {
         cached
     }
 
+    /// Records a view's dimensions, unless a transient scope is open — a view
+    /// that dies with the measurement must leave nothing behind under an
+    /// address the next one will be handed.
     pub(crate) fn store_view_dimensions(
         &mut self,
         view_identity: usize,
@@ -80,12 +93,43 @@ impl MeasurementCaches {
         proposal: ProposalSize,
         dimensions: ViewDimensions,
     ) {
+        if self.transient_depth > 0 {
+            return;
+        }
         let key = ViewMeasurementKey {
             view_identity,
             env_identity,
             proposal: proposal.into(),
         };
         self.view_dimensions.insert(key, dimensions);
+    }
+
+    /// Opens a scope in which measured views are materialized by the
+    /// measurement itself rather than owned by the retained tree.
+    ///
+    /// `view_dimensions` is keyed by a view's heap address, which names one
+    /// view only while that view is allocated. A view built to be measured — a
+    /// list row pulled out of its collection, a control's label re-erased into
+    /// an `AnyView`, a tab's content built for a size — is dropped the moment
+    /// the measurement returns, and the allocator hands its address straight to
+    /// the next such view *within the same frame*. Clearing the cache per frame
+    /// therefore does not make the key sound: the stale entry is read back as
+    /// the new view's size, and a list reports its neighbour's row height.
+    ///
+    /// Inside the scope the cache is neither read nor written, so an address in
+    /// it always belongs to the view that is still holding it. The scope covers
+    /// the whole subtree because a view materialized here owns its children:
+    /// their addresses die with it.
+    pub(crate) fn begin_transient_measurement(&mut self) {
+        self.transient_depth += 1;
+    }
+
+    /// Closes a scope opened by [`Self::begin_transient_measurement`].
+    pub(crate) fn end_transient_measurement(&mut self) {
+        self.transient_depth = self
+            .transient_depth
+            .checked_sub(1)
+            .expect("hydrolysis transient measurement scope underflow");
     }
 
     pub(crate) fn dynamic_intrinsic(&self, identity: usize) -> Option<ViewDimensions> {
@@ -159,8 +203,12 @@ impl MeasurementCaches {
     /// each view's `stable_ptr` (its heap address), which is unique only while
     /// that view is alive: across frames a freed view's address is reused by a
     /// new, different view, so a stale entry under the reused address would
-    /// otherwise be returned as that new view's measurement. Clearing per frame
-    /// keeps the cache sound while preserving within-frame memoization.
+    /// otherwise be returned as that new view's measurement.
+    ///
+    /// Clearing per frame covers views that live as long as the tree does.
+    /// Views a measurement materializes for itself are freed *within* the
+    /// frame, and [`Self::begin_transient_measurement`] keeps those out of the
+    /// cache entirely.
     pub(crate) fn begin_frame(&mut self) {
         self.view_dimensions.clear();
         self.reset_counters();

--- a/backends/hydrolysis/src/widgets/layout/badge.rs
+++ b/backends/hydrolysis/src/widgets/layout/badge.rs
@@ -10,7 +10,7 @@ use waterui_text::styled::StyledStr;
 use crate::renderer::transformed_rect;
 use crate::renderer::{
     HydroNativeView, HydroState, HydrolysisRenderer, RenderContext, RetainedSubview,
-    WidgetRenderContext, measure_view_dimensions_with_proposal, measure_view_intrinsic,
+    WidgetRenderContext, measure_transient_view_intrinsic, measure_view_dimensions_with_proposal,
     normalize_view_for_render,
 };
 use crate::widgets::widget_theme;
@@ -53,7 +53,7 @@ fn badge_content_size(
     env: &Environment,
 ) -> LayoutSize {
     let content = normalize_view_for_render(badge.as_inner().content.build(), env);
-    measure_view_intrinsic(&content, state, env)
+    measure_transient_view_intrinsic(&content, state, env)
 }
 
 fn badge_large_label(value: i32, env: &Environment) -> StyledStr {

--- a/backends/hydrolysis/src/widgets/layout/container.rs
+++ b/backends/hydrolysis/src/widgets/layout/container.rs
@@ -1,7 +1,7 @@
 use crate::renderer::lazy::{LazyStackAxisConfig, lazy_stack_axis_config};
 use crate::renderer::{
     HydroNativeView, HydroState, estimate_layout_intrinsic, measure_layout_dimensions,
-    measure_view_intrinsic, normalize_layout_view,
+    measure_transient_view_intrinsic, normalize_layout_view,
 };
 use nami::Signal;
 use waterui::views::Views;
@@ -58,7 +58,7 @@ impl HydroNativeView for Native<LazyContainer> {
         let sample = children
             .get_view(0)
             .map(|view| normalize_layout_view(view, env))
-            .map(|view| measure_view_intrinsic(&view, state, env))
+            .map(|view| measure_transient_view_intrinsic(&view, state, env))
             .unwrap_or_else(|| panic!("LazyContainer failed to materialize child at index 0"));
         let count = child_count as f64;
         match axis {

--- a/backends/hydrolysis/src/widgets/layout/list.rs
+++ b/backends/hydrolysis/src/widgets/layout/list.rs
@@ -7,7 +7,7 @@ use crate::renderer::AccessibilityActionTarget;
 use crate::renderer::{
     HydroNativeView, HydroState, HydrolysisRenderer, RenderContext, VisibleSubviewCache,
     WidgetRenderContext, local_interaction_state, materialize_list_item, measure_list_intrinsic,
-    measure_list_item_row_height, measure_view_intrinsic, transformed_rect,
+    measure_list_item_row_height, measure_transient_view_intrinsic, transformed_rect,
 };
 use crate::scroll::ScrollHandle;
 #[cfg(feature = "accessibility")]
@@ -994,7 +994,8 @@ pub(crate) fn render_list_parts(
         }
 
         let deletable = ctx.renderer_mut().read_signal(&item.deletable);
-        let content_size = measure_view_intrinsic(&item.content, ctx.state_mut(), &row_env);
+        let content_size =
+            measure_transient_view_intrinsic(&item.content, ctx.state_mut(), &row_env);
         let mut content_rect = list_content_rect(row_rect, list_metrics, content_size);
         let mut trailing_x = row_rect.x1 - 8.0;
 

--- a/backends/hydrolysis/src/widgets/nav/navigation.rs
+++ b/backends/hydrolysis/src/widgets/nav/navigation.rs
@@ -6,9 +6,9 @@ use crate::renderer::accessibility_activation_point;
 use crate::renderer::{
     HydroNativeView, HydroState, HydrolysisRenderer, RenderContext, RetainedSubview,
     WidgetRenderContext, measure_navigation_view_intrinsic,
-    measure_owned_navigation_view_intrinsic, measure_view_intrinsic, navigation_back_button_rect,
-    navigation_base_bar_height_for_display_mode, normalize_layout_view, resolved_color_to_peniko,
-    split_compact_threshold, transformed_rect,
+    measure_owned_navigation_view_intrinsic, measure_transient_view_intrinsic,
+    navigation_back_button_rect, navigation_base_bar_height_for_display_mode,
+    normalize_layout_view, resolved_color_to_peniko, split_compact_threshold, transformed_rect,
 };
 #[cfg(feature = "accessibility")]
 use accesskit::{
@@ -798,7 +798,7 @@ fn measure_navigation_split_layout(
     env: &Environment,
 ) -> LayoutSize {
     let primary_view = normalize_layout_view(split.primary_builder().build(), env);
-    let primary = measure_view_intrinsic(&primary_view, state, env);
+    let primary = measure_transient_view_intrinsic(&primary_view, state, env);
     let primary_selection = split.primary_selection().get();
     let content = split.content_builder().and_then(|builder| {
         primary_selection.map(|selected| {
@@ -811,7 +811,7 @@ fn measure_navigation_split_layout(
     let detail = match detail_selection {
         None => {
             let placeholder = normalize_layout_view(split.placeholder_builder().build(), env);
-            measure_view_intrinsic(&placeholder, state, env)
+            measure_transient_view_intrinsic(&placeholder, state, env)
         }
         Some(selected) => measure_owned_navigation_view_intrinsic(
             split.detail_builder().build(selected),

--- a/backends/hydrolysis/src/widgets/visual/map.rs
+++ b/backends/hydrolysis/src/widgets/visual/map.rs
@@ -14,7 +14,8 @@ use waterui_text::Text;
 
 use crate::renderer::{
     HydroNativeView, HydroState, HydrolysisRenderer, RetainedSubview, WidgetRenderContext,
-    measure_view_dimensions_with_proposal, measure_view_intrinsic, normalize_view_for_render,
+    measure_transient_view_intrinsic, measure_view_dimensions_with_proposal,
+    normalize_view_for_render,
 };
 
 const MAP_SURFACE_HEIGHT: f32 = 184.0;
@@ -181,7 +182,7 @@ impl HydroNativeView for Native<MapConfig> {
     fn intrinsic(state: &mut HydroState, view: &Self, env: &Environment) -> LayoutSize {
         let render_env = map_render_env(env);
         let surface_label = map_surface_label(env);
-        measure_view_intrinsic(
+        measure_transient_view_intrinsic(
             &map_content(view.as_inner(), &surface_label, &render_env),
             state,
             &render_env,


### PR DESCRIPTION
Fixes #238

`measure_view_dimensions_with_proposal` memoizes by the boxed view's heap address, and `begin_frame` only clears the map per frame. Measurements that materialize a view and drop it inside the same frame (label, list, list-item row, tabs/table/navigation/badge, `LazyContainer`) hand that address to the next transient view, which then reads the previous view's dimensions as its own. That is the intermittent macOS failure of `material_list_exposes_list_item_semantics_and_actions` (min-height probe 144 vs max-height probe 112 for the same list): 3/80 failures before, 0/200 with the fix.

`MeasurementCaches` gains a transient-measurement scope inside which the view-dimension cache is neither read nor written; every measurement that builds its own subject runs inside it. Retained-tree views keep their memoization. Not a regression in cost: the hydrolysis renderer/runner tests run in 6.35 s with the fix vs 9.94 s before.

(#227 was merged before this commit reached it; this PR carries the remaining commit.)