### PR TITLE
feat(dew): route interaction metadata to gesture and hover handlers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12729,6 +12729,7 @@ dependencies = [
  "waterui",
  "waterui-backend-core",
  "waterui-canvas",
+ "waterui-chart",
  "waterui-controls",
  "waterui-core",
  "waterui-graphics",

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["ui", "backend", "waterui", "embedded", "gui"]
 categories = ["gui", "embedded"]
 
 [features]
-default = ["system-fonts", "progress", "host"]
+default = ["system-fonts", "progress", "host", "gestures"]
 # Host-side surfaces: the in-memory framebuffer (`BufferDisplay`), the
 # reference `HostBoard`, and PNG snapshot export. Firmware builds
 # (default-features = false) drop them along with the PNG encoder they pull
@@ -44,6 +44,16 @@ espidf = [
 # Desktop font enumeration; firmware targets disable this and register
 # bundled fonts into the parley FontContext instead.
 system-fonts = ["parley/system"]
+# Interaction metadata: `Metadata<GestureObserver>` (tap / long-press / drag /
+# pinch / rotate) and `Metadata<OnEvent>` (hover enter / move / exit). The
+# recognizer state machines come from `waterui-backend-core`, which pulls the
+# `waterui` facade the gesture event payloads are defined in — the same reason
+# `progress` is gated. A firmware build that drops this feature keeps a
+# pointer-driven UI (buttons, toggles, sliders, tabs all route through
+# `PointerRouter`); what it loses is the `.gesture(...)` / `.on_hover(...)`
+# modifier surface, and a view carrying that metadata fails fast in dispatch
+# rather than rendering as if the handler were wired.
+gestures = ["waterui-backend-core/gestures"]
 # The Progress widget's config type lives in the `waterui` facade crate,
 # which pulls the visual component stack (and thus a GPU graphics build).
 # Gating it keeps the lean firmware graph (default-features = false) free of
@@ -102,6 +112,11 @@ waterui-testing = { path = "../../testing" }
 # built from the library alone, stays GPU-free.
 waterui-canvas.workspace = true
 waterui-svg.workspace = true
+# The component issue #180 is actually about: an interactive chart wraps its
+# canvas in `Metadata<GestureObserver>` and `Metadata<OnEvent>`, and every one
+# of those wrappers used to abort dew's dispatch. Test-only, like the scene
+# crates above and for the same reason.
+waterui-chart.workspace = true
 fearless_simd = { version = "0.4", features = ["force_support_fallback"] }
 executor-core.workspace = true
 native-executor.workspace = true

--- a/backends/dew/src/dispatch.rs
+++ b/backends/dew/src/dispatch.rs
@@ -25,6 +25,8 @@ use waterui_controls::stepper::StepperConfig;
 use waterui_controls::text_field::ResolvedTextFieldConfig;
 use waterui_controls::toggle::ToggleConfig;
 use waterui_core::dynamic::Dynamic;
+use waterui_core::event::OnEvent;
+use waterui_core::gesture::GestureObserver;
 use waterui_core::layout::{
     ProposalSize, Rect as LayoutRect, Size, StretchAxis, SubView, ViewDimensions,
 };
@@ -48,6 +50,17 @@ use crate::theme;
 use crate::views;
 
 const MAX_BODY_DEPTH: usize = 64;
+
+/// What a build without the `gestures` feature says when a view asks for
+/// pointer semantics it cannot provide.
+///
+/// The generic `Metadata` panic would name the type and stop there; naming the
+/// feature is the difference between "dew is broken" and "this firmware image
+/// was built without gesture recognition". Silently rendering the content
+/// unwrapped is not an option: the view would draw correctly and never
+/// respond, which is the failure mode hardest to diagnose on a device.
+#[cfg(not(feature = "gestures"))]
+const INTERACTION_FEATURE_REQUIRED: &str = "dew: interaction metadata (`GestureObserver` / `OnEvent`) needs the `waterui-dew/gestures` feature, which this build does not enable";
 
 /// Where a view draws: the accumulated transform and its local bounds.
 #[derive(Clone, Copy, Debug)]
@@ -177,6 +190,8 @@ pub struct DewRenderer {
     state: RefCell<DewState>,
     list: DisplayList,
     pointer: PointerRouter,
+    #[cfg(feature = "gestures")]
+    interaction: crate::interaction::InteractionRouter,
     accessibility: AccessibilityBuilder,
     accessibility_enabled: bool,
     root: Option<Box<dyn DewNode>>,
@@ -215,6 +230,8 @@ impl DewRenderer {
             state: RefCell::new(DewState::new(fonts)),
             list: DisplayList::new(),
             pointer: PointerRouter::default(),
+            #[cfg(feature = "gestures")]
+            interaction: crate::interaction::InteractionRouter::default(),
             accessibility: AccessibilityBuilder::default(),
             accessibility_enabled: true,
             root: None,
@@ -271,6 +288,8 @@ impl DewRenderer {
             .expect("Dew refresh requires an initialized retained root");
         self.list.clear();
         self.pointer.begin_frame();
+        #[cfg(feature = "gestures")]
+        self.interaction.begin_frame();
         if self.accessibility_enabled {
             self.accessibility
                 .begin_frame(Rect::new(0.0, 0.0, width, height));
@@ -287,6 +306,8 @@ impl DewRenderer {
         root.patch(self);
         root.render(self, RenderContext::root(width, height));
         self.pointer.finish_frame();
+        #[cfg(feature = "gestures")]
+        self.interaction.finish_frame();
         if self.accessibility_enabled {
             self.accessibility.finish_frame();
         }
@@ -316,6 +337,62 @@ impl DewRenderer {
 
     pub(crate) fn handle_pointer(&mut self, sample: crate::board::PointerSample) -> bool {
         self.pointer.dispatch(sample)
+    }
+
+    /// Registers a fresh gesture recognizer at `bounds`, returning the target
+    /// so the retained node can re-register the same recognizer next frame.
+    #[cfg(feature = "gestures")]
+    pub(crate) fn register_gesture_target(
+        &mut self,
+        bounds: Rect,
+        gesture: waterui_core::gesture::Gesture,
+        action: waterui_core::handler::BoxedAction<()>,
+    ) -> waterui_backend_core::gesture::GestureTarget {
+        self.interaction.register_gesture(bounds, gesture, action)
+    }
+
+    /// Re-registers a retained node's recognizer at its current placement.
+    #[cfg(feature = "gestures")]
+    pub(crate) fn register_existing_gesture_target(
+        &mut self,
+        target: waterui_backend_core::gesture::GestureTarget,
+    ) {
+        self.interaction.register_existing_gesture(target);
+    }
+
+    #[cfg(feature = "gestures")]
+    pub(crate) fn register_hover_target(
+        &mut self,
+        bounds: Rect,
+        state: std::rc::Rc<crate::interaction::HoverState>,
+    ) {
+        self.interaction.register_hover(bounds, state);
+    }
+
+    /// Routes one pointer sample to the gesture recognizers and hover targets.
+    ///
+    /// Separate from [`Self::handle_pointer`], which routes the same sample to
+    /// the control hit-test: a control's activation needs neither a clock nor
+    /// an environment, and a firmware build without the `gestures` feature
+    /// still has controls.
+    #[cfg(feature = "gestures")]
+    pub(crate) fn handle_interaction_pointer(
+        &mut self,
+        sample: crate::board::PointerSample,
+        now: waterui_backend_core::time::Instant,
+        env: &Environment,
+    ) -> bool {
+        self.interaction.dispatch(sample, now, env)
+    }
+
+    /// Advances time-driven gesture recognition (long-press hold deadlines).
+    #[cfg(feature = "gestures")]
+    pub(crate) fn tick_interaction(
+        &mut self,
+        now: waterui_backend_core::time::Instant,
+        env: &Environment,
+    ) -> bool {
+        self.interaction.tick(now, env)
     }
 
     pub(crate) const fn allocate_accessibility_id(&mut self) -> NodeId {
@@ -428,6 +505,30 @@ fn build_unmeasured_node(
             .downcast::<Metadata<ClipShape>>()
             .expect("dew clip metadata downcast must match its type id");
         return views::shape::build_clip(value, build_node(renderer, content, env, depth + 1));
+    }
+    if type_id == TypeId::of::<Metadata<GestureObserver>>() {
+        let Metadata { content, value } = *view
+            .downcast::<Metadata<GestureObserver>>()
+            .expect("dew gesture metadata downcast must match its type id");
+        #[cfg(feature = "gestures")]
+        return crate::interaction::build_gesture(renderer, content, value, env, depth + 1);
+        #[cfg(not(feature = "gestures"))]
+        {
+            let _ = (content, value);
+            panic!("{}", INTERACTION_FEATURE_REQUIRED);
+        }
+    }
+    if type_id == TypeId::of::<Metadata<OnEvent>>() {
+        let Metadata { content, value } = *view
+            .downcast::<Metadata<OnEvent>>()
+            .expect("dew event metadata downcast must match its type id");
+        #[cfg(feature = "gestures")]
+        return crate::interaction::build_hover(renderer, content, value, env, depth + 1);
+        #[cfg(not(feature = "gestures"))]
+        {
+            let _ = (content, value);
+            panic!("{}", INTERACTION_FEATURE_REQUIRED);
+        }
     }
     if type_id == TypeId::of::<Metadata<Retain>>() {
         let Metadata { content, value } = *view

--- a/backends/dew/src/embedded_executor.rs
+++ b/backends/dew/src/embedded_executor.rs
@@ -86,6 +86,10 @@ pub fn install() {
 /// Drives every ready task on the render thread's cooperative executor,
 /// returning the number of tasks polled. Call once per frame after rendering
 /// so reactive watchers make progress.
+#[expect(
+    clippy::must_use_candidate,
+    reason = "draining the executor is the point of the call; the polled count is a diagnostic, and every loop that drives a frame legitimately ignores it"
+)]
 pub fn tick() -> usize {
     RENDER_EXECUTOR.with(|cell| {
         let borrow = cell.borrow();

--- a/backends/dew/src/embedded_simulator.rs
+++ b/backends/dew/src/embedded_simulator.rs
@@ -171,9 +171,22 @@ impl ApplicationHandler for SimulatorApp {
                     return;
                 };
                 self.cursor = Some(position);
-                if self.mouse_pressed && self.active_touch.is_none() {
+                // Reported whether or not a button is held. Pressed, it drives
+                // drag recognition; unpressed, it is the panel's only source of
+                // hover, which `.on_hover_*` handlers (an interactive chart's
+                // among them) have nothing else to work from.
+                if self.active_touch.is_none() {
                     self.enqueue_pointer(TouchPhase::Moved, position);
                 }
+            }
+            WindowEvent::CursorLeft { .. } if self.active_touch.is_none() => {
+                let Some(position) = self.cursor.take() else {
+                    return;
+                };
+                // The pointer is gone rather than somewhere else, so hovered
+                // targets exit instead of waiting for a move that never comes.
+                self.enqueue_pointer(TouchPhase::Cancelled, position);
+                self.mouse_pressed = false;
             }
             WindowEvent::MouseInput {
                 state,

--- a/backends/dew/src/interaction.rs
+++ b/backends/dew/src/interaction.rs
@@ -1,0 +1,356 @@
+//! Interaction metadata: gesture recognition and hover routing.
+//!
+//! `Metadata<GestureObserver>` (`.gesture(...)`, `.on_tap(...)`) and
+//! `Metadata<OnEvent>` (`.on_hover_*`) are the two wrappers a view uses to ask
+//! for pointer semantics richer than "this rectangle is a control", and they
+//! are what makes an interactive chart interactive. Dew answers both here.
+//!
+//! Recognition itself is not dew's to invent: the tap / long-press / drag /
+//! pinch / rotate state machines live in `waterui-backend-core`, shared with
+//! the GPU renderer, so a double tap means the same thing on a panel as it
+//! does on a desktop window. Dew supplies the two halves the shared engine
+//! cannot know about — where each target currently sits, and when a frame is
+//! worth spending.
+//!
+//! Registration follows [`crate::pointer::PointerRouter`]: every frame clears
+//! the target list and the retained tree re-registers as it renders, so a
+//! target's hit rectangle is always the rectangle layout just placed it at.
+//! The *state* those registrations drive is retained on the node instead — an
+//! in-flight drag's recognizer, a hover target's inside/outside flag — so a
+//! frame never restarts an interaction that is still in progress.
+//!
+//! Dirty regions are not this module's business. A handler writes signals; the
+//! signals request a refresh; the refreshed display list is diffed against the
+//! previous one and only the commands that actually changed are re-rasterized
+//! (see [`crate::runtime`]). A hover that moves the pointer within a chart
+//! without changing its focused point therefore costs nothing at all, which is
+//! why a hover *move* over an already-hovered target deliberately does not
+//! force a frame of its own.
+
+use core::cell::{Cell, RefCell};
+use std::rc::Rc;
+
+use kurbo::{Point, Rect};
+use waterui_backend_core::gesture::{GestureEngine, GestureTarget};
+use waterui_backend_core::input::TouchPhase;
+use waterui_backend_core::time::Instant;
+use waterui_core::event::{Event, HoverEvent, OnEvent};
+use waterui_core::gesture::{Gesture, GestureObserver};
+use waterui_core::handler::BoxedAction;
+use waterui_core::layout::{ProposalSize, StretchAxis, ViewDimensions};
+use waterui_core::{AnyView, Environment};
+
+use crate::board::PointerSample;
+use crate::dispatch::{DewNode, DewRenderer, RenderContext, build_node};
+use crate::text::DewState;
+use crate::views::to_f32;
+
+/// Dew registers interaction targets in draw order, and the shared engine
+/// breaks priority ties by registration index — which is exactly the
+/// painter's-algorithm rule [`crate::pointer::PointerRouter`] applies when it
+/// searches its targets in reverse. Nesting depth, sibling order, and
+/// hit-test group carry no information dew does not already have from that
+/// order, so they stay uniform rather than encoding a second, redundant
+/// z-order that could disagree with the one actually drawn.
+const HIT_DEPTH: usize = 0;
+const HIT_ORDER: usize = 0;
+const HIT_GROUP: usize = 0;
+
+/// Dew's interaction routing: the shared gesture engine plus hover targets.
+#[derive(Default)]
+pub struct InteractionRouter {
+    gestures: GestureEngine,
+    hovers: Vec<HoverTarget>,
+    /// The last position the board's pointer device reported, kept so
+    /// recognizers whose registration moved under them can be re-hit-tested
+    /// after layout. `None` once the sequence was cancelled — a cancelled
+    /// pointer has no position.
+    pointer: Option<Point>,
+}
+
+impl core::fmt::Debug for InteractionRouter {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("InteractionRouter")
+            .field("gesture_targets", &self.gestures.target_count())
+            .field("hover_targets", &self.hovers.len())
+            .field("pointer", &self.pointer)
+            .finish()
+    }
+}
+
+impl InteractionRouter {
+    pub fn begin_frame(&mut self) {
+        self.gestures.clear_targets();
+        self.hovers.clear();
+    }
+
+    pub fn finish_frame(&mut self) {
+        self.gestures.sync_after_layout(self.pointer);
+    }
+
+    pub fn register_gesture(
+        &mut self,
+        bounds: Rect,
+        gesture: Gesture,
+        action: BoxedAction<()>,
+    ) -> GestureTarget {
+        self.gestures
+            .register_target(bounds, gesture, action, HIT_DEPTH, HIT_ORDER, HIT_GROUP)
+    }
+
+    pub fn register_existing_gesture(&mut self, target: GestureTarget) {
+        self.gestures.register_existing_target(target);
+    }
+
+    pub fn register_hover(&mut self, bounds: Rect, state: Rc<HoverState>) {
+        self.hovers.push(HoverTarget { bounds, state });
+    }
+
+    /// Routes one board pointer sample to the hover targets and the gesture
+    /// recognizers, returning whether the frame must be refreshed for a reason
+    /// the reactive graph cannot see for itself.
+    pub fn dispatch(&mut self, sample: PointerSample, now: Instant, env: &Environment) -> bool {
+        let point = Point::new(sample.x, sample.y);
+        match sample.phase {
+            // A press is also a position report: a touch panel's first sample
+            // of a sequence is the only "the pointer is here" it ever sends,
+            // so hover enter has to be resolved from it too.
+            TouchPhase::Started => {
+                self.pointer = Some(point);
+                let hovered = self.sync_hover(point, env);
+                hovered | self.gestures.handle_pointer_down(point, now, env)
+            }
+            // Moves arrive whether or not a button is held: an unpressed move
+            // is a hover, a pressed one additionally drives the drag
+            // recognizers, and the engine ignores a move that no recognizer is
+            // active for.
+            TouchPhase::Moved => {
+                self.pointer = Some(point);
+                let hovered = self.sync_hover(point, env);
+                hovered | self.gestures.handle_pointer_move(point, now, env)
+            }
+            TouchPhase::Ended => {
+                self.pointer = Some(point);
+                self.gestures.handle_pointer_up(point, now, env)
+            }
+            // The pointer is gone rather than elsewhere, so every hovered
+            // target exits and every in-flight recognizer fails.
+            TouchPhase::Cancelled => {
+                self.pointer = None;
+                let exited = self.exit_hovers(env);
+                exited | self.gestures.handle_pointer_cancel(now, env)
+            }
+        }
+    }
+
+    /// Advances time-driven recognition (a long press firing once its hold
+    /// deadline passes). Only meaningful while a sequence is in flight, which
+    /// is what keeps this off the cost of an idle frame.
+    pub fn tick(&mut self, now: Instant, env: &Environment) -> bool {
+        self.gestures.has_active_recognizer() && self.gestures.handle_tick(now, env)
+    }
+
+    /// Hover is not exclusive. Every registered target compares the pointer
+    /// against its own rectangle, because hover handlers stack: an interactive
+    /// chart wraps its canvas in a move handler *and* an exit handler, and a
+    /// topmost-only search would deliver to one of them.
+    fn sync_hover(&self, point: Point, env: &Environment) -> bool {
+        let mut changed = false;
+        for target in &self.hovers {
+            changed |= target.state.pointer_at(Some(point), target.bounds, env);
+        }
+        changed
+    }
+
+    fn exit_hovers(&self, env: &Environment) -> bool {
+        let mut changed = false;
+        for target in &self.hovers {
+            changed |= target.state.pointer_at(None, target.bounds, env);
+        }
+        changed
+    }
+}
+
+/// One frame's registration of a hover handler: where it currently sits, and
+/// the retained state it drives.
+struct HoverTarget {
+    bounds: Rect,
+    state: Rc<HoverState>,
+}
+
+/// The retained half of an [`OnEvent`] handler.
+///
+/// `inside` is what turns a stream of positions into enter/exit edges, and it
+/// belongs to the node rather than to a frame: the pointer does not re-enter a
+/// chart because the chart re-rendered.
+pub struct HoverState {
+    event: Event,
+    handler: RefCell<OnEvent>,
+    /// The environment the handler was built in — the one its extractors have
+    /// to resolve against, layered over whatever environment the pointer
+    /// arrives in.
+    env: Environment,
+    inside: Cell<bool>,
+}
+
+impl HoverState {
+    /// Applies the pointer's current position (or its absence) to this target,
+    /// returning whether the frame must be refreshed for a reason the reactive
+    /// graph cannot see.
+    fn pointer_at(&self, point: Option<Point>, bounds: Rect, env: &Environment) -> bool {
+        let inside = point.is_some_and(|point| bounds.contains(point));
+        let crossed = self.inside.replace(inside) != inside;
+        match self.event {
+            Event::HoverEnter if crossed && inside => {
+                self.handler.borrow_mut().handle(&self.env.layered_on(env));
+                true
+            }
+            Event::HoverExit if crossed && !inside => {
+                self.handler.borrow_mut().handle(&self.env.layered_on(env));
+                true
+            }
+            Event::HoverMove if inside => {
+                let point = point.expect("a hover move inside a target has a position");
+                let hover = HoverEvent::new(waterui_core::layout::Point::new(
+                    to_f32(point.x - bounds.x0),
+                    to_f32(point.y - bounds.y0),
+                ));
+                let hover_env = self.env.layered_on(&env.extending(hover));
+                self.handler.borrow_mut().handle(&hover_env);
+                // Deliberately not a refresh request. Moves inside an already
+                // hovered target are the high-rate case, and a handler that
+                // changed something wrote it to a signal, which schedules the
+                // frame — and the display-list diff then dirties only the part
+                // that moved. Forcing a frame here would relayout the tree at
+                // pointer rate for a chart that decided nothing changed.
+                false
+            }
+            _ => false,
+        }
+    }
+}
+
+/// The retained node behind `Metadata<GestureObserver>`.
+struct GestureNode {
+    gesture: Gesture,
+    /// Handed to the recognizer the first time this node renders; from then on
+    /// the recognizer lives in `target` and is re-registered, which is what
+    /// keeps a drag alive across the frames it spans.
+    action: Option<BoxedAction<()>>,
+    target: Option<GestureTarget>,
+    child: Box<dyn DewNode>,
+}
+
+impl DewNode for GestureNode {
+    fn measure(&self, state: &RefCell<DewState>, proposal: ProposalSize) -> ViewDimensions {
+        self.child.measure(state, proposal)
+    }
+
+    fn render(&mut self, renderer: &mut DewRenderer, ctx: RenderContext) {
+        let bounds = ctx.window_bounds();
+        let target = if let Some(target) = self.target.take() {
+            let target = target.with_bounds_depth_and_group(bounds, HIT_DEPTH, HIT_GROUP);
+            renderer.register_existing_gesture_target(target.clone());
+            target
+        } else {
+            let action = self
+                .action
+                .take()
+                .expect("dew gesture action is bound exactly once, on the node's first render");
+            renderer.register_gesture_target(bounds, self.gesture.clone(), action)
+        };
+        self.target = Some(target);
+        self.child.render(renderer, ctx);
+    }
+
+    fn stretch_axis(&self) -> StretchAxis {
+        self.child.stretch_axis()
+    }
+
+    fn patch(&mut self, renderer: &mut DewRenderer) -> bool {
+        self.child.patch(renderer)
+    }
+}
+
+/// The retained node behind `Metadata<OnEvent>`.
+struct HoverNode {
+    state: Rc<HoverState>,
+    child: Box<dyn DewNode>,
+}
+
+impl DewNode for HoverNode {
+    fn measure(&self, state: &RefCell<DewState>, proposal: ProposalSize) -> ViewDimensions {
+        self.child.measure(state, proposal)
+    }
+
+    fn render(&mut self, renderer: &mut DewRenderer, ctx: RenderContext) {
+        renderer.register_hover_target(ctx.window_bounds(), Rc::clone(&self.state));
+        self.child.render(renderer, ctx);
+    }
+
+    fn stretch_axis(&self) -> StretchAxis {
+        self.child.stretch_axis()
+    }
+
+    fn patch(&mut self, renderer: &mut DewRenderer) -> bool {
+        self.child.patch(renderer)
+    }
+}
+
+/// Builds the retained node for a gesture-observed subtree.
+pub fn build_gesture(
+    renderer: &mut DewRenderer,
+    content: AnyView,
+    observer: GestureObserver,
+    env: &Environment,
+    depth: usize,
+) -> Box<dyn DewNode> {
+    let GestureObserver {
+        gesture, action, ..
+    } = observer;
+    Box::new(GestureNode {
+        gesture,
+        action: Some(layered_action(action, env)),
+        target: None,
+        child: build_node(renderer, content, env, depth),
+    })
+}
+
+/// Builds the retained node for a hover-observed subtree.
+pub fn build_hover(
+    renderer: &mut DewRenderer,
+    content: AnyView,
+    handler: OnEvent,
+    env: &Environment,
+    depth: usize,
+) -> Box<dyn DewNode> {
+    let event = handler.event();
+    assert!(
+        matches!(
+            event,
+            Event::HoverEnter | Event::HoverMove | Event::HoverExit
+        ),
+        "dew does not implement Event::{event:?}"
+    );
+    Box::new(HoverNode {
+        state: Rc::new(HoverState {
+            event,
+            handler: RefCell::new(handler),
+            env: env.clone(),
+            inside: Cell::new(false),
+        }),
+        child: build_node(renderer, content, env, depth),
+    })
+}
+
+/// Rebinds `action` to the environment its view was built in.
+///
+/// The gesture engine calls an action with the environment the *pointer*
+/// arrived in, carrying the recognized event payload; the handler's extractors
+/// need the scoped environment its view was built in. Layering the captured
+/// environment over the runtime one gives both.
+fn layered_action(mut action: BoxedAction<()>, env: &Environment) -> BoxedAction<()> {
+    let captured = env.clone();
+    Box::new(move |runtime: &Environment| action(&captured.layered_on(runtime)))
+}

--- a/backends/dew/src/lib.rs
+++ b/backends/dew/src/lib.rs
@@ -46,6 +46,20 @@
 //! primitive at all: a `SceneView` draws through the engine-neutral `Scene2D`
 //! contract, so dew installs `SceneViewMergeToParent` and draws it on the CPU
 //! rather than letting it fall back to a GPU surface.
+//!
+//! # Interaction beyond controls: the `gestures` feature
+//!
+//! Controls (buttons, toggles, sliders, tabs) hit-test through
+//! [`pointer::PointerRouter`] and are always available. The richer pointer
+//! semantics a view asks for with `.gesture(...)` / `.on_hover_*` —
+//! `Metadata<GestureObserver>` and `Metadata<OnEvent>`, which is what makes an
+//! interactive chart interactive — recognize through `waterui-backend-core`'s
+//! shared state machines, and that pulls the `waterui` facade the gesture event
+//! payloads live in. They are therefore behind the default-on `gestures`
+//! feature, gated for the same reason `progress` is: a firmware graph built
+//! with `default-features = false` stays free of the facade. A build without
+//! the feature fails fast when such a view reaches dispatch, naming the
+//! feature, rather than drawing a view that silently never responds.
 
 pub mod accessibility;
 pub mod board;
@@ -70,6 +84,8 @@ pub mod espidf;
     all(feature = "espidf", target_os = "espidf")
 ))]
 pub(crate) mod frame_cadence;
+#[cfg(feature = "gestures")]
+mod interaction;
 pub mod painter;
 mod pointer;
 pub mod runtime;

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -108,8 +108,25 @@ impl<B: Board> DewRuntime<B> {
             while let Some(request) = self.board.poll_accessibility_action() {
                 input_changed |= self.renderer.handle_accessibility_action(&request);
             }
+            // One instant for the whole batch: the board reports positions,
+            // not timestamps, and a pump is a single cadence slot — dating the
+            // samples apart would be inventing precision the device never had.
+            #[cfg(feature = "gestures")]
+            let now = self.board.now();
             while let Some(sample) = self.board.poll_pointer() {
                 input_changed |= self.renderer.handle_pointer(sample);
+                #[cfg(feature = "gestures")]
+                {
+                    input_changed |= self
+                        .renderer
+                        .handle_interaction_pointer(sample, now, &self.env);
+                }
+            }
+            // A long press is recognized by time passing rather than by input
+            // arriving, so it needs the frame pump to carry the clock to it.
+            #[cfg(feature = "gestures")]
+            {
+                input_changed |= self.renderer.tick_interaction(now, &self.env);
             }
         }
         if input_changed {

--- a/backends/dew/tests/interaction_metadata.rs
+++ b/backends/dew/tests/interaction_metadata.rs
@@ -1,0 +1,369 @@
+//! Interaction metadata on dew: `Metadata<OnEvent>` and
+//! `Metadata<GestureObserver>`.
+//!
+//! These are the wrappers an interactive chart puts around its canvas, and
+//! before dew handled them every one of them reached `Metadata::body` and
+//! panicked with "not caught by your renderer" — a chart could not be rendered
+//! on dew at all. Each test here therefore doubles as the regression: a frame
+//! that renders is a frame that did not fast-fail.
+//!
+//! Input is driven the way a board drives it, by queueing
+//! [`PointerSample`]s and pumping, because that is the only path dew has to
+//! its renderer — there is no shortcut that skips the pointer plumbing being
+//! tested. State is observed through `Binding`s the handlers write.
+
+use nami::{Binding, binding};
+use waterui::prelude::{Color, vstack};
+use waterui_backend_core::input::TouchPhase;
+use waterui_chart::{DataPoint, HitResult, LineChart};
+use waterui_core::event::{Event, HoverEvent, OnEvent};
+use waterui_core::gesture::{
+    DragEvent, DragGesture, GestureObserver, GesturePhase, TapEvent, TapGesture,
+};
+use waterui_core::{AnyView, Environment, Metadata};
+use waterui_dew::{DewRuntime, HostBoard, PointerSample, render_view_png};
+
+mod support;
+
+const WIDTH: u32 = 200;
+const HEIGHT: u32 = 120;
+/// A row inside the top half of the test stack — the half a chart occupies.
+const HOVER_Y: f64 = 30.0;
+
+fn runtime(build_root: impl Fn() -> AnyView + 'static) -> DewRuntime<HostBoard> {
+    DewRuntime::new(
+        HostBoard::new(WIDTH, HEIGHT),
+        support::test_environment(),
+        16,
+        build_root,
+    )
+}
+
+fn send(runtime: &mut DewRuntime<HostBoard>, x: f64, y: f64, phase: TouchPhase) {
+    runtime
+        .board_mut()
+        .push_pointer(PointerSample { x, y, phase });
+}
+
+/// A hover handler must see the pointer enter, move within, and leave its own
+/// rectangle — the three edges an interactive chart's focus tracking is built
+/// from.
+///
+/// The hovered view is the top half of a two-colour stack, so "outside the
+/// target" is a real position on the panel rather than an off-screen
+/// coordinate no board would ever report.
+#[test]
+fn hover_metadata_reports_enter_move_and_exit() {
+    let entered: Binding<i32> = binding(0_i32);
+    let exited: Binding<i32> = binding(0_i32);
+    let last_move: Binding<Option<(f32, f32)>> = Binding::container(None);
+
+    let entered_for_view = entered.clone();
+    let exited_for_view = exited.clone();
+    let last_move_for_view = last_move.clone();
+
+    let mut runtime = runtime(move || {
+        let hot = Metadata::new(
+            Metadata::new(
+                Metadata::new(Color::red(), {
+                    let entered = entered_for_view.clone();
+                    OnEvent::new(Event::HoverEnter, move || *entered.get_mut() += 1)
+                }),
+                {
+                    let last_move = last_move_for_view.clone();
+                    OnEvent::new(Event::HoverMove, move |env: Environment| {
+                        let hover = env
+                            .get::<HoverEvent>()
+                            .expect("dew must place HoverEvent in the hover environment");
+                        last_move.set(Some((hover.location.x, hover.location.y)));
+                    })
+                },
+            ),
+            {
+                let exited = exited_for_view.clone();
+                OnEvent::new(Event::HoverExit, move || *exited.get_mut() += 1)
+            },
+        );
+        AnyView::new(vstack((hot, Color::blue())))
+    });
+
+    runtime
+        .pump()
+        .expect("the initial frame must render the hover-wrapped tree");
+    assert_eq!(entered.get(), 0, "rendering alone must not fire a hover");
+
+    // Into the top half: enter and move both fire, and the move location is
+    // local to the hovered view, whose origin is the window origin here.
+    send(&mut runtime, 40.0, 20.0, TouchPhase::Moved);
+    runtime
+        .pump()
+        .expect("a hover enter must refresh the frame it may have changed");
+    assert_eq!(entered.get(), 1);
+    assert_eq!(exited.get(), 0);
+    assert_eq!(last_move.get(), Some((40.0, 20.0)));
+
+    // Still inside: the move handler runs again, and because nothing in the
+    // tree observes what it wrote, no frame is spent. That is the whole point
+    // of not forcing a refresh from a hover move — see `interaction.rs`.
+    send(&mut runtime, 60.0, 30.0, TouchPhase::Moved);
+    assert!(
+        runtime.pump().is_none(),
+        "a hover move that changes nothing must not cost a frame"
+    );
+    assert_eq!(entered.get(), 1, "staying inside must not re-enter");
+    assert_eq!(last_move.get(), Some((60.0, 30.0)));
+
+    // Into the bottom half: outside the hovered view, so it exits.
+    send(&mut runtime, 60.0, 100.0, TouchPhase::Moved);
+    runtime
+        .pump()
+        .expect("a hover exit must refresh the frame it may have changed");
+    assert_eq!(exited.get(), 1);
+    assert_eq!(entered.get(), 1);
+}
+
+/// A cancelled pointer sequence is the pointer being gone rather than
+/// elsewhere, so a hovered target must exit rather than wait for a move that
+/// never arrives. This is what the simulator's `CursorLeft` produces.
+#[test]
+fn cancelled_pointer_exits_hovered_targets() {
+    let exited: Binding<i32> = binding(0_i32);
+    let exited_for_view = exited.clone();
+
+    let mut runtime = runtime(move || {
+        let exited = exited_for_view.clone();
+        AnyView::new(Metadata::new(
+            Metadata::new(
+                Color::red(),
+                OnEvent::new(Event::HoverExit, move || *exited.get_mut() += 1),
+            ),
+            OnEvent::new(Event::HoverEnter, || {}),
+        ))
+    });
+
+    runtime.pump().expect("the initial frame must render");
+    send(&mut runtime, 50.0, 50.0, TouchPhase::Moved);
+    runtime.pump().expect("hover enter refreshes");
+    assert_eq!(exited.get(), 0);
+
+    send(&mut runtime, 50.0, 50.0, TouchPhase::Cancelled);
+    runtime
+        .pump()
+        .expect("a cancelled pointer must refresh the frame its exit may have changed");
+    assert_eq!(exited.get(), 1);
+}
+
+/// A tap observer must recognize a press/release pair and receive the
+/// `TapEvent` payload, localized to the observed view.
+#[test]
+fn tap_gesture_metadata_recognizes_a_press_and_release() {
+    let taps: Binding<Option<(f32, f32, u32)>> = Binding::container(None);
+    let taps_for_view = taps.clone();
+
+    let mut runtime = runtime(move || {
+        let taps = taps_for_view.clone();
+        AnyView::new(Metadata::new(
+            Color::red(),
+            GestureObserver::new(TapGesture::new(), move |env: Environment| {
+                let tap = env
+                    .get::<TapEvent>()
+                    .expect("dew must place TapEvent in the gesture environment");
+                taps.set(Some((tap.location.x, tap.location.y, tap.count)));
+            }),
+        ))
+    });
+
+    runtime
+        .pump()
+        .expect("the initial frame must render the gesture-wrapped tree");
+    assert_eq!(taps.get(), None, "rendering alone must not fire a gesture");
+
+    send(&mut runtime, 80.0, 40.0, TouchPhase::Started);
+    send(&mut runtime, 80.0, 40.0, TouchPhase::Ended);
+    runtime
+        .pump()
+        .expect("a recognized tap must refresh the frame its action may have changed");
+    assert_eq!(taps.get(), Some((80.0, 40.0, 1)));
+}
+
+/// A drag observer must see the whole sequence, not just its end: an
+/// interactive chart tracks the pointer through `Started`/`Updated` and
+/// commits on `Ended`.
+///
+/// Tap and drag are stacked over the same view exactly as a chart stacks them,
+/// which also proves dew delivers input to every observer over a point rather
+/// than only the topmost one.
+#[test]
+fn drag_gesture_metadata_reports_every_phase() {
+    let phases: Binding<Vec<GesturePhase>> = Binding::container(Vec::new());
+    let taps: Binding<i32> = binding(0_i32);
+    let phases_for_view = phases.clone();
+    let taps_for_view = taps.clone();
+
+    let mut runtime = runtime(move || {
+        let phases = phases_for_view.clone();
+        let taps = taps_for_view.clone();
+        AnyView::new(Metadata::new(
+            Metadata::new(
+                Color::red(),
+                GestureObserver::new(TapGesture::new(), move |_: Environment| {
+                    *taps.get_mut() += 1;
+                }),
+            ),
+            GestureObserver::new(DragGesture::new(0.0), move |env: Environment| {
+                let drag = env
+                    .get::<DragEvent>()
+                    .expect("dew must place DragEvent in the gesture environment");
+                phases.get_mut().push(drag.phase);
+            }),
+        ))
+    });
+
+    runtime.pump().expect("the initial frame must render");
+
+    send(&mut runtime, 20.0, 20.0, TouchPhase::Started);
+    send(&mut runtime, 60.0, 40.0, TouchPhase::Moved);
+    send(&mut runtime, 90.0, 60.0, TouchPhase::Moved);
+    send(&mut runtime, 90.0, 60.0, TouchPhase::Ended);
+    runtime
+        .pump()
+        .expect("a recognized drag must refresh the frame its action may have changed");
+
+    assert_eq!(
+        phases.get(),
+        vec![
+            GesturePhase::Started,
+            GesturePhase::Updated,
+            GesturePhase::Ended
+        ]
+    );
+    // The pointer travelled further than the tap tolerance, so the stacked tap
+    // observer correctly failed rather than firing alongside the drag.
+    assert_eq!(taps.get(), 0);
+}
+
+/// The pre-#180 behaviour, stated directly: a view carrying interaction
+/// metadata used to abort dew's dispatch with `Metadata::panic_not_caught`.
+/// Rendering it to a PNG now succeeds, and the content under the metadata is
+/// what gets drawn.
+#[test]
+fn interaction_metadata_renders_instead_of_panicking() {
+    let png = render_view_png(
+        || {
+            Metadata::new(
+                Metadata::new(
+                    Color::red(),
+                    OnEvent::new(Event::HoverMove, |_: Environment| {}),
+                ),
+                GestureObserver::new(TapGesture::new(), || {}),
+            )
+        },
+        support::test_environment(),
+        64,
+        64,
+    );
+    let pixmap = vello_cpu::Pixmap::from_png(std::io::Cursor::new(png.as_slice()))
+        .expect("the rendered frame must decode as a PNG");
+    let pixel = pixmap.data()[32 * 64 + 32];
+    assert_eq!(
+        [pixel.r, pixel.g, pixel.b, pixel.a],
+        [244, 67, 54, 255],
+        "the metadata must be transparent to what it wraps"
+    );
+}
+
+/// Interaction metadata must stay transparent to layout: the wrapped view is
+/// placed exactly where it would be without the wrapper, or a chart's hit
+/// rectangle would not match the pixels it drew.
+#[test]
+fn interaction_metadata_is_transparent_to_layout() {
+    let png = render_view_png(
+        || {
+            vstack((
+                Metadata::new(Color::red(), GestureObserver::new(TapGesture::new(), || {})),
+                Color::blue(),
+            ))
+        },
+        support::test_environment(),
+        64,
+        64,
+    );
+    let pixmap = vello_cpu::Pixmap::from_png(std::io::Cursor::new(png.as_slice()))
+        .expect("the rendered frame must decode as a PNG");
+    let pixel = |x: usize, y: usize| {
+        let pixel = pixmap.data()[y * 64 + x];
+        [pixel.r, pixel.g, pixel.b, pixel.a]
+    };
+    assert_eq!(pixel(32, 10), [244, 67, 54, 255]);
+    assert_eq!(pixel(32, 54), [33, 150, 243, 255]);
+}
+
+/// The component the issue is about, end to end on dew: an interactive
+/// `LineChart` wraps its canvas in a tap observer, a drag observer, a hover
+/// move handler, and a hover exit handler — four `Metadata` layers, every one
+/// of which used to abort dew's dispatch before the first pixel was drawn.
+///
+/// Hovering sweeps across the plot rather than aiming at one datum: the
+/// assertion is that dew delivers hover positions the chart's own hit-testing
+/// can resolve, not a re-derivation of the chart's geometry inside a backend
+/// test. Leaving the canvas must then clear the focus, which is the
+/// `Event::HoverExit` half.
+#[test]
+fn line_chart_hover_and_tap_drive_selection_on_dew() {
+    let focused: Binding<Option<HitResult<DataPoint>>> = Binding::container(None);
+    let selected: Binding<Option<HitResult<DataPoint>>> = Binding::container(None);
+    let focused_for_view = focused.clone();
+    let selected_for_view = selected.clone();
+
+    let mut runtime = runtime(move || {
+        let data: Vec<DataPoint> = (0_u8..8)
+            .map(|index| {
+                let x = f32::from(index);
+                DataPoint::new(x, (x * 0.7).sin().mul_add(6.0, 12.0))
+            })
+            .collect();
+        AnyView::new(vstack((
+            LineChart::new(Binding::container(data))
+                .focused(&focused_for_view)
+                .selected(&selected_for_view),
+            Color::blue(),
+        )))
+    });
+
+    runtime
+        .pump()
+        .expect("the initial frame must render an interactive chart");
+    assert!(focused.get().is_none());
+
+    // Sweep the top half — the chart's own share of the stack — until its hit
+    // testing resolves a datum, and remember where that was so the tap below
+    // aims at a point the chart agrees is there.
+    let hovered = (1_u8..10).find_map(|step| {
+        let x = f64::from(step) * f64::from(WIDTH) / 10.0;
+        send(&mut runtime, x, HOVER_Y, TouchPhase::Moved);
+        let _ = runtime.pump();
+        focused.get().map(|hit| (x, hit))
+    });
+    let (hit_x, hovered) = hovered.expect("hovering the chart must focus one of its points");
+    assert_eq!(hovered.series, 0);
+
+    // Down into the bottom half: off the chart, so its hover-exit handler
+    // clears the focus.
+    send(&mut runtime, hit_x, 110.0, TouchPhase::Moved);
+    let _ = runtime.pump();
+    assert!(
+        focused.get().is_none(),
+        "leaving the chart must clear its focus"
+    );
+
+    // A tap at the position the chart just resolved a hover for commits that
+    // point as the selection, through the chart's tap observer.
+    send(&mut runtime, hit_x, HOVER_Y, TouchPhase::Started);
+    send(&mut runtime, hit_x, HOVER_Y, TouchPhase::Ended);
+    let _ = runtime.pump();
+    let selected_hit = selected
+        .get()
+        .expect("tapping the chart must select one of its points");
+    assert_eq!(selected_hit.series, hovered.series);
+    assert_eq!(selected_hit.index, hovered.index);
+}

--- a/backends/dew/tests/interaction_without_gestures.rs
+++ b/backends/dew/tests/interaction_without_gestures.rs
@@ -1,0 +1,41 @@
+//! The firmware contract for interaction metadata: without the `gestures`
+//! feature, a view that asks for pointer semantics dew cannot provide must say
+//! so, naming the feature, rather than rendering as if the handler were wired.
+//!
+//! Everything here is compiled out of a default build, and no default test run
+//! executes it. It runs in the shape it is about:
+//!
+//! ```text
+//! cargo test -p waterui-dew --no-default-features --features host,system-fonts \
+//!     --test interaction_without_gestures
+//! ```
+#![cfg(not(feature = "gestures"))]
+
+use waterui_core::event::{Event, OnEvent};
+use waterui_core::gesture::{GestureObserver, TapGesture};
+use waterui_core::{AnyView, Environment, Metadata, Native};
+use waterui_dew::DewRenderer;
+use waterui_graphics::color::ResolvedColor;
+
+fn render(view: AnyView) {
+    let mut renderer = DewRenderer::default();
+    let _ = renderer.render_tree(view, &Environment::new(), 32.0, 32.0);
+}
+
+#[test]
+#[should_panic(expected = "waterui-dew/gestures")]
+fn hover_metadata_names_the_feature_it_needs() {
+    render(AnyView::new(Metadata::new(
+        Native::new(ResolvedColor::default()),
+        OnEvent::new(Event::HoverMove, |_: Environment| {}),
+    )));
+}
+
+#[test]
+#[should_panic(expected = "waterui-dew/gestures")]
+fn gesture_metadata_names_the_feature_it_needs() {
+    render(AnyView::new(Metadata::new(
+        Native::new(ResolvedColor::default()),
+        GestureObserver::new(TapGesture::new(), || {}),
+    )));
+}


### PR DESCRIPTION
Fixes #180

## The defect

Views wrapped in `Metadata<GestureObserver>` or `Metadata<OnEvent>` reached `Metadata::body` on dew and aborted dispatch with *"not caught by your renderer"*. That is every interactive chart: `waterui-chart` stacks a tap observer, a drag observer, a hover-move handler and a hover-exit handler around its canvas, so a chart could not be rendered on dew at all.

## How dew answers it

Not by importing hydrolysis's retained-scene machinery — dew keeps its own tree and dirty-region model.

- **Recognition is shared, not reinvented.** The tap / long-press / drag / pinch / rotate state machines come from `waterui-backend-core`'s `GestureEngine`, the same ones the GPU renderer uses, so a gesture means the same thing on a panel as on a desktop window. Dew supplies the two halves the shared engine cannot know: where each target currently sits, and when a frame is worth spending.
- **Registration follows `PointerRouter`.** Each frame clears the target list and the retained tree re-registers as it renders, so a hit rectangle is always the rectangle layout just placed. The *state* those registrations drive stays on the retained node: the recognizer handle (re-registered through `GestureTarget::with_bounds_depth_and_group`, so a drag survives the frames it spans) and a hover target's inside/outside flag, so the pointer does not re-enter a chart because the chart re-rendered.
- **Priority is registration order**, which is draw order — the painter's-algorithm rule `PointerRouter` already applies with its reverse search. Hover is deliberately non-exclusive, because hover handlers stack.
- **Dirty regions need no new machinery and get none.** Handlers write signals; the refreshed display list is diffed against the previous one and only the commands that actually changed are re-rasterized. A hover *move* inside an already-hovered target deliberately does not force a refresh, so a chart that decides nothing changed costs no frame at pointer rate; enter, exit and recognized gestures do.

## Feature gating

New default-on `gestures` feature, because the recognizers pull the `waterui` facade the event payloads live in — the same reason `progress` is gated. A firmware build with `default-features = false` keeps its controls (buttons, toggles, sliders, tabs all route through `PointerRouter`, untouched) and **fails fast naming the feature** if interaction metadata reaches it. It never draws a view that silently cannot respond.

## Simulator

The desktop simulator now reports cursor motion whether or not a button is held — its only source of hover — and turns `CursorLeft` into a cancelled pointer, so hovered targets exit instead of waiting for a move that never comes.

## Tests

`backends/dew/tests/interaction_metadata.rs`, driven the way a board drives dew (queued `PointerSample`s + pumps), with state observed through `Binding`s:

| test | asserts |
| --- | --- |
| `hover_metadata_reports_enter_move_and_exit` | enter fires once on entry, move carries a `HoverEvent` local to the target, exit fires on leaving — and a move that changes nothing costs no frame |
| `cancelled_pointer_exits_hovered_targets` | a cancelled sequence exits hovered targets |
| `tap_gesture_metadata_recognizes_a_press_and_release` | `TapEvent` reaches the handler, localized |
| `drag_gesture_metadata_reports_every_phase` | `Started`/`Updated`/`Ended`; the stacked tap observer correctly fails |
| `interaction_metadata_renders_instead_of_panicking` | the pre-#180 fast-fail is gone, and the wrapped content is what gets drawn |
| `interaction_metadata_is_transparent_to_layout` | the wrapper does not move what it wraps |
| `line_chart_hover_and_tap_drive_selection_on_dew` | the real component: an interactive `LineChart` focuses a point on hover, clears it on exit, and selects it on tap |

`backends/dew/tests/interaction_without_gestures.rs` covers the firmware contract (both metadata types name the missing feature). It is compiled out of a default build and runs under the profile it is about; the command is in its module doc.

## Verification

```
cargo +stable clippy -p waterui-dew --all-targets --all-features -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 4.62s
cargo +stable check -p waterui-dew --no-default-features
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1.09s
cargo +stable nextest run -p waterui-dew
    Summary [3.160s] 101 tests run: 101 passed, 0 skipped
cargo +stable test -p waterui-dew --no-default-features --features host,system-fonts \
    --test interaction_without_gestures
    test result: ok. 2 passed; 0 failed
```

## Pre-existing defect fixed

Unrelated to the above but surfaced by the `--all-features` clippy gate: `embedded_executor::tick` tripped `must_use_candidate`. That is a false positive — draining the executor is the point of the call and every frame loop legitimately ignores the polled count — so it carries a scoped `expect` with that reason rather than an attribute that would force `let _ =` at both call sites.
