### PR TITLE
Stop requiring nightly to be the active toolchain for agent workspaces

### DIFF
--- a/.claude/skills/waterui-agent-workspace/SKILL.md
+++ b/.claude/skills/waterui-agent-workspace/SKILL.md
@@ -99,6 +99,15 @@ fast-forwarded`. Releasing the slot then has to be done by hand: confirm with
 every submodule back on their integration branch, and delete the spent agent
 branches in the superproject *and* in each submodule.
 
+**Then rebase the topic branch onto `origin/dev` — GitHub's — before opening the
+pull request, and check that `git log origin/dev..HEAD` lists only your own
+commits.** `create_workspace.sh` branches from the *local canonical* `dev`, and
+that is routinely ahead of GitHub while anyone has a pull request in flight or a
+superseded commit sitting on it. Whatever it carries becomes part of your pull
+request: a diff touching files you never opened, and someone else's failing test
+attributed to your change. Once the topic branch is pushed, leave canonical `dev`
+at `origin/dev` so the next workspace does not inherit the same passengers.
+
 7. Never use `git worktree` for this repository.
 
 8. Never set `CARGO_TARGET_DIR` or Cargo `build.target-dir` for this repository. This workflow depends on per-workspace `target/` directories plus shared `sccache`.

--- a/.claude/skills/waterui-agent-workspace/SKILL.md
+++ b/.claude/skills/waterui-agent-workspace/SKILL.md
@@ -88,6 +88,17 @@ If the canonical superproject and the workspace both changed the same submodule 
 
 Run it from anywhere inside the agent workspace, not from the canonical repository.
 
+**Run it before you push the topic branch and open the pull request**, in the
+order `AGENTS.md` gives: finish, then push, then open the PR. It fast-forwards
+the local canonical `dev` onto the agent branch, which is only possible while
+canonical is *behind* that branch. Once the pull request has merged, `dev`
+contains the work as a merge commit and is therefore ahead of the branch, so the
+fast-forward can never succeed and the script stops with `superproject cannot be
+fast-forwarded`. Releasing the slot then has to be done by hand: confirm with
+`git log origin/dev..HEAD` that nothing is unmerged, put the superproject and
+every submodule back on their integration branch, and delete the spent agent
+branches in the superproject *and* in each submodule.
+
 7. Never use `git worktree` for this repository.
 
 8. Never set `CARGO_TARGET_DIR` or Cargo `build.target-dir` for this repository. This workflow depends on per-workspace `target/` directories plus shared `sccache`.

--- a/.claude/skills/waterui-agent-workspace/scripts/common.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/common.sh
@@ -70,10 +70,6 @@ require_command() {
   command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
 }
 
-ensure_nightly_cargo() {
-  cargo -V | rg -q 'nightly' || die "nightly cargo is required to inspect Cargo configuration"
-}
-
 canonical_dir() {
   local path="$1"
   [[ -d "$path" ]] || die "directory does not exist: $path"
@@ -306,12 +302,39 @@ branch_submodules() {
   done < <(submodule_records "$repo_root")
 }
 
+# Refuse to run while every slot would share one target directory.
+#
+# Read the setting the way cargo resolves it, rather than through
+# `cargo -Z unstable-options config get`: that subcommand is nightly-only, and
+# requiring nightly to be the *active* toolchain broke both scripts once the
+# repository standardised on stable. Nothing else here needs a nightly cargo.
+#
+# `CARGO_TARGET_DIR` wins over the config files, and among those cargo merges
+# `$CARGO_HOME/config.toml` with every `.cargo/config.toml` from the working
+# directory upward, nearest first.
 ensure_no_shared_target_dir() {
-  local configured_target
+  local search config
 
-  if configured_target="$(cargo -Z unstable-options config get build.target-dir 2>/dev/null)"; then
-    die "cargo build.target-dir is configured (${configured_target//$'\n'/ }); remove it before creating agent workspaces"
+  if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
+    die "CARGO_TARGET_DIR is set ($CARGO_TARGET_DIR); unset it before creating agent workspaces"
   fi
+
+  search="$PWD"
+  while true; do
+    for config in "$search/.cargo/config.toml" "$search/.cargo/config"; do
+      if [[ -f "$config" ]] && rg -q '^\s*target-dir\s*=' "$config"; then
+        die "cargo target-dir is configured in $config; remove it before creating agent workspaces"
+      fi
+    done
+    [[ "$search" == "/" ]] && break
+    search="$(dirname "$search")"
+  done
+
+  for config in "${CARGO_HOME:-$HOME/.cargo}/config.toml" "${CARGO_HOME:-$HOME/.cargo}/config"; do
+    if [[ -f "$config" ]] && rg -q '^\s*target-dir\s*=' "$config"; then
+      die "cargo target-dir is configured in $config; remove it before creating agent workspaces"
+    fi
+  done
 }
 
 validate_slug() {

--- a/.claude/skills/waterui-agent-workspace/scripts/create_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/create_workspace.sh
@@ -59,7 +59,6 @@ main() {
   require_command awk
   require_command shasum
 
-  ensure_nightly_cargo
   validate_slug "$slug"
   ensure_canonical_repo_context
   ensure_no_shared_target_dir

--- a/.claude/skills/waterui-agent-workspace/scripts/finish_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/finish_workspace.sh
@@ -172,7 +172,6 @@ main() {
   require_command rm
   require_command shasum
 
-  ensure_nightly_cargo
   ensure_no_shared_target_dir
 
   source_root="$(canonical_dir "$SOURCE_REPO")"


### PR DESCRIPTION
Fixes #245.

## The defect

`ensure_nightly_cargo` refused to run unless `cargo -V` reported nightly, and
the sole reason was one guard reading `build.target-dir` through the
nightly-only `cargo -Z unstable-options config get`.

As the repository standardises on stable (#236), that made both
`create_workspace.sh` and `finish_workspace.sh` unusable. The failure mode is
worse than "the script errors": an agent creates a workspace while nightly
happens to be active, does its work, and then cannot release the slot once the
default has moved to stable. That happened in a single session today — the slot
had to be released by hand.

## The fix

The guard is worth keeping. Every slot sharing one target directory is an
expensive failure and a silent one. It just does not need nightly.

It now reads the setting the way cargo resolves it:

- `CARGO_TARGET_DIR` from the environment, which wins over config;
- `target-dir` in `.cargo/config.toml` (and the extensionless `.cargo/config`)
  from the working directory upward;
- then the same under `$CARGO_HOME`.

`ensure_nightly_cargo` had no other callers and is removed.

## The ordering note

`finish_workspace.sh` fast-forwards the local canonical `dev` onto the agent
branch, which only works while canonical is *behind* that branch. `AGENTS.md`
step 2 already puts it before the push and the PR, but the consequence of
getting it wrong is not obvious from the script: once the pull request merges,
`dev` holds the work as a merge commit and is ahead of the branch, the
fast-forward can never succeed, and the slot has to be released by hand.

I hit this myself, read it as a script defect, and was corrected. Rather than
leave it to be rediscovered, `SKILL.md` now states the ordering next to the
command, along with what to do if you are already past it.

## Verification

Behaviour checked on stable 1.98.0 — the toolchain that was breaking it:

| case | result |
|---|---|
| `CARGO_TARGET_DIR` set | guard fires, names the variable |
| `target-dir` in a discovered `.cargo/config.toml` | guard fires, names the file |
| neither set | passes |

End to end, this PR is its own test. The branch was produced in an agent
workspace, and `finish_workspace.sh` ran **on stable** and reported
`slot slot-3 released back to the pool, warm and FREE` — which is the exact
operation that was impossible before this change. It was run before the push
and this PR, in the order the new note documents.
