### PR TITLE
test(dew): compile the test targets in every supported feature shape

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -77,6 +77,16 @@ jobs:
       - name: Clippy (WPE real engine)
         if: runner.os == 'Linux'
         run: cargo clippy -p waterui-browser-wpe --features real-engine --all-targets -- -D warnings
+      # Dew's firmware shape, which is a first-class configuration rather than
+      # a degraded one. Neither pass above compiles dew's test targets without
+      # default features, and the `Features` job's `--each-feature` sweep runs
+      # `--no-dev-deps`, so the shape a device actually ships was the one
+      # configuration nothing checked — and its test targets had stopped
+      # compiling entirely (#259). `--all-targets` is the whole point: the
+      # library alone has always been clean here.
+      - name: Clippy (dew firmware shape)
+        if: runner.os == 'Linux'
+        run: cargo clippy -p waterui-dew --all-targets --no-default-features -- -D warnings
       # The waterui skill's snippet compile gate: every rust fence in
       # .claude/skills/waterui is transcribed into .claude/skills/waterui/skill_snippets
       # and must keep compiling. The non-default feature exposes the test/bench

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -153,6 +153,14 @@ name = "form_render"
 required-features = ["host", "progress"]
 
 [[test]]
+name = "interaction_metadata"
+required-features = ["host", "gestures"]
+
+[[test]]
+name = "interaction_without_gestures"
+required-features = ["host", "system-fonts"]
+
+[[test]]
 name = "navigation_render"
 required-features = ["host"]
 

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -103,6 +103,15 @@ esp-idf-svc = { version = "0.52", optional = true }
 
 [dev-dependencies]
 waterui-testing = { path = "../../testing" }
+# The theme installation API (`Theme`, `ColorSettings`, `FontSettings`) and the
+# authoring prelude every test view tree is written in live in the facade
+# crate, and nothing below it exposes them. The library reaches the facade only
+# through the optional `progress` feature, so without this entry the test
+# targets compile in exactly one feature shape — the default one — and the
+# firmware shape's tests do not build at all. Tests are host-side and never
+# enter a flash image, so depending on the facade here costs the firmware graph
+# nothing.
+waterui = { path = "../..", default-features = false }
 # Scene content, for the tests that prove `Scene2D` drawings render on dew's
 # CPU rasterizer unchanged. Test-only on purpose: dew draws a scene through
 # the engine-neutral contract and never needs to know which component produced
@@ -123,6 +132,54 @@ native-executor.workspace = true
 # The performance simulation emits its report as serialized TOML rather than
 # hand-concatenated lines.
 toml = "1.1.3"
+
+# Every integration test declares the feature shape it needs, the way the
+# simulator example does. `host` buys the in-memory framebuffer (`HostBoard`,
+# `BufferDisplay`) and the PNG snapshot entry these tests inspect; `progress`
+# buys the Progress widget's config type, without which dew has no handler to
+# dispatch a progress bar to. A test that needs neither — `fallback_probe`, the
+# scalar-rasterizer probe — is left to auto-discovery and runs in every shape,
+# firmware included.
+[[test]]
+name = "accessibility"
+required-features = ["host"]
+
+[[test]]
+name = "dispatch_views"
+required-features = ["host"]
+
+[[test]]
+name = "form_render"
+required-features = ["host", "progress"]
+
+[[test]]
+name = "navigation_render"
+required-features = ["host"]
+
+[[test]]
+name = "scene_render"
+required-features = ["host"]
+
+[[test]]
+name = "shape_render"
+required-features = ["host"]
+
+[[test]]
+name = "smoke_frame"
+required-features = ["host"]
+
+[[test]]
+name = "tabs_render"
+required-features = ["host"]
+
+# The embedded simulation models a panel bus and a flash-bundled font, so it
+# wants no host surface at all — only the payment-progress bar its work and
+# memory budgets are calibrated around. It is the one integration test that
+# runs in the firmware shape (`--no-default-features --features progress`),
+# which is the point of it.
+[[test]]
+name = "vending_performance"
+required-features = ["progress"]
 
 [[example]]
 name = "watch_sim"

