### PR TITLE
ci(bench): run the macOS leg on pull requests only when the code it measures changes

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -45,27 +45,112 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  # Which bench legs the run below executes.
+  #
+  # The rule: the macOS leg runs when the code it measures changes.
+  #
+  # macOS is the only leg with a real GPU and therefore the only full-shape
+  # measurement, so it cannot simply be dropped from pull requests. It is also
+  # the org's scarcest runner — macOS concurrency is the CI bottleneck, and
+  # every pull request already holds three macOS jobs. So on a pull request the
+  # macOS leg is spent only when the diff touches something the two bench
+  # suites actually execute; every other pull request runs Linux and Windows
+  # only. `schedule` and `workflow_dispatch` are unaffected and always run the
+  # full matrix, which is what keeps the `bench-history` trend series complete.
+  #
+  # No checkout: for a `pull_request` event dorny/paths-filter reads the
+  # changed files from the API, so this job is a few seconds of API calls.
+  select-legs:
+    name: Select bench legs
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      # dorny/paths-filter lists the pull request's changed files.
+      pull-requests: read
+    outputs:
+      matrix: ${{ steps.legs.outputs.matrix }}
+    steps:
+      - uses: dorny/paths-filter@v3
+        id: filter
+        if: github.event_name == 'pull_request'
+        with:
+          filters: |
+            perf:
+              # The two bench suites this workflow runs (`water bench --path`).
+              - "examples/stress/**"
+              - "examples/list/**"
+              # The harness that measures them: the `#[waterui::bench]`
+              # expansion, the `PerfApp` frame pump and in-process budget
+              # evaluation, the `water bench` runner, and the report / env-var
+              # contract the runner and the harness share.
+              - "macros/**"
+              - "testing/**"
+              - "cli/src/bench/**"
+              - "cli/src/terminal/commands/bench.rs"
+              - "components/devtools/preview/protocol/**"
+              # What renders every measured frame. Both benches install
+              # `hydrolysis_m3::install` as their theme and are driven by the
+              # Hydrolysis GPU renderer through the shared backend contract.
+              - "backends/core/**"
+              - "backends/hydrolysis/**"
+              - "backends/hydrolysis_m3/**"
+              - "backends/dew/**"
+              # Foundations both scenes go through: the View contract and
+              # reactivity, layout / text / shape / controls, the colour and
+              # filter pipeline the stress scene's third pressure path drives,
+              # the `waterui` facade the examples import, and `waterui-str`,
+              # which backs every text node.
+              - "core/**"
+              - "components/foundation/**"
+              - "components/visual/graphics/**"
+              - "src/**"
+              - "utils/**"
+              # Build inputs that move the numbers without touching any source
+              # above: nami, filtrate, vello, wgpu and shaderloom are crates.io
+              # dependencies, so a bench-relevant bump appears only here.
+              - "Cargo.toml"
+              - "Cargo.lock"
+              - "rust-toolchain*"
+              # And this workflow itself.
+              - ".github/workflows/bench.yml"
+      - name: Build the bench matrix
+        id: legs
+        shell: bash
+        env:
+          # Every leg, with its measurement shape. macOS runners have a real
+          # (paravirtualized Metal) GPU and run the full default shape. The
+          # Linux and Windows runners rasterize in software (llvmpipe / WARP),
+          # where a heavy scene runs at seconds per frame — the full shape blew
+          # straight through nextest's terminate ceiling there. A reduced shape
+          # keeps those legs meaningful (the counter budgets are
+          # shape-independent, and the wall-clock series stays self-consistent
+          # per OS over time) while fitting the job budget.
+          ALL_LEGS: >-
+            [{"os": "ubuntu-latest", "bench-shape": "--warmups 2 --samples 24 --repetitions 3"},
+             {"os": "macos-latest", "bench-shape": ""},
+             {"os": "windows-latest", "bench-shape": "--warmups 2 --samples 24 --repetitions 3"}]
+          # Forced true off pull requests, so `schedule` and
+          # `workflow_dispatch` keep the full matrix.
+          RUN_MACOS: ${{ github.event_name != 'pull_request' || steps.filter.outputs.perf == 'true' }}
+        run: |
+          printf 'matrix=%s\n' \
+            "$(jq -c --argjson run_macos "$RUN_MACOS" \
+                 '{include: map(select(.os != "macos-latest" or $run_macos))}' \
+                 <<<"$ALL_LEGS")" >> "$GITHUB_OUTPUT"
+
   bench:
     name: Bench (${{ matrix.os }})
+    needs: select-legs
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
       fail-fast: false
