### PR TITLE
fix(hydrolysis): derive the output encoding from the target's format

### DIFF
--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -20,6 +20,7 @@
 #[cfg(feature = "accessibility")]
 mod accessibility;
 mod bindings;
+mod color;
 mod effects;
 mod frame;
 mod identity;
@@ -139,7 +140,7 @@ use waterui_form::picker::PickerConfig;
 use waterui_form::picker::color::ColorPickerConfig;
 use waterui_form::picker::date::DatePickerConfig;
 use waterui_form::secure::{Secure as FormSecure, SecureFieldConfig};
-use waterui_graphics::color::{Color, ResolvedColor, Srgb};
+use waterui_graphics::color::{Color, ResolvedColor};
 
 use shaderloom::WgslModuleCache;
 use waterui_graphics::filter_view::{EffectContext, EffectInput, EffectOutput};

--- a/backends/hydrolysis/src/renderer/color.rs
+++ b/backends/hydrolysis/src/renderer/color.rs
@@ -1,0 +1,166 @@
+//! How a render target expects colour to be written into it.
+//!
+//! Everything that puts colour into a target — the clear value and the
+//! compositor's fragment shader alike — has to answer the same question: does
+//! the attachment apply the sRGB transfer function on write, or does it store
+//! exactly what it is given? Answering it twice, in two places, from two
+//! assumptions is what produced water-rs/waterui#233, where every colour the
+//! renderer emitted came out as `srgb_to_linear` of itself. Both answers are
+//! derived here, from the format itself.
+
+use waterui_graphics::color::{ResolvedColor, Srgb};
+
+/// The encoding a render target's format implies for the values written to it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum TargetEncoding {
+    /// An `…Srgb` format. The hardware applies the linear-to-sRGB transfer
+    /// function on write, so the values handed to it are linear.
+    HardwareSrgb,
+    /// A plain 8-bit UNORM format. Nothing transforms the value on the way in,
+    /// so it has to arrive already carrying the sRGB transfer function.
+    StoredSrgb,
+    /// A float format, holding extended-range linear values. This is what
+    /// wide-gamut and HDR output are written into.
+    Linear,
+}
+
+impl TargetEncoding {
+    /// Reads the encoding off a target's format.
+    pub(crate) fn of(format: wgpu::TextureFormat) -> Self {
+        if format.is_srgb() {
+            Self::HardwareSrgb
+        } else if matches!(
+            format,
+            wgpu::TextureFormat::Rgba16Float | wgpu::TextureFormat::Rgba32Float
+        ) {
+            Self::Linear
+        } else {
+            Self::StoredSrgb
+        }
+    }
+
+    /// Whether a colour written to this target has to carry the sRGB transfer
+    /// function itself, because nothing downstream will apply it.
+    pub(crate) const fn stores_encoded_srgb(self) -> bool {
+        matches!(self, Self::StoredSrgb)
+    }
+
+    /// The clear value for this target.
+    ///
+    /// `wgpu` hands the value to the attachment untouched, so what it must
+    /// contain depends entirely on what the attachment does with it.
+    pub(crate) fn clear_value(self, color: vello::peniko::Color) -> wgpu::Color {
+        let srgb = Srgb::new(
+            color.components[0],
+            color.components[1],
+            color.components[2],
+        );
+        let alpha = f64::from(color.components[3]);
+        if self.stores_encoded_srgb() {
+            return wgpu::Color {
+                r: f64::from(srgb.red),
+                g: f64::from(srgb.green),
+                b: f64::from(srgb.blue),
+                a: alpha,
+            };
+        }
+        let linear = ResolvedColor::from_srgb(srgb).linear_with_headroom();
+        wgpu::Color {
+            r: f64::from(linear[0]),
+            g: f64::from(linear[1]),
+            b: f64::from(linear[2]),
+            a: alpha,
+        }
+    }
+
+    /// Whether the compositor's shader should decode the sRGB it samples.
+    ///
+    /// The scene it samples is always sRGB — vello composites in sRGB and
+    /// stores it into a plain `Rgba8Unorm` texture. Decoding is right exactly
+    /// when something downstream puts the transfer function back: the hardware
+    /// on an `…Srgb` attachment, or nothing at all on a float attachment, which
+    /// wants linear in the first place.
+    pub(crate) const fn compositor_decodes_source(self) -> bool {
+        !self.stores_encoded_srgb()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::TargetEncoding;
+
+    #[test]
+    fn a_plain_unorm_target_stores_the_srgb_it_is_given() {
+        let encoding = TargetEncoding::of(wgpu::TextureFormat::Rgba8Unorm);
+        assert_eq!(encoding, TargetEncoding::StoredSrgb);
+        assert!(encoding.stores_encoded_srgb());
+        // Decoding here is the #233 defect: nothing would put the transfer
+        // function back, so every colour would land as linear.
+        assert!(!encoding.compositor_decodes_source());
+    }
+
+    #[test]
+    fn an_srgb_target_is_handed_linear_because_the_hardware_encodes() {
+        for format in [
+            wgpu::TextureFormat::Rgba8UnormSrgb,
+            wgpu::TextureFormat::Bgra8UnormSrgb,
+        ] {
+            let encoding = TargetEncoding::of(format);
+            assert_eq!(encoding, TargetEncoding::HardwareSrgb);
+            assert!(!encoding.stores_encoded_srgb());
+            assert!(encoding.compositor_decodes_source());
+        }
+    }
+
+    #[test]
+    fn a_float_target_holds_extended_range_linear() {
+        for format in [
+            wgpu::TextureFormat::Rgba16Float,
+            wgpu::TextureFormat::Rgba32Float,
+        ] {
+            let encoding = TargetEncoding::of(format);
+            assert_eq!(encoding, TargetEncoding::Linear);
+            assert!(encoding.compositor_decodes_source());
+        }
+    }
+
+    /// The clear value and the compositor have to agree, because they paint the
+    /// same pixels: the clear fills the frame and the compositor draws over it.
+    /// Disagreeing is what made the window background and the content wrong by
+    /// the same amount but for different reasons.
+    #[test]
+    fn the_clear_value_and_the_shader_answer_the_same_question() {
+        for format in [
+            wgpu::TextureFormat::Rgba8Unorm,
+            wgpu::TextureFormat::Bgra8Unorm,
+            wgpu::TextureFormat::Rgba8UnormSrgb,
+            wgpu::TextureFormat::Rgba16Float,
+        ] {
+            let encoding = TargetEncoding::of(format);
+            let white = encoding.clear_value(vello::peniko::Color::WHITE);
+            // White is the fixed point of the transfer function, so it pins the
+            // plumbing without depending on which branch was taken.
+            assert!((white.r - 1.0).abs() < 1e-6, "{format:?}");
+            assert_eq!(
+                encoding.compositor_decodes_source(),
+                !encoding.stores_encoded_srgb(),
+                "{format:?}"
+            );
+        }
+    }
+
+    /// The value a mid-tone clear carries differs by exactly the transfer
+    /// function, which is the whole of #233 in one assertion.
+    #[test]
+    fn a_mid_tone_differs_between_the_two_kinds_of_target() {
+        let mid = vello::peniko::Color::new([0.5, 0.5, 0.5, 1.0]);
+        let stored = TargetEncoding::of(wgpu::TextureFormat::Rgba8Unorm).clear_value(mid);
+        let hardware = TargetEncoding::of(wgpu::TextureFormat::Rgba8UnormSrgb).clear_value(mid);
+        assert!((stored.r - 0.5).abs() < 1e-6, "stored sRGB keeps the value");
+        assert!(
+            (hardware.r - 0.214_04).abs() < 1e-3,
+            "an sRGB attachment is handed linear, got {}",
+            hardware.r
+        );
+    }
+}

--- a/backends/hydrolysis/src/renderer/frame.rs
+++ b/backends/hydrolysis/src/renderer/frame.rs
@@ -32,21 +32,6 @@ pub(crate) fn scene_has_content(scene: &vello::Scene) -> bool {
     !encoding.is_empty() || !encoding.resources.glyph_runs.is_empty()
 }
 
-pub(crate) fn color_to_wgpu(color: vello::peniko::Color) -> wgpu::Color {
-    let linear = ResolvedColor::from_srgb(Srgb::new(
-        color.components[0],
-        color.components[1],
-        color.components[2],
-    ))
-    .linear_with_headroom();
-    wgpu::Color {
-        r: f64::from(linear[0]),
-        g: f64::from(linear[1]),
-        b: f64::from(linear[2]),
-        a: f64::from(color.components[3]),
-    }
-}
-
 impl HydrolysisRenderer {
     /// Records the window's logical bounds and the root transform that maps
     /// them onto the target's physical pixel grid.

--- a/backends/hydrolysis/src/renderer/render/compositor.rs
+++ b/backends/hydrolysis/src/renderer/render/compositor.rs
@@ -1,4 +1,5 @@
 use super::*;
+use crate::renderer::color::TargetEncoding;
 use core::num::NonZeroU32;
 #[cfg(hydrolysis_macos_system_webview)]
 use objc2::rc::Retained;
@@ -1489,6 +1490,7 @@ impl HydrolysisRenderer {
         queue: &wgpu::Queue,
         target: &wgpu::TextureView,
         base_color: vello::peniko::Color,
+        encoding: TargetEncoding,
     ) {
         let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
             label: Some("hydrolysis_surface_clear_encoder"),
@@ -1500,7 +1502,7 @@ impl HydrolysisRenderer {
                 depth_slice: None,
                 resolve_target: None,
                 ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(color_to_wgpu(base_color)),
+                    load: wgpu::LoadOp::Clear(encoding.clear_value(base_color)),
                     store: wgpu::StoreOp::Store,
                 },
             })],
