### PR TITLE
fix(math): redraw a bound formula when its source changes

### DIFF
--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -4,6 +4,7 @@ use alloc::string::String;
 use core::cell::RefCell;
 
 use nami::signal::IntoComputed;
+use nami::watcher::BoxWatcherGuard;
 use parley::FontContext;
 use peniko::{Brush, Color as PenikoColor, FontData};
 use waterui_core::layout::Size;
@@ -209,6 +210,10 @@ pub struct MathContent {
     brush: Brush,
     cache: RefCell<MathCache>,
     invalidator: Option<SceneInvalidator>,
+    /// Keeps the source watcher installed by [`SceneContent::set_invalidator`]
+    /// alive. Dropping it stops asking for redraws, which is what clearing the
+    /// invalidator means.
+    source_guard: Option<BoxWatcherGuard>,
 }
 
 /// The font collection and the last measurement, shared by drawing and layout.
@@ -246,6 +251,7 @@ impl MathContent {
             brush,
             cache: RefCell::new(MathCache::default()),
             invalidator: None,
+            source_guard: None,
         }
     }
 
@@ -357,6 +363,15 @@ impl SceneContent for MathContent {
     }
 
     fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
+        // A formula is typeset from the source read in `build_scene`, so a
+        // surface that is never told the source changed keeps presenting the
+        // box it typeset last. Watching the signal schedules the frame that
+        // re-typesets it; this is scene invalidation, not a subtree rebuild,
+        // so the content instance and its resolved font survive the change.
+        self.source_guard = invalidator.as_ref().map(|invalidator| {
+            let invalidator = SceneInvalidator::clone(invalidator);
+            self.source.watch(move |_| invalidator())
+        });
         self.invalidator = invalidator;
     }
 }
@@ -400,4 +415,72 @@ fn to_peniko(color: &ResolvedColor) -> PenikoColor {
         channel(srgb.blue),
         channel(color.opacity),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+    use core::cell::Cell;
+
+    use nami::Binding;
+    use peniko::{Brush, Color as PenikoColor};
+    use waterui_graphics::{SceneContent, SceneInvalidator};
+    use waterui_str::Str;
+
+    use super::{DEFAULT_MATH_FAMILY, MathContent};
+    use crate::ast::MathStyle;
+
+    /// A [`SceneInvalidator`] that counts the frames it was asked for.
+    fn counting_invalidator() -> (SceneInvalidator, Rc<Cell<usize>>) {
+        let redraws = Rc::new(Cell::new(0_usize));
+        let counted = Rc::clone(&redraws);
+        let invalidator: SceneInvalidator = Rc::new(move || counted.set(counted.get() + 1));
+        (invalidator, redraws)
+    }
+
+    fn content(source: &Binding<Str>) -> MathContent {
+        MathContent::new(
+            source.clone(),
+            18.0,
+            MathStyle::Text,
+            DEFAULT_MATH_FAMILY,
+            Brush::Solid(PenikoColor::BLACK),
+        )
+    }
+
+    #[test]
+    fn changing_the_source_asks_for_a_frame() {
+        let source = Binding::container(Str::from_static("x"));
+        let mut content = content(&source);
+        let (invalidator, redraws) = counting_invalidator();
+
+        content.set_invalidator(Some(invalidator));
+        let installed = redraws.get();
+
+        source.set(Str::from_static("y"));
+
+        assert!(
+            redraws.get() > installed,
+            "a formula bound to state must schedule a frame when its source changes"
+        );
+    }
+
+    #[test]
+    fn clearing_the_invalidator_stops_the_frames() {
+        let source = Binding::container(Str::from_static("x"));
+        let mut content = content(&source);
+        let (invalidator, redraws) = counting_invalidator();
+
+        content.set_invalidator(Some(invalidator));
+        content.set_invalidator(None);
+        let cleared = redraws.get();
+
+        source.set(Str::from_static("y"));
+
+        assert_eq!(
+            redraws.get(),
+            cleared,
+            "a surface that took its invalidator back must stop being asked for frames"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #268.

`MathContent::set_invalidator` stored the `SceneInvalidator` but nothing watched the formula's source, so a formula bound to a `Binding`/`Computed` never asked for the frame that would re-typeset it: the surface kept presenting the box it typeset last until something else happened to invalidate it.

`set_invalidator` now subscribes the source signal to the invalidator and holds the watcher guard beside it, so clearing the invalidator drops the subscription with it. This is a scene invalidation, not a `watch(...)` subtree replacement — the `MathContent` instance and its resolved `MATH` font survive the source change, which is the whole point of keeping the formula in a signal.

### The test, and why it is not a `waterui-testing` case

The issue asked for a `waterui-testing` (hydrolysis headless) case. That harness cannot observe this defect, so writing one would have added a test that is green with or without the fix:

- Hydrolysis merges `SceneView` into the parent scene (`SceneViewMergeToParent`), so `RenderNode::SceneView`'s flush calls `build_scene` — which reads `self.source.get()` — on **every** flush.
- `OffscreenApp::snapshot()` pumps with `capture_snapshot = true`, and `HeadlessRuntime::pump_at` then sets `should_render` unconditionally. Every snapshot therefore re-flushes and shows the new formula regardless of whether a frame was ever requested.
- `Math` publishes no formula-derived accessibility text either: the scene node emits an `Image` node whose label comes from the environment (`emit_graphics_image_accessibility`), so there is nothing in the a11y tree that changes with the source.

The only faithful observable is the contract the bug broke: with an invalidator installed, a source change must ask for a frame. `view::tests::changing_the_source_asks_for_a_frame` installs a counting `SceneInvalidator`, changes a `Binding<Str>`, and asserts the count rose; `clearing_the_invalidator_stops_the_frames` covers the guard being dropped with the invalidator. Verified by stubbing the subscription out (`self.source_guard = None;`) once: the first test fails with "a formula bound to state must schedule a frame when its source changes", the second still passes. Restored afterwards.

The user-visible defect is unchanged and real — a live hydrolysis window stays `Idle` after the source changes, so nothing re-typesets on screen.

### Verification

- `cargo +stable clippy -p waterui-math --all-targets -- -D warnings` — clean
- `cargo +stable nextest run -p waterui-math` — 35 tests run: 35 passed
- `rustfmt --edition 2024 components/visual/math/src/view.rs`

### Note

This may need a rebase over #267 (`feat(graphics)!: give SceneContent an intrinsic size`, open and currently conflicting), which touches the same `MathContent` to add a measurement cache keyed by source. The change here is deliberately small and orthogonal — one guard field plus the subscription in `set_invalidator` — so the rebase is a field addition next to #267's cache field. If #267 lands first, that cache will also want clearing from this same subscription; that belongs in whichever PR lands second.
