### PR TITLE
feat(graphics)!: give SceneContent an intrinsic size

### DIFF
--- a/backends/dew/src/views/scene.rs
+++ b/backends/dew/src/views/scene.rs
@@ -29,7 +29,9 @@ use accesskit::{Node as AccessibilityNode, NodeId, Role};
 use kurbo::{Affine, Rect};
 use waterui_backend_core::frame_signals::FrameSignals;
 use waterui_core::layout::{ProposalSize, Size, StretchAxis, ViewDimensions};
-use waterui_graphics::{SceneContent, SceneRecording, SceneView};
+use waterui_graphics::{
+    SceneContent, SceneRecording, SceneView, resolve_scene_proposal, scene_stretch_axis,
+};
 
 use crate::dispatch::{DewNode, DewRenderer, RenderContext};
 use crate::display_list::DrawCommand;
@@ -55,9 +57,12 @@ struct SceneNode {
 
 impl DewNode for SceneNode {
     fn measure(&self, _state: &RefCell<DewState>, proposal: ProposalSize) -> ViewDimensions {
-        // A scene has no intrinsic size: it fills whatever it is proposed,
-        // like a colour or a shape, and is sized by `.frame()` or its
-        // container.
+        // Content that is naturally a size (an SVG's viewBox, a formula's
+        // typeset box) answers with it on whichever axis the container left
+        // open, and keeps its aspect ratio when only one axis was named.
+        // Content that has no size of its own fills whatever it is proposed,
+        // like a colour or a shape, and is sized by `.frame()` or its container.
+        let proposal = resolve_scene_proposal(self.content.intrinsic_size(), proposal);
         ViewDimensions::new(Size::new(
             proposal
                 .width
@@ -132,7 +137,7 @@ impl DewNode for SceneNode {
     }
 
     fn stretch_axis(&self) -> StretchAxis {
-        StretchAxis::Both
+        scene_stretch_axis(self.content.intrinsic_size())
     }
 }
 

--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -31,6 +31,7 @@ use waterui_dew::{
 };
 use waterui_graphics::color::Srgb;
 use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
+use waterui_layout::scroll::ScrollView;
 use waterui_svg::Svg;
 
 mod support;
@@ -325,4 +326,63 @@ fn animated_content_keeps_asking_for_frames() {
         );
     }
     assert_eq!(builds.get(), 4, "every frame redraws the animated content");
+}
+
+/// Scene content that *is* 100 x 200 logical points — an SVG's `viewBox`, an
+/// image's pixel size, a formula's typeset box.
+struct NaturallySizedContent;
+
+impl SceneContent for NaturallySizedContent {
+    fn build_scene(&mut self, scene: &mut dyn Scene2D, width: f32, height: f32) -> bool {
+        let path = Rect::new(0.0, 0.0, f64::from(width), f64::from(height)).to_path(0.1);
+        let brush: peniko::Brush = peniko::Color::new([0.0, 0.4, 1.0, 1.0]).into();
+        scene.fill(peniko::Fill::NonZero, Affine::IDENTITY, &brush, None, &path);
+        false
+    }
+
+    fn intrinsic_size(&self) -> Option<Size> {
+        Some(Size::new(100.0, 200.0))
+    }
+}
+
+/// The one scene command in a list that also carries a scroll view's chrome.
+fn find_scene(list: &DisplayList) -> (&DrawCommand, Rect) {
+    let placed = list
+        .commands()
+        .iter()
+        .find(|placed| matches!(placed.command(), DrawCommand::Scene { .. }))
+        .expect("the list must carry exactly one scene command");
+    (placed.command(), placed.bounds())
+}
+
+/// Dew resolves an unconstrained scroll axis from the content's natural size,
+/// exactly as hydrolysis does — the two self-drawn backends must not disagree
+/// about how big a drawing is (water-rs/waterui#253).
+#[test]
+fn an_unconstrained_scroll_axis_resolves_to_the_natural_size() {
+    let list = render_scene(
+        || ScrollView::vertical(SceneView::new(NaturallySizedContent)),
+        100,
+        120,
+    );
+    let (command, _) = find_scene(&list);
+    let DrawCommand::Scene { bounds: local, .. } = command else {
+        unreachable!("find_scene asserted the variant")
+    };
+    // The viewport names the width (100, the natural width), and leaves the
+    // scroll axis open; the drawing is laid out at the 200 points it is, rather
+    // than collapsing to zero and being clamped up to the 120-point viewport.
+    assert_eq!(*local, Rect::new(0.0, 0.0, 100.0, 200.0));
+}
+
+/// Content with no natural size still fills the viewport on the scroll axis,
+/// which is what a background or a shader wants.
+#[test]
+fn a_sizeless_scene_still_fills_an_unconstrained_scroll_axis() {
+    let list = render_scene(|| ScrollView::vertical(swatch()), 100, 120);
+    let (command, _) = find_scene(&list);
+    let DrawCommand::Scene { bounds: local, .. } = command else {
+        unreachable!("find_scene asserted the variant")
+    };
+    assert_eq!(*local, Rect::new(0.0, 0.0, 100.0, 120.0));
 }

--- a/backends/hydrolysis/src/renderer/tree/layout.rs
+++ b/backends/hydrolysis/src/renderer/tree/layout.rs
@@ -3,6 +3,7 @@
 //! child frames for the flush pass.
 
 use super::*;
+use waterui_graphics::{resolve_scene_proposal, scene_stretch_axis};
 
 impl RenderNode {
     /// The stretch axis this node exposes when it is a layout child.
@@ -94,7 +95,11 @@ impl RenderNode {
             RenderNode::Retain(node) => node.child.stretch(),
             RenderNode::Env(node) => node.child.stretch(),
             RenderNode::Dynamic(node) => node.child.stretch(),
-            RenderNode::SceneView(_) => StretchAxis::Both,
+            // Scene content that is naturally a size is content-sized and claims
+            // no leftover space; content that has no size of its own fills.
+            RenderNode::SceneView(node) => {
+                scene_stretch_axis(node.content.borrow().intrinsic_size())
+            }
             // A GpuSurface fills its proposal (`GpuView::stretch_axis` default);
             // a ViewEffect is a `StretchAxis::None` raw view; an AppliedFilter is
             // a layout-transparent wrapper delegating to its child.
@@ -156,10 +161,17 @@ impl RenderNode {
             RenderNode::Retain(node) => node.child.measure(state, env, proposal),
             RenderNode::Env(node) => node.child.measure(state, &node.env, proposal),
             RenderNode::Dynamic(node) => node.child.measure(state, env, proposal),
-            RenderNode::SceneView(_) => ViewDimensions::new(Size::new(
-                proposal.width.unwrap_or(0.0),
-                proposal.height.unwrap_or(0.0),
-            )),
+            // Scene content that is naturally a size (an SVG's viewBox, a
+            // formula's typeset box) answers with it on whichever axis the
+            // container left open; content that is not fills the proposal.
+            RenderNode::SceneView(node) => {
+                let resolved =
+                    resolve_scene_proposal(node.content.borrow().intrinsic_size(), proposal);
+                ViewDimensions::new(Size::new(
+                    resolved.width.unwrap_or(0.0),
+                    resolved.height.unwrap_or(0.0),
+                ))
+            }
             // A GpuSurface fills its proposal, like a self-drawn scene.
             RenderNode::GpuSurface(_) => ViewDimensions::new(Size::new(
                 proposal.width.unwrap_or(0.0),

--- a/backends/hydrolysis/src/widgets/visual/graphics.rs
+++ b/backends/hydrolysis/src/widgets/visual/graphics.rs
@@ -4,7 +4,7 @@ use waterui_core::layout::{ProposalSize, ViewDimensions};
 use waterui_core::{Environment, Native};
 use waterui_graphics::color::{Color, ResolvedColor};
 use waterui_graphics::view_effect::ViewEffectErased;
-use waterui_graphics::{GpuSurface, ResolvedGradient, SceneView};
+use waterui_graphics::{GpuSurface, ResolvedGradient, SceneView, resolve_scene_proposal};
 use waterui_shape::{ResolvedMorphShape, ResolvedShape};
 
 impl HydroNativeView for Native<GpuSurface> {
@@ -23,17 +23,24 @@ impl HydroNativeView for Native<GpuSurface> {
 }
 
 impl HydroNativeView for Native<SceneView> {
-    fn intrinsic(_state: &mut HydroState, _view: &Self, _env: &Environment) -> LayoutSize {
-        LayoutSize::zero()
+    fn intrinsic(_state: &mut HydroState, view: &Self, _env: &Environment) -> LayoutSize {
+        view.as_inner()
+            .intrinsic_size()
+            .unwrap_or_else(LayoutSize::zero)
     }
 
     fn dimensions(
         _state: &mut HydroState,
-        _view: &Self,
+        view: &Self,
         _env: &Environment,
         proposal: ProposalSize,
     ) -> ViewDimensions {
-        graphics_dimensions_from_proposal(proposal)
+        // Scene content that is naturally a size answers with it wherever the
+        // container left an axis open; content that is not fills the proposal.
+        graphics_dimensions_from_proposal(resolve_scene_proposal(
+            view.as_inner().intrinsic_size(),
+            proposal,
+        ))
     }
 }
 

--- a/components/visual/graphics/src/lib.rs
+++ b/components/visual/graphics/src/lib.rs
@@ -124,7 +124,10 @@ pub use image_generator::{
     LinearGradientGenerator, NoiseGenerator, RadialGradientGenerator, StripeGenerator,
 };
 
-pub use scene_view::{SceneContent, SceneInvalidator, SceneView, SceneViewMergeToParent};
+pub use scene_view::{
+    SceneContent, SceneInvalidator, SceneView, SceneViewMergeToParent, resolve_scene_proposal,
+    scene_stretch_axis,
+};
 pub use scene2d::{Glyph, GlyphRun, Scene2D, SceneRecording};
 #[cfg(feature = "vello-scene")]
 pub use scene2d_hybrid::{HybridImageAtlas, HybridRenderer, HybridScene2D, HybridUpload};

--- a/components/visual/graphics/src/scene/scene_surface.rs
+++ b/components/visual/graphics/src/scene/scene_surface.rs
@@ -8,10 +8,11 @@
 use alloc::boxed::Box;
 
 use waterui_core::MainThreadBound;
+use waterui_core::layout::{ProposalSize, Size, StretchAxis, ViewDimensions};
 
 use crate::gpu::shared_context::SceneEngine;
 use crate::gpu_surface::{GpuContext, GpuFrame, GpuView};
-use crate::scene_view::SceneContent;
+use crate::scene_view::{SceneContent, resolve_scene_proposal, scene_stretch_axis};
 use crate::scene2d_hybrid::{HybridScene2D, HybridUpload};
 use crate::scene2d_vello::VelloScene2D;
 
@@ -32,9 +33,11 @@ enum SceneBuffer {
 }
 
 pub struct SceneSurfaceRenderer {
-    // `SceneContent` is `!Send` (it carries an `Rc` invalidator). `measure` never
-    // touches it (it returns a fixed size), so confining it keeps the renderer
-    // `Send + Sync` for the `SubView` bound while setup/render stay on the main thread.
+    // `SceneContent` is `!Send` (it carries an `Rc` invalidator), and confining it
+    // keeps the renderer `Send + Sync` for the `SubView` bound. Layout is
+    // single-threaded by contract and runs on the thread that built this surface,
+    // so `measure` reads the content's intrinsic size straight through the binding
+    // alongside setup/render.
     content: MainThreadBound<Box<dyn SceneContent>>,
     // Which engine's scene this is settles in setup, once the device says which
     // one it rasterizes with.
@@ -171,6 +174,18 @@ impl GpuView for SceneSurfaceRenderer {
 
         self.blit_bind_group_layout = Some(bind_group_layout);
         core::future::ready(())
+    }
+
+    fn measure(&self, proposal: ProposalSize) -> ViewDimensions {
+        let resolved = resolve_scene_proposal(self.content.intrinsic_size(), proposal);
+        ViewDimensions::new(Size::new(
+            resolved.width.unwrap_or(0.0),
+            resolved.height.unwrap_or(0.0),
+        ))
+    }
+
+    fn stretch_axis(&self) -> StretchAxis {
+        scene_stretch_axis(self.content.intrinsic_size())
     }
 
     fn render(&mut self, frame: &mut GpuFrame) {

--- a/components/visual/graphics/src/scene/scene_view.rs
+++ b/components/visual/graphics/src/scene/scene_view.rs
@@ -2,7 +2,7 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::fmt;
 
-use waterui_core::layout::StretchAxis;
+use waterui_core::layout::{ProposalSize, Size, StretchAxis};
 use waterui_core::{AnyView, Environment, Native, NativeView, View};
 
 #[cfg(feature = "gpu")]
@@ -27,6 +27,104 @@ pub trait SceneContent: 'static {
 
     /// Installs an invalidation callback that content can trigger from signal watchers.
     fn set_invalidator(&mut self, _invalidator: Option<SceneInvalidator>) {}
+
+    /// The size this drawing is naturally, in logical points.
+    ///
+    /// An image's pixel dimensions, an SVG document's `viewBox`, a barcode's
+    /// module grid, a formula's typeset box: content that *is* a particular size
+    /// answers with it, and layout uses it wherever nothing else settles the
+    /// question. `None` — the default — means the drawing has no size of its own
+    /// and takes whatever it is given, which is right for a full-bleed background,
+    /// a shader, or a canvas whose author draws into the box they are handed.
+    ///
+    /// The answer is a whole size rather than a pair of independent axes because
+    /// it is also the drawing's aspect ratio: when a container names one axis and
+    /// leaves the other open, [`resolve_scene_proposal`] derives the open one from
+    /// this ratio, which a per-axis answer could not express.
+    ///
+    /// It must be finite and positive on both axes; a drawing with no honest size
+    /// answers `None` instead of a degenerate one.
+    fn intrinsic_size(&self) -> Option<Size> {
+        None
+    }
+}
+
+/// Fills in the axes a proposal left open from scene content's intrinsic size.
+///
+/// This is the one rule every realization of a [`SceneView`] measures by — the
+/// `GpuSurface` one, hydrolysis' retained tree, dew's display list — so a scene
+/// cannot be sized differently depending on which backend drew it.
+///
+/// - Content with no intrinsic size is returned unchanged, so a scene that takes
+///   whatever it is given keeps doing exactly that, and each caller keeps its own
+///   fallback for the axes still left open.
+/// - Both axes named: the proposal stands. A scene fills a box it was given a box
+///   for, which is what `StretchAxis::Both` promises.
+/// - Neither axis named: the natural size, which is the whole point of the hook.
+/// - Exactly one axis named: that axis stands and the other follows the natural
+///   aspect ratio — an image `.resizable()` under aspect fit, sized by the axis its
+///   container actually constrained.
+///
+/// A named axis that is not finite (`f32::INFINITY` is how a container asks for a
+/// maximum) cannot scale anything, so the open axis falls back to its natural
+/// extent rather than becoming infinite too.
+///
+/// # Panics
+///
+/// Panics when `intrinsic` is not finite and positive on both axes: a
+/// [`SceneContent`] that claims a degenerate natural size would otherwise push
+/// `NaN` geometry into layout, which surfaces far away from the content that
+/// produced it.
+#[must_use]
+pub fn resolve_scene_proposal(intrinsic: Option<Size>, proposal: ProposalSize) -> ProposalSize {
+    let Some(natural) = intrinsic else {
+        return proposal;
+    };
+    assert!(
+        natural.width.is_finite()
+            && natural.height.is_finite()
+            && natural.width > 0.0
+            && natural.height > 0.0,
+        "SceneContent::intrinsic_size must be finite and positive, got {}x{}",
+        natural.width,
+        natural.height
+    );
+
+    match (proposal.width, proposal.height) {
+        (Some(_), Some(_)) => proposal,
+        (None, None) => ProposalSize::new(natural.width, natural.height),
+        (Some(width), None) => {
+            ProposalSize::new(width, scale_across(width, natural.width, natural.height))
+        }
+        (None, Some(height)) => {
+            ProposalSize::new(scale_across(height, natural.height, natural.width), height)
+        }
+    }
+}
+
+/// The extent across the named axis, at the scale that axis was named at.
+fn scale_across(named: f32, natural_along: f32, natural_across: f32) -> f32 {
+    if named.is_finite() {
+        natural_across * (named / natural_along)
+    } else {
+        natural_across
+    }
+}
+
+/// Which axes a scene claims from its container, given its intrinsic size.
+///
+/// Content with no size of its own takes whatever it is offered, exactly as it
+/// always has. Content that *is* a size is content-sized and claims no leftover
+/// space: an icon in a row must not eat the row, and a container that wants it
+/// bigger says so with a frame, which [`resolve_scene_proposal`] then honours.
+/// This is the rule `waterui-image` already measures its own surfaces by.
+#[must_use]
+pub const fn scene_stretch_axis(intrinsic: Option<Size>) -> StretchAxis {
+    if intrinsic.is_some() {
+        StretchAxis::None
+    } else {
+        StretchAxis::Both
+    }
 }
 
 /// A view that renders scene content either directly (backend) or via `GpuSurface`.
@@ -55,6 +153,15 @@ impl SceneView {
         &mut *self.content
     }
 
+    /// The natural size of the wrapped content, if it has one.
+    ///
+    /// See [`SceneContent::intrinsic_size`]; backends measuring a `SceneView` as a
+    /// native leaf feed this to [`resolve_scene_proposal`].
+    #[must_use]
+    pub fn intrinsic_size(&self) -> Option<Size> {
+        self.content.intrinsic_size()
+    }
+
     /// Takes ownership of the wrapped scene content.
     #[must_use]
     pub fn into_content(self) -> Box<dyn SceneContent> {
@@ -75,7 +182,7 @@ impl SceneView {
 
 impl NativeView for SceneView {
     fn stretch_axis(&self) -> StretchAxis {
-        StretchAxis::Both
+        scene_stretch_axis(self.intrinsic_size())
     }
 }
 
@@ -102,6 +209,139 @@ impl View for SceneView {
     }
 
     fn stretch_axis(&self) -> StretchAxis {
-        StretchAxis::Both
+        scene_stretch_axis(self.intrinsic_size())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        NativeView, ProposalSize, SceneContent, SceneView, Size, StretchAxis,
+        resolve_scene_proposal, scene_stretch_axis,
+    };
+    use crate::scene2d::Scene2D;
+
+    /// Content that is naturally 100x200 — twice as tall as it is wide.
+    struct Tall;
+
+    impl SceneContent for Tall {
+        fn build_scene(&mut self, _scene: &mut dyn Scene2D, _width: f32, _height: f32) -> bool {
+            false
+        }
+
+        fn intrinsic_size(&self) -> Option<Size> {
+            Some(Size::new(100.0, 200.0))
+        }
+    }
+
+    /// Content with no size of its own, which is the trait's default.
+    struct Sizeless;
+
+    impl SceneContent for Sizeless {
+        fn build_scene(&mut self, _scene: &mut dyn Scene2D, _width: f32, _height: f32) -> bool {
+            false
+        }
+    }
+
+    #[test]
+    fn content_defaults_to_no_intrinsic_size() {
+        assert_eq!(Sizeless.intrinsic_size(), None);
+        assert_eq!(
+            SceneView::new(Sizeless).intrinsic_size(),
+            None,
+            "a view must report exactly what its content reports"
+        );
+        assert_eq!(
+            SceneView::new(Tall).intrinsic_size(),
+            Some(Size::new(100.0, 200.0))
+        );
+    }
+
+    #[test]
+    fn sizeless_content_is_proposed_unchanged() {
+        // Every axis, open or named, reaches the caller's own fallback untouched.
+        for proposal in [
+            ProposalSize::UNSPECIFIED,
+            ProposalSize::ZERO,
+            ProposalSize::INFINITY,
+            ProposalSize::new(Some(80.0), None),
+            ProposalSize::new(None, Some(40.0)),
+        ] {
+            assert_eq!(resolve_scene_proposal(None, proposal), proposal);
+        }
+    }
+
+    #[test]
+    fn an_open_proposal_resolves_to_the_natural_size() {
+        assert_eq!(
+            resolve_scene_proposal(Tall.intrinsic_size(), ProposalSize::UNSPECIFIED),
+            ProposalSize::new(100.0, 200.0)
+        );
+    }
+
+    #[test]
+    fn a_named_proposal_stands_on_both_axes() {
+        let named = ProposalSize::new(320.0, 40.0);
+        assert_eq!(
+            resolve_scene_proposal(Tall.intrinsic_size(), named),
+            named,
+            "content given a box fills it, however far that is from its natural size"
+        );
+        assert_eq!(
+            resolve_scene_proposal(Tall.intrinsic_size(), ProposalSize::ZERO),
+            ProposalSize::ZERO,
+            "a minimum-size probe must still be answerable with zero"
+        );
+    }
+
+    #[test]
+    fn one_named_axis_drives_the_other_by_aspect_ratio() {
+        assert_eq!(
+            resolve_scene_proposal(Tall.intrinsic_size(), ProposalSize::new(Some(200.0), None)),
+            ProposalSize::new(200.0, 400.0),
+            "twice the natural width is twice the natural height"
+        );
+        assert_eq!(
+            resolve_scene_proposal(Tall.intrinsic_size(), ProposalSize::new(None, Some(50.0))),
+            ProposalSize::new(25.0, 50.0),
+            "a quarter of the natural height is a quarter of the natural width"
+        );
+    }
+
+    #[test]
+    fn an_unbounded_named_axis_leaves_the_other_natural() {
+        // `INFINITY` is how a container asks for a maximum; nothing can be scaled
+        // by it, so the open axis stays the size the content actually is.
+        assert_eq!(
+            resolve_scene_proposal(
+                Tall.intrinsic_size(),
+                ProposalSize::new(Some(f32::INFINITY), None)
+            ),
+            ProposalSize::new(f32::INFINITY, 200.0)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "must be finite and positive")]
+    fn a_degenerate_natural_size_is_rejected() {
+        let _ = resolve_scene_proposal(Some(Size::new(0.0, 10.0)), ProposalSize::UNSPECIFIED);
+    }
+
+    #[test]
+    fn only_sizeless_content_claims_leftover_space() {
+        assert_eq!(scene_stretch_axis(None), StretchAxis::Both);
+        assert_eq!(
+            scene_stretch_axis(Tall.intrinsic_size()),
+            StretchAxis::None,
+            "an icon in a row must not eat the row"
+        );
+        assert_eq!(
+            NativeView::stretch_axis(&SceneView::new(Tall)),
+            StretchAxis::None
+        );
+        assert_eq!(
+            NativeView::stretch_axis(&SceneView::new(Sizeless)),
+            StretchAxis::Both
+        );
     }
 }

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -1,10 +1,12 @@
 //! The `Math` view.
 
 use alloc::string::String;
+use core::cell::RefCell;
 
 use nami::signal::IntoComputed;
 use parley::FontContext;
 use peniko::{Brush, Color as PenikoColor, FontData};
+use waterui_core::layout::Size;
 use waterui_core::{Computed, Environment, Signal, View};
 use waterui_graphics::color::{Color, ForegroundColor, ResolvedColor};
 use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
@@ -205,9 +207,22 @@ pub struct MathContent {
     font_size: f32,
     family: Str,
     brush: Brush,
+    cache: RefCell<MathCache>,
+    invalidator: Option<SceneInvalidator>,
+}
+
+/// The font collection and the last measurement, shared by drawing and layout.
+///
+/// Measuring a formula *is* laying it out, and a container probes a child
+/// several times in one pass, so the answer is kept. A plain `RefCell` is the
+/// right cell for it: layout is single-threaded by contract and runs on the same
+/// thread that draws.
+#[derive(Default)]
+struct MathCache {
     fonts: Option<FontContext>,
     font: Option<FontData>,
-    invalidator: Option<SceneInvalidator>,
+    /// The formula last measured and the box it occupies.
+    measured: Option<(Str, Size)>,
 }
 
 impl MathContent {
@@ -229,10 +244,30 @@ impl MathContent {
             font_size,
             family: family.into(),
             brush,
-            fonts: None,
-            font: None,
+            cache: RefCell::new(MathCache::default()),
             invalidator: None,
         }
+    }
+
+    /// The math face this formula is set in, resolved once and kept.
+    ///
+    /// `None` means no installed family by that name carries a `MATH` table, and
+    /// there is deliberately no substitute — a face without the table has no
+    /// layout constants, so the formula has no geometry at all.
+    fn font(&self) -> Option<FontData> {
+        let mut cache = self.cache.borrow_mut();
+        if cache.font.is_none() {
+            let cache = &mut *cache;
+            let fonts = cache.fonts.get_or_insert_with(FontContext::new);
+            match resolve_font(fonts, self.family.as_str()) {
+                Ok(font) => cache.font = Some(font),
+                Err(error) => {
+                    tracing::error!(%error, "math formula has no usable font");
+                    return None;
+                }
+            }
+        }
+        cache.font.clone()
     }
 }
 
@@ -255,17 +290,7 @@ impl SceneContent for MathContent {
 
         // The font collection is discovered once and kept for the life of this
         // surface, which is where per-surface resources belong.
-        if self.font.is_none() {
-            let fonts = self.fonts.get_or_insert_with(FontContext::new);
-            match resolve_font(fonts, self.family.as_str()) {
-                Ok(font) => self.font = Some(font),
-                Err(error) => {
-                    tracing::error!(%error, "math formula has no usable font");
-                    return false;
-                }
-            }
-        }
-        let Some(font) = self.font.clone() else {
+        let Some(font) = self.font() else {
             return false;
         };
 
@@ -294,6 +319,41 @@ impl SceneContent for MathContent {
 
         scene::draw(&layout, scene, &font, &self.brush, 0.0, prepared.ascent);
         false
+    }
+
+    /// The typeset box the formula occupies, at this content's em size.
+    ///
+    /// A formula is text: it is exactly as wide as its advance and as tall as its
+    /// ascent plus descent, and a container that names neither axis should get
+    /// that rather than nothing. `None` when the family carries no `MATH` table,
+    /// when the source does not parse, or when the formula is empty — none of
+    /// which is a size.
+    fn intrinsic_size(&self) -> Option<Size> {
+        let source = self.source.get();
+        let cached = self.cache.borrow().measured.clone();
+        if let Some((measured, size)) = cached
+            && measured == source
+        {
+            return Some(size);
+        }
+
+        let font = self.font()?;
+        let prepared = match prepare(source.as_str(), &font, self.font_size, self.style) {
+            Ok(prepared) => prepared,
+            Err(error) => {
+                tracing::error!(%error, formula = %source, "could not measure math formula");
+                return None;
+            }
+        };
+        let size = Size::new(prepared.width, prepared.height());
+        if !(size.width.is_finite() && size.height.is_finite())
+            || size.width <= 0.0
+            || size.height <= 0.0
+        {
+            return None;
+        }
+        self.cache.borrow_mut().measured = Some((source, size));
+        Some(size)
     }
 
     fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {

--- a/components/visual/svg/src/scene_data.rs
+++ b/components/visual/svg/src/scene_data.rs
@@ -1,5 +1,7 @@
 //! Parsed SVG documents, ready to draw into a scene.
 
+use waterui_core::layout::Size;
+
 /// A parsed SVG document.
 #[derive(Debug)]
 pub struct SvgSceneData {
@@ -24,6 +26,17 @@ impl SvgSceneData {
         );
 
         Self { svg_tree }
+    }
+
+    /// The document's own size, from its `viewBox` / `width` / `height`.
+    ///
+    /// This is the size an SVG *is*: `parse` has already established it is finite
+    /// and positive, so an icon with no frame around it measures at the size its
+    /// author drew, and one given a single axis keeps this document's aspect ratio.
+    #[must_use]
+    pub fn intrinsic_size(&self) -> Size {
+        let size = self.svg_tree.size();
+        Size::new(size.width(), size.height())
     }
 
     /// The transform that fits this document into `width` × `height`.

--- a/components/visual/svg/src/scene_renderer.rs
+++ b/components/visual/svg/src/scene_renderer.rs
@@ -3,6 +3,7 @@ use alloc::rc::Rc;
 use core::{any::Any, cell::Cell};
 
 use waterui_core::Signal;
+use waterui_core::layout::Size;
 use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator};
 
 use crate::scene_data::SvgSceneData;
@@ -27,6 +28,10 @@ impl SceneContent for SvgSceneContent {
     fn build_scene(&mut self, scene: &mut dyn Scene2D, width: f32, height: f32) -> bool {
         self.scene_data.draw(scene, width, height);
         false
+    }
+
+    fn intrinsic_size(&self) -> Option<Size> {
+        Some(self.scene_data.intrinsic_size())
     }
 }
 
@@ -64,16 +69,22 @@ where
 {
     /// Content drawing `svg_template`, with its colour placeholder replaced by
     /// whatever `tint` currently reads.
+    ///
+    /// The document is parsed here rather than at the first draw: its geometry is
+    /// the same whatever the tint is, and layout asks for the size before anything
+    /// has drawn.
     #[must_use]
     pub fn new(svg_template: alloc::string::String, tint: S) -> Self {
-        Self {
+        let mut content = Self {
             svg_template,
             tint,
             scene_data: None,
             current_color: None,
             pending_update: Rc::new(Cell::new(true)),
             watcher_guard: None,
-        }
+        };
+        content.ensure_scene_data();
+        content
     }
 
     fn ensure_scene_data(&mut self) {
@@ -105,6 +116,15 @@ where
             .expect("reactive svg scene data must be initialized")
             .draw(scene, width, height);
         false
+    }
+
+    fn intrinsic_size(&self) -> Option<Size> {
+        Some(
+            self.scene_data
+                .as_ref()
+                .expect("reactive svg scene data is parsed when the content is created")
+                .intrinsic_size(),
+        )
     }
 
     fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {

--- a/testing/src/tests.rs
+++ b/testing/src/tests.rs
@@ -9,13 +9,15 @@ use hydrolysis::{HydrolysisRenderer, OffscreenGpuContext, OffscreenWindow, Platf
 use hydrolysis_m3::install as install_m3;
 use vello::kurbo::Shape;
 use waterui::Computed;
-use waterui::View as _;
+use waterui::View;
 use waterui::ViewExt as _;
 use waterui::color::ResolvedColor;
-use waterui::component::{text, vstack};
+use waterui::component::{hstack, text, vstack};
 use waterui::graphics::SceneViewMergeToParent;
 use waterui::graphics::color::Srgb;
 use waterui::graphics::{Scene2D, SceneContent, SceneView};
+use waterui::layout::frame::Frame;
+use waterui::layout::scroll::ScrollView;
 use waterui::text::Text;
 use waterui::theme;
 use waterui_canvas::Canvas;
@@ -1327,5 +1329,153 @@ fn a_perpetually_animating_app_is_never_settled_yet_stays_current() {
     assert!(
         !app.driver.has_pending_semantic_update(),
         "reading the tree must have applied the update, not merely waited for it"
+    );
+}
+
+/// Scene content that *is* a size: 100 x 200 logical points, twice as tall as
+/// it is wide. Stands in for an SVG's `viewBox`, an image's pixel dimensions,
+/// or a formula's typeset box — everything the intrinsic-size hook exists for.
+struct NaturallySizedContent;
+
+impl NaturallySizedContent {
+    const NATURAL: Size = Size {
+        width: 100.0,
+        height: 200.0,
+    };
+}
+
+impl SceneContent for NaturallySizedContent {
+    fn build_scene(&mut self, scene: &mut dyn Scene2D, width: f32, height: f32) -> bool {
+        let rect = vello::kurbo::Rect::from_origin_size(
+            vello::kurbo::Point::ZERO,
+            vello::kurbo::Size::new(f64::from(width), f64::from(height)),
+        )
+        .to_path(0.1);
+        let brush: vello::peniko::Brush = vello::peniko::Color::new([0.0, 0.4, 1.0, 1.0]).into();
+        scene.fill(
+            vello::peniko::Fill::NonZero,
+            vello::kurbo::Affine::IDENTITY,
+            &brush,
+            None,
+            &rect,
+        );
+        false
+    }
+
+    fn intrinsic_size(&self) -> Option<Size> {
+        Some(Self::NATURAL)
+    }
+}
+
+fn naturally_sized_scene() -> impl View {
+    SceneView::new(NaturallySizedContent)
+        .a11y_role(waterui::accessibility::AccessibilityRole::Image)
+        .a11y_label("Intrinsic scene")
+}
+
+fn sizeless_scene() -> impl View {
+    SceneView::new(TestSceneContent(Rc::new(Cell::new(false))))
+        .a11y_role(waterui::accessibility::AccessibilityRole::Image)
+        .a11y_label("Sizeless scene")
+}
+
+fn scene_bounds(app: &mut SemanticApp, label: &str) -> NodeBounds {
+    app.query().role(Role::IMAGE).label(label).single().bounds()
+}
+
+/// (a) The scroll axis proposes nothing, so the scene is laid out at the height
+/// it naturally is instead of collapsing to zero — the defect in #253. The
+/// viewport is deliberately shorter than the content so the scroll view's
+/// `max(content, viewport)` cannot hide the answer.
+#[test]
+fn scene_with_a_natural_size_keeps_it_on_an_unconstrained_scroll_axis() {
+    let mut app = ui()
+        .viewport(100, 120)
+        .theme(install_m3)
+        .mount(|| ScrollView::vertical(naturally_sized_scene()));
+
+    let bounds = scene_bounds(&mut app, "Intrinsic scene");
+    assert!(
+        (bounds.height() - NaturallySizedContent::NATURAL.height).abs() < 0.5,
+        "the unconstrained scroll axis must resolve to the natural height, got {}",
+        bounds.height()
+    );
+}
+
+/// (b) Given a box, the scene still fills it: an intrinsic size is what layout
+/// falls back to, never a cap on what a container may ask for.
+#[test]
+fn scene_with_a_natural_size_still_fills_a_frame() {
+    let mut app = ui().viewport(400, 400).theme(install_m3).mount(|| {
+        Frame::new(naturally_sized_scene())
+            .width(160.0)
+            .height(90.0)
+    });
+
+    let bounds = scene_bounds(&mut app, "Intrinsic scene");
+    assert!(
+        (bounds.width() - 160.0).abs() < 0.5 && (bounds.height() - 90.0).abs() < 0.5,
+        "a framed scene must fill its frame, got {}x{}",
+        bounds.width(),
+        bounds.height()
+    );
+}
+
+/// (c) One axis named, the other open: the natural aspect ratio settles the open
+/// one. A vertical scroll view names the width and leaves the height open, which
+/// is exactly the `.resizable()`-image case in #253.
+#[test]
+fn one_named_axis_drives_the_other_by_the_natural_aspect_ratio() {
+    let mut app = ui()
+        .viewport(200, 120)
+        .theme(install_m3)
+        .mount(|| ScrollView::vertical(naturally_sized_scene()));
+
+    let bounds = scene_bounds(&mut app, "Intrinsic scene");
+    // 200 is twice the natural width, so the height is twice the natural height.
+    assert!(
+        (bounds.width() - 200.0).abs() < 0.5 && (bounds.height() - 400.0).abs() < 0.5,
+        "the natural 100x200 ratio must carry the named width to the open height, got {}x{}",
+        bounds.width(),
+        bounds.height()
+    );
+}
+
+/// Content with no size of its own is untouched by any of this: it still fills
+/// whatever the scroll view gives it.
+#[test]
+fn scene_without_a_natural_size_still_fills_its_container() {
+    let mut app = ui()
+        .viewport(200, 120)
+        .theme(install_m3)
+        .mount(|| ScrollView::vertical(sizeless_scene()));
+
+    let bounds = scene_bounds(&mut app, "Sizeless scene");
+    assert!(
+        (bounds.width() - 200.0).abs() < 0.5 && (bounds.height() - 120.0).abs() < 0.5,
+        "a scene with no natural size must fill the viewport, got {}x{}",
+        bounds.width(),
+        bounds.height()
+    );
+}
+
+/// A scene that is naturally a size is content-sized: it takes its own width in
+/// a row and leaves the rest to its sibling, rather than eating the row the way
+/// a background or a shader legitimately does.
+#[test]
+fn a_naturally_sized_scene_does_not_eat_the_row() {
+    let mut app = ui().viewport(400, 200).theme(install_m3).mount(|| {
+        hstack((
+            naturally_sized_scene(),
+            text("beside it").a11y_label("beside it"),
+        ))
+    });
+
+    let bounds = scene_bounds(&mut app, "Intrinsic scene");
+    assert!(
+        (bounds.width() - NaturallySizedContent::NATURAL.width).abs() < 0.5,
+        "a content-sized scene takes its own width and leaves the rest of the row \
+         to its sibling, got {}",
+        bounds.width()
     );
 }


### PR DESCRIPTION
`SceneContent` could only draw itself into a box; it could not tell layout what
size the drawing wants. `SceneView` answered `StretchAxis::Both` and inherited
`GpuView`'s default measure, which resolves an unconstrained axis to zero, so
every component lowered onto `SceneContent` collapsed wherever nothing else
settled its size.

## The hook

```rust
pub trait SceneContent: 'static {
    fn intrinsic_size(&self) -> Option<Size> { None }
}
```

A whole `waterui_core::layout::Size` rather than a per-axis `Option` pair, and
`layout::Size` rather than `kurbo::Size`:

- **Whole size, not per-axis.** The natural size *is* the drawing's aspect
  ratio, and the resolution rule is stated per *proposal* axis, not per
  intrinsic axis. A per-axis answer cannot express "the open axis follows from
  the named one", which is exactly the `.resizable()`-with-aspect-fit behaviour
  the issue asks for. Nothing in the tree has a natural width but no natural
  height.
- **`layout::Size` (f32), not `kurbo::Size` (f64).** This value feeds
  `ProposalSize`/`ViewDimensions`, which are f32, and `build_scene` already
  speaks f32 extents. Using the layout currency puts no lossy cast between the
  content's answer and the layout that consumes it.

## The measure rule, shared by every realization

`resolve_scene_proposal(intrinsic, proposal) -> ProposalSize` fills in the axes
a proposal left open, and every backend calls it, so a drawing cannot be a
different size depending on who drew it. It returns a *proposal* rather than a
size so that content with **no** intrinsic size passes through byte-identical
and each caller keeps its own existing fallback (hydrolysis' `unwrap_or(0.0)`,
dew's finite-filter).

| proposal | result |
| --- | --- |
| no intrinsic size | unchanged |
| both axes named | the proposal — a framed scene still fills its frame |
| neither named | the natural size |
| exactly one named | that axis stands, the other follows the natural aspect ratio |
| named axis is `INFINITY` | the open axis stays at its natural extent |

A degenerate intrinsic size (zero, negative, non-finite) panics with a clear
message rather than pushing `NaN` into layout, which would surface far from the
content that produced it.

Per backend:

| where | measure |
| --- | --- |
| `SceneSurfaceRenderer` (`GpuSurface` realization — Apple, Android, GTK, web reach `SceneView` through this) | `GpuView::measure` / `stretch_axis` overridden; no FFI change, so `ffi/waterui.h` is untouched |
| hydrolysis retained tree | `RenderNode::SceneView` measure and stretch read `node.content.borrow().intrinsic_size()` |
| hydrolysis native leaf | `HydroNativeView for Native<SceneView>` — `intrinsic` returns the natural size, `dimensions` resolves the proposal |
| dew | `SceneNode::measure` / `stretch_axis` read the content, keeping dew's own finite-clamp for size-less content |

### Breaking half

A scene that reports a natural size is now content-sized
(`StretchAxis::None`) instead of claiming its container's leftover space.
Without this the hook is inert in stacks: the icon in the issue would measure
its natural width and then be handed the whole row anyway. This is the rule
`waterui-image` already measures its own GPU surfaces by
(`components/visual/image/src/image.rs`), so the two now agree. Content with no
intrinsic size keeps `StretchAxis::Both` exactly as before. The trait method is
defaulted, so out-of-tree implementors still compile.

## In-tree implementors

| content | natural size | source |
| --- | --- | --- |
| `SvgSceneContent` | the document's own size | `usvg::Tree::size()` — already asserted finite and positive by `SvgSceneData::parse` |
| `ReactiveSvgSceneContent` | same | the template is now parsed in `new` instead of at the first draw: its geometry does not depend on the tint, and layout asks before anything has drawn |
| `MathContent` | the typeset box | `prepare()`'s advance width by ascent + descent; font resolution and the last measurement moved into a `RefCell` cache, keyed by the source string, so a container probing a child several times per pass lays the formula out once |
| `CanvasContent` | — | default `None`: a canvas draws into the box its author is handed, and `Canvas` has no declared size |
| `PreparedMap`, `MapScene` (`waterui-map-gpu`) | — | default `None`: a map is full-bleed |

In-tree `waterui-image`, `waterui-barcode` and `waterui-particle` are
`GpuView`s, not `SceneContent`, so they are untouched here; image already
reports its pixel size.

## Tests

Unit (`waterui-graphics`): the resolver's whole truth table — passthrough for
size-less content, natural size when nothing is named, the proposal when both
are, aspect in both directions when one is, the `INFINITY` guard, the
degenerate-size panic, and the stretch axis.

End to end (`waterui-testing`, hydrolysis headless, asserting accessibility
bounds):

- `scene_with_a_natural_size_keeps_it_on_an_unconstrained_scroll_axis` — (a)
- `scene_with_a_natural_size_still_fills_a_frame` — (b)
- `one_named_axis_drives_the_other_by_the_natural_aspect_ratio` — (c)
- `scene_without_a_natural_size_still_fills_its_container`
- `a_naturally_sized_scene_does_not_eat_the_row`

`waterui-dew`, so both self-drawn backends are pinned to the same answer:

- `an_unconstrained_scroll_axis_resolves_to_the_natural_size` — (a)
- `a_sizeless_scene_still_fills_an_unconstrained_scroll_axis`

Every one of the backend assertions was checked against a stubbed resolver
first and fails without the fix (the scroll axis comes back as the 120-point
viewport instead of the 200-point drawing).

**No snapshot PNG was re-baselined** — no baseline image changed.

## Verification

```
cargo +stable clippy -p waterui-graphics -p waterui-svg -p waterui-math \
  -p hydrolysis -p waterui-dew -p waterui-testing --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 14.65s

cargo +stable nextest run -p waterui-graphics -p waterui-svg -p waterui-math -p waterui-canvas
    Summary [   6.871s] 95 tests run: 95 passed, 0 skipped
cargo +stable nextest run -p hydrolysis
    Summary [   6.980s] 198 tests run: 198 passed, 1 skipped
cargo +stable nextest run -p waterui-dew
    Summary [   4.816s] 96 tests run: 96 passed, 0 skipped
cargo +stable nextest run -p waterui-testing
    Summary [   1.655s] 45 tests run: 45 passed (1 leaky), 0 skipped
cargo +stable nextest run -p waterui-icon -p waterui-icons-fontawesome7
    Summary [   0.297s] 1 test run: 1 passed, 0 skipped

cargo +stable test --doc -p waterui-graphics -p waterui-svg -p waterui-math   # ok
cargo +stable check -p waterui-ffi -p waterui-map-gpu                          # ok
rustfmt --edition 2024 <each touched file>
```

`ffi/` is unchanged, so the checked-in C header needs no regeneration.

## Follow-ups

The hook has to be implemented in the standalone repos, each in its own PR
after this merges:

- `water-rs/image` — the decoded image's pixel size (the case in water-rs/image#2)
- `water-rs/svg` — the document `viewBox`
- `water-rs/barcode` — the module grid
- `water-rs/canvas` — whatever size the canvas declares, if any
- `water-rs/visualizer` — the chart canvas

## Out of scope, reported not fixed

`MathContent::set_invalidator` stores the invalidator but nothing watches
`self.source`, so a formula bound to a signal does not appear to schedule a
redraw when the source changes. Pre-existing, unrelated to sizing, and left
alone here.

Fixes #253
