### PR TITLE
ci: lint every crate's own features, not just the root crate's

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,23 +60,73 @@ jobs:
       - name: Format
         if: runner.os == 'Linux'
         run: cargo fmt --all -- --check
-      # Two passes, split for the same structural reason as the two test
-      # passes below: workspace-wide under default features, then the root
-      # crate alone with every feature on.
+      # Workspace-wide under default features first: it is the cheapest of the
+      # lint passes and the one every crate's normal build shape goes through.
       - name: Clippy (workspace)
         if: runner.os == 'Linux'
         run: cargo clippy --workspace --all-targets -- -D warnings
-      - name: Clippy (all features)
+      # Then every crate's own optional features. This pass used to be
+      # `cargo clippy --all-targets --all-features`, with neither `-p` nor
+      # `--workspace`: the root manifest carries both `[workspace]` and
+      # `[package]`, so cargo narrowed it to the root `waterui` crate, and a
+      # backend's own non-default features were linted only where the root
+      # happened to enable them. Nothing in CI compiled dew's
+      # `embedded-simulator` / `espidf`, hydrolysis' `web` / `testing`, gtk's
+      # `webkitgtk`, or the browsers' engine features at all (#261).
+      #
+      # `--workspace --all-features` covers all of those. Four crates cannot
+      # join it, because `--all-features` asks for feature sets that are
+      # mutually exclusive by construction; each is excluded here and linted
+      # below in the shapes it actually has. Every one of the four is still
+      # linted under its default features by the workspace pass above, and the
+      # steps share this job's target dir, so each is an increment on a graph
+      # that is already built.
+      #
+      # A separate `-p waterui-browser-wpe --features real-engine` step used to
+      # follow; `--workspace --all-features` selects that crate with every
+      # feature on, so it is now a strict subset and has been removed.
+      - name: Clippy (all features, workspace)
         if: runner.os == 'Linux'
-        run: cargo clippy --all-targets --all-features -- -D warnings
-      # The WPE real-engine tests sit behind a feature, because running them
-      # needs a staged WPE WebKit runtime that only `browser-wpe.yml` provisions
-      # — and that workflow only fires on the paths those tests cover. Neither
-      # pass above compiles them, so lint them here: compiling them costs
-      # nothing extra and keeps them from rotting between real-engine runs.
-      - name: Clippy (WPE real engine)
+        run: |
+          cargo clippy --workspace --all-targets --all-features \
+            --exclude waterui-core \
+            --exclude waterui-ffi \
+            --exclude hydrolysis \
+            --exclude waterui-browser-cef \
+            -- -D warnings
+      # `waterui-core`'s `nightly` feature turns on `feature(never_type)`, which
+      # is a hard E0554 on the stable channel this job pins. Everything else the
+      # crate has, it gets here.
+      - name: Clippy (waterui-core, every stable feature)
         if: runner.os == 'Linux'
-        run: cargo clippy -p waterui-browser-wpe --features real-engine --all-targets -- -D warnings
+        run: cargo clippy -p waterui-core --all-targets --features std,serde -- -D warnings
+      # `waterui-ffi` selects its ABI with mutually exclusive features and
+      # `ffi/src/lib.rs` turns `c-api` + `android-jni` into a `compile_error!`.
+      # This is the `c-api` half with every optional C surface a runtime build
+      # can carry; the `android-jni` half is the `Android FFI` job in ci.yml,
+      # and the compile-only `cef-header` shape is the macOS leg below.
+      - name: Clippy (waterui-ffi, C ABI surfaces)
+        if: runner.os == 'Linux'
+        run: cargo clippy -p waterui-ffi --all-targets --features map,chromium,webview-cef -- -D warnings
+      # `webview-system` bridges the macOS WKWebView into the winit window and
+      # `compile_error!`s anywhere else, so this is every hydrolysis feature but
+      # that one. The macOS leg compiles `webview-system` in its
+      # `real_engine_macos` step.
+      - name: Clippy (hydrolysis, every portable feature)
+        if: runner.os == 'Linux'
+        run: |
+          cargo clippy -p hydrolysis --all-targets \
+            --features accessibility,inspector-signals,testing,web,winit -- -D warnings
+      # `compile-only` swaps in CEF's `dox` stubs and stops the build script
+      # downloading the distribution that `cef-runtime` — and the `real_engine`
+      # test target — need, so the two can never be enabled together. This is
+      # the runtime shape, which nothing else lints: the macOS leg's
+      # `real-engine` pass has no `chromium`, and its `cef-header` pass is
+      # `compile-only`. `real-engine` stays off here because that test target is
+      # macOS-only; `--all-targets` skips it for want of its required feature.
+      - name: Clippy (waterui-browser-cef, CEF runtime)
+        if: runner.os == 'Linux'
+        run: cargo clippy -p waterui-browser-cef --all-targets --features chromium,webview -- -D warnings
       # Dew's firmware shape, which is a first-class configuration rather than
       # a degraded one. Neither pass above compiles dew's test targets without
       # default features, and the `Features` job's `--each-feature` sweep runs
