### PR TITLE
build(fontawesome7): declare only the dependencies the crate links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12922,17 +12922,11 @@ version = "0.1.0"
 dependencies = [
  "arkiv",
  "dirs",
- "hex",
  "serde",
  "serde_json",
- "sha2",
- "waterui-core",
- "waterui-graphics",
  "waterui-icon",
  "waterui-icons-codegen",
- "waterui-str",
  "waterui-svg",
- "waterui-text",
 ]
 
 [[package]]

--- a/components/icon/fontawesome7/Cargo.toml
+++ b/components/icon/fontawesome7/Cargo.toml
@@ -12,24 +12,25 @@ readme = "../../../README.md"
 
 [features]
 default = ["webfont"]
-svg = []
+svg = ["dep:waterui-svg"]
 webfont = ["dep:waterui-icon"]
 
 [dependencies]
-waterui-graphics = { workspace = true, features = ["gpu"] }
-waterui-svg.workspace = true
-waterui-text = { workspace = true, optional = true }
-waterui-core.workspace = true
-waterui-str.workspace = true
+# Only the two rendering entry points are linked: the generated modules refer
+# to `crate::Svg` (svg feature) and the re-exported `IconGlyph` (webfont).
+waterui-svg = { workspace = true, optional = true }
 waterui-icon = { workspace = true, optional = true }
+
+# cargo-machete does not follow build.rs, so the build-script dependencies
+# are listed here, as in the sibling icon crates.
+[package.metadata.cargo-machete]
+ignored = ["serde", "serde_json", "arkiv", "dirs", "waterui-icons-codegen"]
 
 [build-dependencies]
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 arkiv = { version = "0.7", features = ["download"] }
 dirs = "6"
-sha2 = "0.11"
-hex = "0.4"
 waterui-icons-codegen.workspace = true
 
 [lints]
@@ -55,17 +56,3 @@ required-feature = "webfont"
 name = "Font Awesome 7 Brands"
 remote_path = "https://github.com/FortAwesome/Font-Awesome/releases/download/7.1.0/fontawesome-free-7.1.0-desktop.zip"
 required-feature = "webfont"
-[package.metadata.cargo-machete]
-ignored = [
-    "arkiv",
-    "dirs",
-    "hex",
-    "serde",
-    "serde_json",
-    "sha2",
-    "waterui-icons-codegen",
-    "waterui-core",
-    "waterui-graphics",
-    "waterui-str",
-    "waterui-text",
-]


### PR DESCRIPTION
Fixes #183

`waterui-icons-fontawesome7` declared waterui-graphics (with `gpu`), waterui-core, waterui-str and an optional waterui-text that no feature enabled, plus `sha2` and `hex` as build-dependencies; nothing referenced any of them (the generated modules only touch `crate::Svg` and the re-exported `IconGlyph`), and a blanket `cargo-machete` ignore list hid it. This removes them, makes `waterui-svg` optional behind the `svg` feature that uses it, and drops the ignore list entirely — `cargo machete` is clean without it. Every webfont consumer stops linking the GPU stack.

Verified: `cargo +stable check -p waterui-icons-fontawesome7 --all-features` / `--no-default-features`, `clippy --all-targets --all-features -- -D warnings`, `cargo machete components/icon/fontawesome7`.