### PR TITLE
build(deps): bump shaderloom to 0.1.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7043,7 +7043,6 @@ dependencies = [
  "num-traits",
  "once_cell",
  "rustc-hash 1.1.0",
- "spirv",
  "thiserror 2.0.20",
  "unicode-ident",
 ]
@@ -9942,11 +9941,11 @@ dependencies = [
 
 [[package]]
 name = "shaderloom"
-version = "0.1.0"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef95e00f176da60d5e802773d563a7a263d24e99bcb91c07488ebeabfd8d7851"
+checksum = "abfe38a4a8d473f595240dd001b51c5778b30ee439a0c5f4960554a977bcba93"
 dependencies = [
- "naga 30.0.0",
+ "naga 29.0.4",
  "wgpu",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -192,7 +192,7 @@ waterui-dylib = { version = "0.3.0", path = "utils/dylib", default-features = fa
 hydrolysis = { version = "0.1.0", path = "backends/hydrolysis", default-features = false }
 waterui = { version = "0.3.0", path = "." }
 waterui-icons-codegen = { version = "0.1.0", path = "components/icon/codegen" }
-shaderloom = "0.1.0"
+shaderloom = "0.1.2"
 hydrolysis-m3 = { version = "0.1.0", path = "backends/hydrolysis_m3" }
 native-executor = { version = "0.8.0" }
 waterui-macros = { version = "0.3.0", path = "macros" }


### PR DESCRIPTION
Consumes shaderloom 0.1.2 (water-rs/shaderloom#8, fixes the Y flip described in #239): its SPIR-V writer options now match wgpu-hal's Vulkan backend, so precompiled shaders stop rendering upside down on Vulkan. Raises the requirement so the flipped 0.1.0/0.1.1 cannot satisfy it. `kit/` has its own pin and gets a separate bump in water-rs/waterkit.

Expect Linux snapshot artifacts to change orientation; any Linux-specific baselines captured upside down need re-baselining with visual review.