--- a/backends/dew/src/lib.rs
+++ b/backends/dew/src/lib.rs
@@ -112,6 +112,33 @@ pub use stats::{ChipBudget, FrameWork, Provenance};
 
 use kurbo::Rect;
 
+/// The faces this crate's unit tests shape with: the host collection, exactly
+/// as `HostBoard` resolves it on a desktop build.
+#[cfg(all(test, feature = "system-fonts"))]
+pub(crate) const fn test_fonts() -> FontSources {
+    FontSources::System
+}
+
+/// The faces this crate's unit tests shape with: the repository's own test
+/// binaries, registered the way a firmware board registers flash-resident
+/// fonts.
+///
+/// This build has no `system-fonts` feature and therefore no
+/// `FontSources::System` — the same asymmetry [`Board::fonts`] is declared
+/// twice for. Bundling here is what keeps the shaping tests *running* in the
+/// configuration a device ships instead of being gated away with it. Regular
+/// and bold are both registered because the styled-span tests assert that a
+/// bold run separates from the surrounding body text.
+///
+/// [`Board::fonts`]: board::Board::fonts
+#[cfg(all(test, not(feature = "system-fonts")))]
+pub(crate) fn test_fonts() -> FontSources {
+    FontSources::bundled(&[
+        include_bytes!("../../../testing/fonts/Roboto-Regular.ttf"),
+        include_bytes!("../../../testing/fonts/Roboto-Bold.ttf"),
+    ])
+}
+
 /// Rasterizes the dirty parts of `list` band-by-band and flushes them to
 /// `display`, then presents the frame, accumulating the work performed into
 /// `work`.

