### PR TITLE
fix(cli): keep the CLI clean under the next clippy

### DIFF
--- a/cli/src/android/toolchain.rs
+++ b/cli/src/android/toolchain.rs
@@ -1792,7 +1792,10 @@ mod tests {
             "armv7-linux-androideabi".to_string(),
             "x86_64-linux-android".to_string(),
         ];
-        assert!(missing_android_rust_targets(&installed, &required).is_empty());
+        assert_eq!(
+            missing_android_rust_targets(&installed, &required),
+            [] as [String; 0]
+        );
     }
 
     #[test]

--- a/cli/src/project_model/assets.rs
+++ b/cli/src/project_model/assets.rs
@@ -1508,7 +1508,10 @@ mod permission_audit_tests {
         let enabled = HashSet::from([PermissionKey::Internet]);
         let required = vec![requirement(PermissionKey::Internet)];
 
-        assert!(missing_permissions(&enabled, &required, |_| true).is_empty());
+        assert_eq!(
+            missing_permissions(&enabled, &required, |_| true),
+            [] as [&RequiredPermission; 0]
+        );
     }
 
     #[test]

--- a/cli/src/terminal/commands/mod.rs
+++ b/cli/src/terminal/commands/mod.rs
@@ -15,10 +15,7 @@ fn sccache_allowed() -> bool {
         }
     }
     // Respect explicit wrapper from caller (e.g. passthrough wrapper in constrained envs).
-    if std::env::var_os("RUSTC_WRAPPER").is_some() {
-        return false;
-    }
-    true
+    std::env::var_os("RUSTC_WRAPPER").is_none()
 }
 
 /// Locate `sccache` for compilation caching, noting on the shell when it is


### PR DESCRIPTION
Fixes #219

clippy 0.1.100 (2026-08-30) adds `assert_is_empty`, which flags `assert!(x.is_empty())` at `cli/src/android/toolchain.rs` and `cli/src/project_model/assets.rs`; both now use `assert_eq!` against an empty array so a failure prints the offending value. The same toolchain also flags the bool-literal guard in `rustc_wrapper_is_available` (`needless_bool`), fixed to `is_none()`. Verified with `cargo +nightly clippy -p waterui-cli --all-targets` (both lints gone), `cargo +stable clippy -p waterui-cli --all-targets -- -D warnings`, and the CLI unit tests.