@@ -97,14 +147,15 @@ jobs:
         run: cargo check -p skill_snippets --all-targets --features compile-gate-tests
       - uses: taiki-e/install-action@nextest
       # One full-workspace pass under default features. A workspace-wide
-      # `--all-features` pass is structurally impossible here — `waterui-ffi`
-      # enforces "exactly one ABI" with a `compile_error!` (ffi/src/lib.rs), so
-      # enabling `c-api` and `android-jni` together can never build. The old
-      # second pass that *looked* workspace-wide (`cargo nextest run
-      # --all-features`) never was:
-      # the root manifest has both `[workspace]` and `[package]`, so without
-      # `--workspace` cargo narrowed it to the root `waterui` crate — the only
-      # crate whose features are all mutually compatible.
+      # `--all-features` pass would need the same four `--exclude` flags the
+      # clippy passes above carry — `waterui-ffi` enforces "exactly one ABI"
+      # with a `compile_error!` (ffi/src/lib.rs), so enabling `c-api` and
+      # `android-jni` together can never build. The second pass below only
+      # *looks* workspace-wide: the root manifest has both `[workspace]` and
+      # `[package]`, so without `--workspace` cargo narrows it to the root
+      # `waterui` crate. Running the excluded crates' tests in their own
+      # feature shapes is a separate question from linting them and is not
+      # what this pass is for.
       - run: cargo nextest run --workspace --profile ci
       # The root crate's feature-gated re-export surface, with every feature
       # on. Root-crate-only scope is intentional (see above); most of the
@@ -132,14 +183,13 @@ jobs:
       # application bundle; the test stages one and the target does not compile
       # on the other platforms.
       #
-      # The same step lints the FFI crate's CEF C ABI, which nothing else
-      # compiles: the workspace pass runs default features and that module is
-      # gated behind `cef-runtime`/`cef-header`, while a workspace-wide
-      # `--all-features` pass is structurally impossible for `waterui-ffi` (see
-      # the ABI `compile_error!` note above). macOS is also the only leg that
-      # sees its `#[cfg(target_os = "macos")]` entry points at all. `cef-header`
-      # is the compile-only feature set, so this buys the lint without a CEF
-      # runtime download, on a workspace this job has already built.
+      # The same step lints the FFI crate's compile-only CEF C ABI, which no
+      # other leg reaches: the Linux all-features passes exclude `waterui-ffi`
+      # for its ABI `compile_error!` and lint the `cef-runtime` shape instead,
+      # and `cef-header` is the mutually exclusive `compile-only` one. macOS is
+      # also the only leg that sees its `#[cfg(target_os = "macos")]` entry
+      # points at all, and the compile-only feature set buys the lint without a
+      # CEF runtime download, on a workspace this job has already built.
       - name: Lint the CEF targets
         if: runner.os == 'macOS'
         run: |

--- a/backends/gtk/src/webview_system.rs
+++ b/backends/gtk/src/webview_system.rs
@@ -26,11 +26,32 @@ type JsHandler = Rc<waterui_webview::ScriptMessageHandler>;
 
 /// What the handle's `impl Future` methods return.
 ///
-/// Boxed because the configuration with no linkable WebKitGTK produces no future
+/// Boxed because the configuration with no linkable `WebKitGTK` produces no future
 /// at all — it fast-fails — and the two arms still have to name one type.
 type BoxFuture<T> = std::pin::Pin<Box<dyn std::future::Future<Output = T>>>;
 
 const WEBKIT_FEATURE_MSG: &str = "WebView requires waterui-gtk feature `webkitgtk` and linkable WebKitGTK 6 libraries on Linux (fast-fail: no placeholder backend)";