@@ -1587,7 +1589,9 @@ impl HydrolysisRenderer {
                 depth_slice: None,
                 resolve_target: None,
                 ops: wgpu::Operations {
-                    load: wgpu::LoadOp::Clear(color_to_wgpu(target.base_color)),
+                    load: wgpu::LoadOp::Clear(
+                        TargetEncoding::of(target.format).clear_value(target.base_color),
+                    ),
                     store: wgpu::StoreOp::Store,
                 },
             })],
@@ -1622,8 +1626,15 @@ impl HydrolysisRenderer {
 
         self.flush_vello_scene_layer();
         self.frame_direct_gpu_surfaces = 0;
-        let fullscreen_uniform =
-            encode_compositor_uniform([[-1.0, 1.0], [1.0, 1.0], [1.0, -1.0], [-1.0, -1.0]], true);
+        // The scene the compositor samples is always sRGB. Whether it should be
+        // decoded depends on what the attachment does next, which is the
+        // target's format and nothing else — hard-coding it here is what made
+        // every colour come out as `srgb_to_linear` of itself (#233).
+        let encoding = TargetEncoding::of(target.format);
+        let fullscreen_uniform = encode_compositor_uniform(
+            [[-1.0, 1.0], [1.0, 1.0], [1.0, -1.0], [-1.0, -1.0]],
+            encoding.compositor_decodes_source(),
+        );
         let mut render_layers = core::mem::take(&mut self.compositor.render_layers);
         let transient_layer_count =
             if let Some(scene) = self.transient_scene.take().filter(scene_has_content) {
@@ -1633,7 +1644,13 @@ impl HydrolysisRenderer {
                 0
             };
         if render_layers.is_empty() {
-            self.clear_target_surface(target.device, target.queue, target.view, target.base_color);
+            self.clear_target_surface(
+                target.device,
+                target.queue,
+                target.view,
+                target.base_color,
+                encoding,
+            );
             return;
         }
         // The last condition is the one the layer could not answer for itself:
@@ -1691,6 +1708,7 @@ impl HydrolysisRenderer {
                     target.queue,
                     target.view,
                     target.base_color,
+                    encoding,
                 );
                 self.compositor.render_layers = render_layers;
                 return;
@@ -1879,7 +1897,13 @@ impl HydrolysisRenderer {
 
         // Phase 2 — one render pass, one submit, painter's order.
         if ready.is_empty() {
-            self.clear_target_surface(target.device, target.queue, target.view, target.base_color);
+            self.clear_target_surface(
+                target.device,
+                target.queue,
+                target.view,
+                target.base_color,
+                encoding,
+            );
         } else {
             self.composite_ready_layers(&target, &ready);
         }

--- a/components/visual/canvas/src/lib.rs
+++ b/components/visual/canvas/src/lib.rs
@@ -1371,6 +1371,82 @@ mod tests {
     /// and this is how the two are compared where both are available. The PNGs
     /// are for looking at — the engines rasterize differently, so nothing about
     /// them is asserted pixel-wise.
+    /// A fill keeps its colour from the brush to the pixel.
+    ///
+    /// vello composites in sRGB and stores sRGB into a non-sRGB target, so a
+    /// fill read back out of `Rgba8Unorm` must be the colour it was given. The
+    /// failure this pins is silent and total: a vello that starts emitting
+    /// linear, or a conversion that decodes on the way in, shifts every colour
+    /// in the framework by `srgb_to_linear` — leaving white and black untouched
+    /// and everything between wrong, which reads as a faint colour cast rather
+    /// than as a bug. That is exactly the shape water-rs/waterui#233 took, and
+    /// establishing this contract is what cleared vello of causing it. Both
+    /// engines are checked because they rasterize differently and could drift.
+    #[test]
+    fn a_fill_keeps_its_colour_through_both_scene_engines() {
+        use waterui_graphics::shared_context::SceneEngine;
+        use waterui_graphics::{GpuRuntime, OffscreenRenderConfig, OffscreenSize};
+
+        fn to_linear(c: f64) -> f64 {
+            let c = c / 255.0;
+            let linear = if c <= 0.04045 {
+                c / 12.92
+            } else {
+                ((c + 0.055) / 1.055).powf(2.4)
+            };
+            linear * 255.0
+        }
+
+        // M3 baseline light surfaceVariant, the token #233 rendered as #CCBED6.
+        let token = (0xE7_u8, 0xE0_u8, 0xEC_u8);
+        let fill = waterui_graphics::color::Srgb::from_hex("#E7E0EC");
+        let decoded = (
+            to_linear(f64::from(token.0)),
+            to_linear(f64::from(token.1)),
+            to_linear(f64::from(token.2)),
+        );
+
+        let runtime = pollster::block_on(GpuRuntime::new())
+            .expect("this test requires a working GPU runtime");
+        let size = OffscreenSize::try_from_pixels(64, 64).expect("test size must be valid");
+
+        for (engine, name) in [
+            (SceneEngine::Classic, "classic"),
+            (SceneEngine::Hybrid, "hybrid"),
+        ] {
+            let surface = SceneView::new(CanvasContent {
+                draw_fn: Box::new(move |ctx: &mut DrawingContext| {
+                    ctx.set_fill_style(fill);
+                    ctx.fill_rect(Rect::from_size(Size::new(64.0, 64.0)));
+                }),
+                invalidator: None,
+                pending_redraw: Rc::new(Cell::new(false)),
+                active_guards: Vec::new(),
+                text_engine: TextEngine::default(),
+            })
+            .into_gpu_surface();
+            let config = OffscreenRenderConfig::new(size)
+                .format(wgpu::TextureFormat::Rgba8Unorm)
+                .scene_engine(engine);
+            let mut env = waterui_core::Environment::new();
+            let output = pollster::block_on(surface.render_offscreen(&runtime, config, &mut env))
+                .expect("offscreen render should succeed");
+
+            let centre = ((32 * output.width + 32) * 4) as usize;
+            let pixel = (
+                output.rgba8[centre],
+                output.rgba8[centre + 1],
+                output.rgba8[centre + 2],
+            );
+            assert_eq!(
+                pixel, token,
+                "the {name} engine changed the fill's colour: drew {token:?}, read back \
+                 {pixel:?}. Decoding it to linear would give ({:.0}, {:.0}, {:.0}).",
+                decoded.0, decoded.1, decoded.2
+            );
+        }
+    }
+
     #[test]
     fn both_scene_engines_render_a_canvas() {
         use waterui_graphics::shared_context::SceneEngine;


### PR DESCRIPTION
Fixes #233.

Every colour the renderer emitted came out as `srgb_to_linear` of itself. White and black
were untouched and everything between was darkened non-linearly, so it read as a faint
colour cast rather than as a bug.

| role | token | before | after |
| --- | --- | --- | --- |
| `surface` | `#FEF7FF` | `#FDEDFF` | `#FEF7FF` |
| `surfaceVariant` | `#E7E0EC` | `#CCBED6` | `#E7E0EC` |

### What it was

Two places answered the same question — *does this attachment apply the sRGB transfer
function on write?* — and both answered it without asking the format.

`gpu_surface_compositor.wgsl` decodes the sRGB it samples when a uniform says to, and
`render_scene_to_surface` hard-coded that uniform to `true`. That is right only for an
`…Srgb` attachment, where the hardware puts the transfer function back on write. The
attachment is never one: `normalize_surface_format` strips the suffix from window surfaces
whenever the linear form exists, and the snapshot host asks for `Rgba8Unorm` outright.

`color_to_wgpu` converted the clear colour to linear on the same assumption, which is why
the window background was wrong by the same amount through an entirely different path.

### What it is now

One type, `TargetEncoding`, reads the answer off `wgpu::TextureFormat` and hands out both
the clear value and the shader flag, so they cannot disagree again. It has three cases from
the start:

- `HardwareSrgb` — an `…Srgb` format; hand it linear, the hardware encodes.
- `StoredSrgb` — a plain 8-bit UNORM; hand it sRGB, nothing will transform it.
- `Linear` — a float format; extended-range linear, which is where wide-gamut and HDR
  output goes. `supports_hydrolysis_surface_format` already accepts `Rgba16Float` and
  `Rgba32Float`, so this case exists rather than waiting for a second decision later.

### What was cleared along the way

vello is not at fault: it composites in sRGB (`vello_encoding/src/draw.rs:79`) and stores
sRGB, measured by reading a fill back out of `Rgba8Unorm` on both scene engines. Neither is
the M3 palette — `baseline_light().surface` holds the correct `#FEF7FF`. `waterui-canvas`
gains the test that pins the first of those; it would have turned this hunt into a one-step
diagnosis, and its job now is to make the next silent shift in vello's output space loud.

### Verification

The M3 tokens render as themselves to the byte, and 460 tests across `hydrolysis`,
`hydrolysis-m3`, `waterui-testing`, `waterui-canvas` and `waterui-mermaid` pass.

Note for review: this changes what every hydrolysis render looks like, so any snapshot
baseline captured before it is now wrong by the old amount. No committed baseline needed
updating — the suites above are all green — but the screenshots on waterui.dev were rendered
through this path and are being regenerated separately.