--- a/backends/dew/src/text.rs
+++ b/backends/dew/src/text.rs
@@ -697,7 +697,7 @@ mod tests {
     #[test]
     fn styled_spans_produce_distinct_font_sizes() {
         let env = test_environment();
-        let mut state = DewState::default();
+        let mut state = DewState::new(crate::test_fonts());
         let mut styled = StyledStr::empty();
         styled.push("Heading", Style::new().font(Title));
         styled.push(" subhead", Style::new().font(Subheadline));
@@ -726,7 +726,7 @@ mod tests {
     #[test]
     fn bold_span_splits_into_its_own_run() {
         let env = test_environment();
-        let mut state = DewState::default();
+        let mut state = DewState::new(crate::test_fonts());
         let mut styled = StyledStr::empty();
         styled.push("normal ", Style::new());
         styled.push("bold", Style::new().bold());
@@ -752,7 +752,7 @@ mod tests {
         use waterui_graphics::color::Color;
 
         let env = test_environment();
-        let mut state = DewState::default();
+        let mut state = DewState::new(crate::test_fonts());
         let mut styled = StyledStr::empty();
         styled.push("red", Style::new().foreground(Color::srgb(255, 0, 0)));
 

--- a/backends/dew/src/views/mod.rs
+++ b/backends/dew/src/views/mod.rs
@@ -211,11 +211,20 @@ mod tests {
     use kurbo::Point;
     use nami::binding;
     use peniko::Brush;
+    use waterui_backend_core::time::Instant;
     use waterui_controls::slider::slider;
     use waterui_controls::toggle::Toggle;
     use waterui_core::AnyView;
     use waterui_core::plugin::Plugin;
     use waterui_graphics::color::{ResolvedColor, Srgb};
+
+    /// A renderer wired to the repository's own faces — see
+    /// [`crate::test_fonts`]. These cases hide every control label, so no
+    /// glyph is shaped; the collection exists so the handlers run against a
+    /// font path that a firmware build also has.
+    fn test_renderer() -> DewRenderer {
+        DewRenderer::new(FrameSignals::new(Instant::now()), crate::test_fonts())
+    }
 
     fn render_commands(
         view: impl waterui_core::View,
@@ -224,7 +233,7 @@ mod tests {
     ) -> Vec<crate::display_list::PlacedCommand> {
         let _ = executor_core::try_init_global_executor(native_executor::NativeExecutor::new());
         waterui_testing::install_test_executor();
-        let mut renderer = DewRenderer::default();
+        let mut renderer = test_renderer();
         let list = renderer.render_tree(AnyView::new(view), &Environment::new(), width, height);
         let (background, commands) = list
             .commands()
@@ -339,7 +348,7 @@ mod tests {
             .colors(waterui::theme::ColorSettings::new().accent(accent.clone()))
             .install(&mut env);
 
-        let mut renderer = DewRenderer::default();
+        let mut renderer = test_renderer();
         let commands = renderer.render_tree(
             AnyView::new(Toggle::new("Ready", &binding(true)).hide_label()),
             &env,

--- a/backends/dew/tests/dispatch_views.rs
+++ b/backends/dew/tests/dispatch_views.rs
@@ -59,7 +59,7 @@ fn vstack_of_colors_splits_the_screen() {
 /// Text must produce a real shaped glyph run in the retained display list.
 #[test]
 fn text_emits_shaped_glyphs() {
-    let mut renderer = waterui_dew::DewRenderer::default();
+    let mut renderer = support::test_renderer();
     let list = renderer.render_tree(
         AnyView::new(text("Hello, dew!")),
         &support::test_environment(),

--- a/backends/dew/tests/form_render.rs
+++ b/backends/dew/tests/form_render.rs
@@ -8,7 +8,7 @@ use waterui::prelude::*;
 use waterui::prelude::{slider::slider, stepper::stepper};
 use waterui::reactive::binding;
 use waterui_core::AnyView;
-use waterui_dew::{DewRenderer, DrawCommand, render_view_png, theme};
+use waterui_dew::{DrawCommand, render_view_png, theme};
 
 mod support;
 
@@ -110,7 +110,7 @@ fn form_ui_renders_to_png() {
 /// fill, and progress fill, plus the viewport clip from the scroll view.
 #[test]
 fn form_scene_contains_expected_widget_commands() {
-    let mut renderer = DewRenderer::default();
+    let mut renderer = support::test_renderer();
     let list = renderer.render_tree(
         AnyView::new(build_screen()),
         &support::test_environment(),

--- a/backends/dew/tests/navigation_render.rs
+++ b/backends/dew/tests/navigation_render.rs
@@ -17,9 +17,7 @@ use waterui::theme::{ColorSettings, Theme};
 use waterui_backend_core::input::TouchPhase;
 use waterui_controls::toggle::toggle;
 use waterui_core::Str;
-use waterui_dew::{
-    DewRenderer, DewRuntime, DisplayList, DrawCommand, HostBoard, PlacedCommand, PointerSample,
-};
+use waterui_dew::{DewRuntime, DisplayList, DrawCommand, HostBoard, PlacedCommand, PointerSample};
 use waterui_navigation::{
     NavigationLink, NavigationPath, NavigationSplitView, NavigationStack,
     NavigationTitleDisplayMode, NavigationToolbar, NavigationToolbarItem,
@@ -149,7 +147,7 @@ fn full_width_solid_fills(list: &DisplayList, width: f64) -> Vec<Rect> {
 /// is drawn as chrome above it.
 #[test]
 fn a_stack_draws_its_root_under_a_bar() {
-    let mut renderer = DewRenderer::default();
+    let mut renderer = support::test_renderer();
     let list = renderer.render_tree(
         AnyView::new(NavigationStack::new(NavigationView::new(
             "Settings",
@@ -380,7 +378,7 @@ fn a_stack_opens_on_the_route_its_path_already_holds() {
 #[test]
 fn a_bar_places_every_part_it_declares() {
     let query = binding(Str::from("Bed"));
-    let mut renderer = DewRenderer::default();
+    let mut renderer = support::test_renderer();
     let list = renderer.render_tree(
         AnyView::new(NavigationStack::new(
             NavigationView::new("Rooms", Color::srgb(0, 255, 255))

--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -26,9 +26,7 @@ use waterui::prelude::*;
 use waterui_canvas::Canvas;
 use waterui_core::AnyView;
 use waterui_core::layout::{Point, Rect as LayoutRect, Size};
-use waterui_dew::{
-    ClipRegion, DewRenderer, DewRuntime, DisplayList, DrawCommand, HostBoard, render_view_png,
-};
+use waterui_dew::{ClipRegion, DewRuntime, DisplayList, DrawCommand, HostBoard, render_view_png};
 use waterui_graphics::color::Srgb;
 use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
 use waterui_svg::Svg;
@@ -43,7 +41,7 @@ const EXPORT_DIR: &str = "/tmp/waterui_dew_scene2d";
 const INLINE_SVG: &str = include_str!("assets/scene.svg");
 
 fn render_scene<V: View>(build: impl Fn() -> V + 'static, width: u32, height: u32) -> DisplayList {
-    let mut renderer = DewRenderer::default();
+    let mut renderer = support::test_renderer();
     renderer.render_tree(
         AnyView::new(build()),
         &support::test_environment(),

--- a/backends/dew/tests/shape_render.rs
+++ b/backends/dew/tests/shape_render.rs
@@ -13,7 +13,7 @@ use kurbo::{Affine, BezPath, Circle as KurboCircle, Rect, RoundedRect, Shape as 
 use peniko::Brush;
 use waterui::prelude::*;
 use waterui::shape::{Capsule, Circle, Path, RoundedRectangle, ShapeExt};
-use waterui_dew::{Clip, ClipRegion, DewRenderer, DisplayList, DrawCommand, render_view_png};
+use waterui_dew::{Clip, ClipRegion, DisplayList, DrawCommand, render_view_png};
 
 mod support;
 
@@ -26,7 +26,7 @@ fn display_srgb(red: u8, green: u8, blue: u8) -> peniko::Color {
 }
 
 fn render_scene<V: View>(build: impl Fn() -> V + 'static, width: u32, height: u32) -> DisplayList {
-    let mut renderer = DewRenderer::default();
+    let mut renderer = support::test_renderer();
     renderer.render_tree(
         AnyView::new(build()),
         &support::test_environment(),

--- a/backends/dew/tests/support/mod.rs
+++ b/backends/dew/tests/support/mod.rs
@@ -1,6 +1,9 @@
 use waterui::Plugin as _;
 use waterui::theme::{FontSettings, Theme};
+use waterui_backend_core::frame_signals::FrameSignals;
+use waterui_backend_core::time::Instant;
 use waterui_core::Environment;
+use waterui_dew::{DewRenderer, FontSources};
 use waterui_text::font::{FontWeight, ResolvedFont};
 
 pub fn test_environment() -> Environment {
@@ -20,6 +23,26 @@ pub fn test_environment() -> Environment {
         )
         .install(&mut environment);
     environment
+}
+
+/// A bare renderer for the tests that inspect a display list directly instead
+/// of pumping a board.
+///
+/// It picks its faces the way `HostBoard` does: the system collection on a
+/// desktop build, and the repository's own test faces in the firmware shape,
+/// which has no `system-fonts` feature and therefore no `FontSources::System`.
+/// `DewRenderer::default()` exists only in the former, so calling it here is
+/// what kept these tests from compiling in any other shape.
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn test_renderer() -> DewRenderer {
+    #[cfg(feature = "system-fonts")]
+    let fonts = FontSources::System;
+    #[cfg(not(feature = "system-fonts"))]
+    let fonts = FontSources::bundled(&[
+        include_bytes!("../../../../testing/fonts/Roboto-Regular.ttf"),
+        include_bytes!("../../../../testing/fonts/Roboto-Bold.ttf"),
+    ]);
+    DewRenderer::new(FrameSignals::new(Instant::now()), fonts)
 }
 
 // Only the performance simulation uses this; other integration tests include


### PR DESCRIPTION
Fixes #259.

`cargo clippy -p waterui-dew --all-targets --no-default-features` failed with ~60 errors. The library alone has always been clean in the firmware shape, so nothing noticed — but that shape is a first-class configuration, and a test that cannot compile in it is a latent break for anyone running the crate's tests without defaults.

## Three causes, each fixed at its own level

Gating everything on `host` would have compiled, but it would also have gated away the tests that are *most* meaningful on a device.

**1. The facade is a test dependency, not a `progress` dependency.** `Theme`, `ColorSettings` and `FontSettings` — the only way to install a theme — and the authoring prelude every test view tree is written in live in the `waterui` crate, and nothing below it exposes them. dew reaches the facade only through the optional `progress` feature, so the entire test surface built in exactly one feature shape. Tests are host-side and never enter a flash image, so `waterui` is now a dev-dependency (`default-features = false`, matching the optional entry). The firmware graph is untouched, and `cargo hack check --each-feature` runs `--no-dev-deps` so the Features job is unaffected.

**2. Each integration test declares the shape it needs**, using `required-features` in a `[[test]]` table — the mechanism the crate already uses for the `watch_sim` example.

**3. Font sources fork the way the crate already forks them.** `Board::fonts` is declared twice — system enumeration on a desktop build, flash-resident binaries on a device — and `HostBoard::fonts()` already resolves both. The test fixtures now say the same thing, taking the repository's own Roboto faces when `system-fonts` is absent. Behaviour under default features is unchanged; what changes is that the shaping tests keep *running* in the firmware shape instead of being gated away with it, and that a `host`-only build (`--no-default-features --features host`) compiles too, which it would not have if these had simply been marked `host`.

## What each test got, and why

| target | gate | why |
| --- | --- | --- |
| `fallback_probe` | none | pure `vello_cpu` scalar-rasterizer probe; runs in every shape including firmware |
| `smoke_frame` | `host` | drives `BufferDisplay`, the in-memory framebuffer |
| `accessibility` | `host` | pumps a `HostBoard` runtime |
| `dispatch_views` | `host` | `HostBoard` + `render_view_png` + `Pixmap::from_png` |
| `tabs_render` | `host` | `HostBoard` |
| `navigation_render` | `host` | `HostBoard`; its two display-list cases moved to the font fixture |
| `scene_render` | `host` | `HostBoard` + `render_view_png`; ditto |
| `shape_render` | `host` | `render_view_png`; ditto |
| `form_render` | `host`, `progress` | `render_view_png`, and it renders a progress bar — dew has no handler to dispatch one to without the feature |
| `vending_performance` | `progress` | **not** `host`: it models a panel bus and a flash-bundled font, and only needs the payment-progress bar its work and memory budgets are calibrated around. This is the one integration test that runs in the firmware shape, which is the point of it |
| `text::tests` (3 shaping cases) | none | kept running via the bundled-font fixture instead of `DewState::default()` |
| `views::tests` (4 widget cases) | none | kept running via the bundled-font fixture instead of `DewRenderer::default()`; every label is hidden, so no glyph is shaped |

## Pre-existing defect fixed along the way

`cargo clippy -p waterui-dew --all-targets --all-features` was failing on `must_use_candidate` for `embedded_executor::tick()`. That module only compiles under `embedded-simulator` or `espidf`, and CI's `--all-features` clippy pass is root-crate-scoped, so nothing ran it. `#[must_use]` would be the wrong fix — a frame loop calls `tick()` to advance futures and both in-tree callers discard the count, which is diagnostic — so it carries an item-scoped `#[expect]` with that reason. Pre-existing and unrelated to the gating; called out separately in its own commit.

## CI

`cargo clippy -p waterui-dew --all-targets --no-default-features -- -D warnings` joins the existing Linux lint leg of the Test job, so it costs no new runner. Neither clippy pass there compiled dew without default features, and the Features job's sweep runs `--no-dev-deps`, which is exactly how this rotted.

## Verification

```
cargo +stable clippy -p waterui-dew --all-targets --no-default-features -- -D warnings   Finished (0 warnings)
cargo +stable clippy -p waterui-dew --all-targets --no-default-features --features host -- -D warnings   Finished (0 warnings)
cargo +stable clippy -p waterui-dew --all-targets --all-features -- -D warnings          Finished (0 warnings)
cargo +stable clippy -p waterui-dew --all-targets -- -D warnings                         Finished (0 warnings)
cargo +stable nextest run -p waterui-dew                              94 tests run: 94 passed, 0 skipped
cargo +stable nextest run -p waterui-dew --no-default-features        40 tests run: 40 passed, 0 skipped
cargo +stable nextest run -p waterui-dew --no-default-features --features progress
                                                                     43 tests run: 43 passed, 0 skipped
```

No test was weakened or deleted; the default-feature run is the same 94 tests as before.