+
+/// The fast-fail the future-returning handle methods take when no `WebKitGTK`
+/// is linkable.
+///
+/// A function rather than the bare `panic!` the value-returning methods use,
+/// because `!` does not implement `Future`: a method returning `impl Future`
+/// still has to name a type for the compiler to hide, and that type is
+/// [`BoxFuture`]. Writing the panic inline instead — `let f: BoxFuture<T> =
+/// panic!(…); f` — types the binding through a diverging initializer, which
+/// leaves the binding unused and everything after it unreachable. Behind this
+/// signature the divergence is the whole body and the call site is ordinary
+/// code, so the two configurations stay symmetric.
+#[cfg(not(all(
+    feature = "webkitgtk",
+    gtk_webkitgtk_link_available,
+    unix,
+    not(target_os = "macos")
+)))]
+fn webkit_unavailable<T>() -> BoxFuture<T> {
+    panic!("{WEBKIT_FEATURE_MSG}");
+}
 
 /// Adapts the shared bridge's one-function transport onto `WebKitGTK`'s message handler.
 const TRANSPORT_SCRIPT: &str = concat!(
@@ -1689,6 +1710,10 @@ impl WebViewHandle for GtkWebViewHandle {
     /// Queried live rather than read from a cache refreshed at load: a cookie the
     /// page sets afterwards — an XHR that logs in — was invisible until the next
     /// navigation, while every other backend answered from the live store.
+    #[expect(
+        clippy::future_not_send,
+        reason = "a web view and its handle are main-thread-affine"
+    )]
     fn get_cookies(&self) -> impl std::future::Future<Output = Vec<Cookie<'static>>> {
         #[cfg(all(
             feature = "webkitgtk",
@@ -1718,10 +1743,14 @@ impl WebViewHandle for GtkWebViewHandle {
             unix,
             not(target_os = "macos")
         )))]
-        let cookies: BoxFuture<Vec<Cookie<'static>>> = panic!("{WEBKIT_FEATURE_MSG}");
+        let cookies: BoxFuture<Vec<Cookie<'static>>> = webkit_unavailable();
         cookies
     }
 
+    #[expect(
+        clippy::future_not_send,
+        reason = "a web view and its handle are main-thread-affine"
+    )]
     fn run_javascript(&self, script: &str) -> impl std::future::Future<Output = Result<Str, Str>> {
         #[cfg(all(
             feature = "webkitgtk",
@@ -1734,8 +1763,8 @@ impl WebViewHandle for GtkWebViewHandle {
             webkitgtk::evaluate_javascript,
             webkitgtk::evaluate_javascript_finish,
         ));
-        // Every other method fast-fails without a linkable WebKitGTK; this one used
-        // to answer with an `Err` instead, which reads as "the script failed".
+        // Every other method fast-fails without a linkable `WebKitGTK`; this one
+        // used to answer with an `Err` instead, which reads as "the script failed".
         #[cfg(not(all(
             feature = "webkitgtk",
             gtk_webkitgtk_link_available,
@@ -1744,11 +1773,15 @@ impl WebViewHandle for GtkWebViewHandle {
         )))]
         let result: BoxFuture<Result<Str, Str>> = {
             let _ = script;
-            panic!("{WEBKIT_FEATURE_MSG}")
+            webkit_unavailable()
         };
         result
     }
 
+    #[expect(
+        clippy::future_not_send,
+        reason = "a web view and its handle are main-thread-affine"
+    )]
     fn call_async_javascript(
         &self,
         body: &str,
@@ -1772,7 +1805,7 @@ impl WebViewHandle for GtkWebViewHandle {
         )))]
         let result: BoxFuture<Result<Str, Str>> = {
             let _ = body;
-            panic!("{WEBKIT_FEATURE_MSG}")
+            webkit_unavailable()
         };
         result
     }