-      # macOS runners have a real (paravirtualized Metal) GPU and run the full
-      # default measurement shape. The Linux and Windows runners rasterize in
-      # software (llvmpipe / WARP), where a heavy scene runs at seconds per
-      # frame — the full shape blew straight through nextest's terminate
-      # ceiling there. A reduced shape keeps those legs meaningful (the
-      # counter budgets are shape-independent, and the wall-clock series stays
-      # self-consistent per OS over time) while fitting the job budget.
-      matrix:
-        include:
-          - os: ubuntu-latest
-            bench-shape: --warmups 2 --samples 24 --repetitions 3
-          - os: macos-latest
-            bench-shape: ""
-          - os: windows-latest
-            bench-shape: --warmups 2 --samples 24 --repetitions 3
+      # Built by `select-legs` above rather than written out here, so the macOS
+      # leg can be left out of a pull request that does not touch the code it
+      # measures. The `include` shape and the job name are unchanged, so the
+      # legs that do run keep their existing check names.
+      matrix: ${{ fromJSON(needs.select-legs.outputs.matrix) }}
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
macOS runner concurrency (5) is the org's CI bottleneck, and every pull request already holds three macOS jobs (Test, Bench, FFI Header). The `Bench` macOS leg is the only GPU-measured, full-shape run — Linux and Windows rasterize in software (llvmpipe / WARP) and use a reduced shape — so it cannot simply be dropped from pull requests either.

**The rule: the macOS leg runs on a pull request only when the code it measures changes.**

## Mechanism

A new `select-legs` job (ubuntu, no checkout, a few seconds of API calls) runs `dorny/paths-filter@v3` over the performance-relevant paths and emits the bench matrix as JSON. The `bench` job consumes it with `matrix: ${{ fromJSON(needs.select-legs.outputs.matrix) }}`, so the ubuntu and windows legs are always in the matrix and macOS is included only when the filter matched.

`fromJSON` was chosen over a separate `bench-macos` job because it keeps the job name (`Bench (${{ matrix.os }})`) and every step identical — the legs that run keep their existing check names for branch rulesets and the PR checks list, and no steps are duplicated.

Off `pull_request` the filter step does not run and the result is forced true, so `schedule` and `workflow_dispatch` keep the full three-leg matrix and the `bench-history` trend series stays complete.

Unchanged: job names, the per-leg measurement shapes, the concurrency group, `Swatinem/rust-cache` keys, workflow permissions, every `bench` step, and the whole `bench-history` job.

## The path list, and where it comes from

Derived from what the two suites this workflow runs (`water bench --path examples/stress`, `water bench --path examples/list`) actually execute:

| Group | Paths | Why |
| --- | --- | --- |
| The bench suites | `examples/stress/**`, `examples/list/**` | The `#[waterui::bench]` functions and their scenes |
| The harness that measures them | `macros/**`, `testing/**`, `cli/src/bench/**`, `cli/src/terminal/commands/bench.rs`, `components/devtools/preview/protocol/**` | `#[waterui::bench]` expansion; the `PerfApp` frame pump and in-process budget evaluation; the `water bench` runner; the report / env-var contract (`BenchBudgets`, `BenchReport`, `WATERUI_BENCH_*`) the runner and the harness share |
| What renders every measured frame | `backends/core/**`, `backends/hydrolysis/**`, `backends/hydrolysis_m3/**`, `backends/dew/**` | Both benches declare `theme = hydrolysis_m3::install` and are driven by the Hydrolysis GPU renderer through the shared backend contract |
| Foundations both scenes go through | `core/**`, `components/foundation/**`, `components/visual/graphics/**`, `src/**`, `utils/**` | The `View` contract and reactivity; layout / text / shape / controls (`scroll`, `vstack`, `List`, `Toggle`, text); colour and the filter pipeline that `filter_section` — one of the stress scene's three pressure paths — drives; the `waterui` facade the examples import; `waterui-str`, which backs every text node |
| Build inputs that move the numbers without touching any source above | `Cargo.toml`, `Cargo.lock`, `rust-toolchain*` | `nami`, `filtrate`, `vello`, `wgpu` and `shaderloom` are crates.io dependencies, so a bench-relevant bump appears only in the lockfile |
| This workflow | `.github/workflows/bench.yml` | A change to the matrix, the shapes or the runner has to be validated on the leg it affects |

## Validation

- `actionlint` clean on the final file.
- The matrix builder verified on both branches offline: with the filter true it reproduces today's three-leg `include` byte for byte (same `os` values, same `bench-shape` strings); with it false the `include` is ubuntu + windows.
- This pull request edits `.github/workflows/bench.yml`, which is deliberately in the list, so its own `Bench` matrix is expected to include macOS — that is the intended behaviour for a change to the bench workflow itself.