@@ -2185,7 +2218,7 @@ unsafe extern "C" fn on_script_message_received(
 /// means. No policy installed denies: the policy is installed before the first
 /// handler exists, so a call arriving without one cannot be authenticated.
 ///
-/// WebKitGTK reports script messages without the frame that sent them, so this
+/// `WebKitGTK` reports script messages without the frame that sent them, so this
 /// authenticates the document the view is showing. Subframe content is kept away
 /// from the bridge by injecting the transport into the top frame only, and only
 /// into documents the policy's URI patterns admit.

--- a/src/widget/rich_text.rs
+++ b/src/widget/rich_text.rs
@@ -1261,10 +1261,6 @@ mod tests {
     #[cfg(feature = "markdown-math")]
     #[test]
     fn inline_and_display_math_become_math_elements() {
-        let elements = parse_markdown("before $e^{i\\pi}+1=0$ after\n\n$$\\frac{a}{b}$$");
-
-        let mut inline = 0;
-        let mut block = 0;
         fn count(elements: &[RichTextElement], inline: &mut usize, block: &mut usize) {
             for element in elements {
                 match element {
@@ -1278,6 +1274,11 @@ mod tests {
                 }
             }
         }
+
+        let elements = parse_markdown("before $e^{i\\pi}+1=0$ after\n\n$$\\frac{a}{b}$$");
+
+        let mut inline = 0;
+        let mut block = 0;
         count(&elements, &mut inline, &mut block);
 
         assert_eq!(inline, 1, "expected one inline formula in {elements:?}");


### PR DESCRIPTION
The `Clippy (all features)` step ran `cargo clippy --all-targets --all-features`
with neither `-p` nor `--workspace`. The root manifest carries both
`[workspace]` and `[package]`, so cargo narrowed the pass to the root `waterui`
crate and its closure under the root's features. A backend crate's own
non-default features were linted only where the root happened to enable them,
so dew's `embedded-simulator` / `espidf`, hydrolysis' `web` / `testing`, gtk's
`webkitgtk` and the browsers' engine features compiled nowhere in CI.

## Measured first

`cargo +stable clippy --workspace --all-targets --all-features -- -D warnings`
does not compile. Four crates ask for feature sets that are unsatisfiable by
construction, so each is excluded from the workspace pass and gets an explicit
pass in the shapes it really has. All four remain linted under their default
features by the existing `Clippy (workspace)` pass.

| Excluded | Why `--all-features` cannot build it | Covered instead by |
| --- | --- | --- |
| `waterui-core` | `nightly` turns on `feature(never_type)` — `error[E0554]` on the stable channel this job pins | `-p waterui-core --all-targets --features std,serde` |
| `waterui-ffi` | `c-api` + `android-jni` is a `compile_error!` (`ffi/src/lib.rs:19`) | `-p waterui-ffi --all-targets --features map,chromium,webview-cef` here; the `android-jni` shape by the `Android FFI` job (#256); the `cef-header` shape by the macOS leg |
| `hydrolysis` | `webview-system` bridges the macOS `WKWebView` into the winit window and `compile_error!`s off macOS (`widgets/platform/webview.rs:14`) | `-p hydrolysis --all-targets --features accessibility,inspector-signals,testing,web,winit`; `webview-system` is compiled by the macOS `real_engine_macos` step |
| `waterui-browser-cef` | `compile-only` substitutes CEF's `dox` stubs, so the build script skips the download and the `real_engine` test fails with `environment variable WATERUI_CEF_DISTRIBUTION not defined at compile time`; `cef-runtime` needs it | `-p waterui-browser-cef --all-targets --features chromium,webview` here (the runtime + `chromium` shape nothing else lints); `real-engine` and `compile-only` by the macOS leg |

The dedicated `-p waterui-browser-wpe --features real-engine` step is removed:
the workspace pass now selects that crate with every feature on, so it was a
strict subset. Every pass is a step of the same Linux job and shares its target
dir, so each is an increment on a graph that is already built.

## Backlog the new passes exposed

One diagnostic across the whole workspace, now fixed: `items_after_statements`
on the `count` helper in
`src/widget/rich_text.rs::inline_and_display_math_become_math_elements`. That
test only compiles under the `markdown-math` feature, which no CI pass had ever
enabled. No `allow` was added anywhere; the job gates on `-D warnings` from day
one.

## Verification

Every command in the new steps was run locally on `stable`, in the order the
workflow runs them; all five exit 0 with no warnings.

Fixes #261
