### PR TITLE
fix(hydrolysis): make direct_to_target work on HiDPI, one format, opaque only

### DIFF
--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -222,6 +222,13 @@ pub struct HydrolysisRenderer {
     popup_menu: PopupMenuState,
     render_depth: usize,
     window_bounds: vello::kurbo::Rect,
+    /// The transform the window's root content is flushed under: logical layout
+    /// units onto the target's physical pixel grid. Stored alongside
+    /// [`Self::window_bounds`] because the pair is what says where the viewport
+    /// is in device pixels, which is what
+    /// [`HydrolysisRenderer::push_gpu_surface_layer`] tests a full-window GPU
+    /// surface against.
+    window_root_transform: vello::kurbo::Affine,
     /// Frame triggers shared with reactive closures; see [`FrameSignals`].
     signals: FrameSignals,
     /// Wake target supplied when this renderer itself is hosted by a
@@ -239,6 +246,11 @@ pub struct HydrolysisRenderer {
     frame_instant: Instant,
     frame_clip_layers: u32,
     frame_max_clip_depth: u32,
+    /// Whether this frame's window pass was handed straight to a GPU surface
+    /// instead of being composited. Recorded by
+    /// [`HydrolysisRenderer::render_scene_to_surface`] as it decides, so the
+    /// frame report says what happened rather than what was eligible.
+    frame_direct_gpu_surfaces: u32,
     frame_applied_filter_count: u32,
     frame_applied_filter_capture: Duration,
     frame_applied_filter_effect: Duration,
@@ -356,6 +368,7 @@ impl HydrolysisRenderer {
             popup_menu: PopupMenuState::default(),
             render_depth: 0,
             window_bounds: vello::kurbo::Rect::ZERO,
+            window_root_transform: vello::kurbo::Affine::IDENTITY,
             signals: FrameSignals::new(frame_instant),
             host_redraw_handle: None,
             shader_cache: Arc::new(WgslModuleCache::new()),
@@ -365,6 +378,7 @@ impl HydrolysisRenderer {
             frame_instant,
             frame_clip_layers: 0,
             frame_max_clip_depth: 0,
+            frame_direct_gpu_surfaces: 0,
             frame_applied_filter_count: 0,
             frame_applied_filter_capture: Duration::ZERO,
             frame_applied_filter_effect: Duration::ZERO,

--- a/backends/hydrolysis/src/renderer/effects.rs
+++ b/backends/hydrolysis/src/renderer/effects.rs
@@ -578,10 +578,22 @@ impl HydrolysisRenderer {
         }
 
         self.flush_vello_scene_layer();
+        let GpuSurfaceSource::Owned(runtime) = &source;
+        // Rendering straight into the window's target replaces the whole
+        // composite pass, so everything the composite would have done has to be
+        // unnecessary: nothing may be drawn under or over this surface, no
+        // scene layer may be masking or fading it, the view must fill every
+        // pixel it is handed (the target arrives uncleared, still holding the
+        // previous frame), and its transformed bounds must land exactly on the
+        // window's device-pixel viewport.
+        //
+        // That last test is deliberately *not* `transform == IDENTITY`. The
+        // window root is `Affine::scale(scale_factor)`, so an identity test is
+        // false on every HiDPI display and this path never ran on one.
         let direct_to_target = self.compositor.render_layers.is_empty()
             && self.compositor.active_scene_layers.is_empty()
-            && affine_near(transform, vello::kurbo::Affine::IDENTITY)
-            && rect_near(bounds, self.window_bounds);
+            && runtime.borrow().is_opaque()
+            && covers_viewport_directly(transform, bounds, self.window_viewport());
         self.compositor
             .render_layers
             .push(RenderLayer::GpuSurface(GpuSurfaceLayer {

--- a/backends/hydrolysis/src/renderer/frame.rs
+++ b/backends/hydrolysis/src/renderer/frame.rs
@@ -3,6 +3,21 @@
 
 use super::*;
 
+/// What one frame's window pass was made of.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub(crate) struct RenderLayerStats {
+    /// Layers the compositor drew, which is every layer unless the window pass
+    /// was handed to a GPU surface outright.
+    pub(crate) composited_scene_layers: u32,
+    /// Composited layers that were Vello scenes.
+    pub(crate) vello_scene_layers: u32,
+    /// Composited layers that were embedded GPU surfaces.
+    pub(crate) gpu_surface_layers: u32,
+    /// GPU surfaces that rendered straight into the window's own target,
+    /// skipping the offscreen intermediate and the composite entirely.
+    pub(crate) direct_gpu_surfaces: u32,
+}
+
 pub(crate) fn duration_micros_u64(duration: Duration) -> u64 {
     u64::try_from(duration.as_micros()).unwrap_or(u64::MAX)
 }
@@ -33,8 +48,27 @@ pub(crate) fn color_to_wgpu(color: vello::peniko::Color) -> wgpu::Color {
 }
 
 impl HydrolysisRenderer {
-    pub(crate) fn set_window_bounds(&mut self, bounds: vello::kurbo::Rect) {
+    /// Records the window's logical bounds and the root transform that maps
+    /// them onto the target's physical pixel grid.
+    ///
+    /// Both halves are needed together: the bounds alone say how big the window
+    /// is in layout units, and only the transform says which device pixels that
+    /// covers — which is the rectangle a full-window GPU surface has to match to
+    /// be rendered straight into the target.
+    pub(crate) fn set_window_viewport(
+        &mut self,
+        bounds: vello::kurbo::Rect,
+        root_transform: vello::kurbo::Affine,
+    ) {
         self.window_bounds = bounds;
+        self.window_root_transform = root_transform;
+    }
+
+    /// The window's viewport in physical pixels: where the root transform puts
+    /// the window's logical bounds.
+    pub(crate) fn window_viewport(&self) -> vello::kurbo::Rect {
+        self.window_root_transform
+            .transform_rect_bbox(self.window_bounds)
     }
 
     /// Whether the persistent render tree has been built. The view tree's `body()`
@@ -467,7 +501,7 @@ impl HydrolysisRenderer {
         self.state.measurement.stats()
     }
 
-    pub(crate) fn render_layer_stats(&self) -> (u32, u32, u32) {
+    pub(crate) fn render_layer_stats(&self) -> RenderLayerStats {
         let scene_layers = u32::try_from(self.compositor.render_layers.len())
             .expect("hydrolysis render layer count exceeds u32");
         let vello_scene_layers = u32::try_from(
@@ -478,22 +512,12 @@ impl HydrolysisRenderer {
                 .count(),
         )
         .expect("hydrolysis Vello scene layer count exceeds u32");
-        let direct_gpu_surfaces = u32::try_from(
-            self.compositor
-                .render_layers
-                .iter()
-                .filter(|layer| {
-                    matches!(
-                        layer,
-                        RenderLayer::GpuSurface(GpuSurfaceLayer {
-                            direct_to_target: true,
-                            ..
-                        })
-                    )
-                })
-                .count(),
-        )
-        .expect("hydrolysis direct GpuSurface count exceeds u32");
+        // What was rendered directly is recorded by the render pass itself, not
+        // re-derived from the layer's `direct_to_target` flag: that flag says
+        // the layer is eligible on geometry, structure and opacity, and the
+        // render pass adds the one condition only it can see — that the target
+        // already carries the format the view was set up for.
+        let direct_gpu_surfaces = self.frame_direct_gpu_surfaces;
         let gpu_surface_layers = scene_layers
             .checked_sub(vello_scene_layers)
             .and_then(|count| count.checked_sub(direct_gpu_surfaces))
@@ -501,11 +525,12 @@ impl HydrolysisRenderer {
         let composited_scene_layers = scene_layers
             .checked_sub(direct_gpu_surfaces)
             .expect("hydrolysis render layer count accounting underflow");
-        (
+        RenderLayerStats {
             composited_scene_layers,
             vello_scene_layers,
             gpu_surface_layers,
-        )
+            direct_gpu_surfaces,
+        }
     }
 
     pub(crate) fn clip_layer_stats(&self) -> (u32, u32) {

--- a/backends/hydrolysis/src/renderer/render/compositor.rs
+++ b/backends/hydrolysis/src/renderer/render/compositor.rs
@@ -163,6 +163,12 @@ pub(crate) struct EmbeddedGpuSurfaceRuntime {
     /// duration of async setup, and a target that disappeared for those frames
     /// would drop the focus it holds.
     wants_input_events: bool,
+    /// Whether the view fills every pixel it is handed opaquely, and may
+    /// therefore be rendered straight into the window's uncleared texture.
+    /// Sampled once at construction for the same reason as
+    /// `wants_input_events`: the surface is moved out for the duration of async
+    /// setup, and the layer-pushing path must still be able to ask.
+    is_opaque: bool,
     msaa_samples: NonZeroU32,
     prefers_hdr: Option<bool>,
     output_format: wgpu::TextureFormat,
@@ -638,6 +644,7 @@ impl EmbeddedGpuSurfaceRuntime {
     pub(crate) fn new(surface: GpuSurface, env: &Environment) -> Self {
         let msaa_samples = surface.msaa_sample_limit();
         let wants_input_events = surface.wants_input_events();
+        let is_opaque = surface.is_opaque();
         let prefers_hdr = surface.resolved_hdr_preference().or_else(|| {
             env.get::<DynamicRangePreference>()
                 .map(|preference| preference.0)
@@ -647,6 +654,7 @@ impl EmbeddedGpuSurfaceRuntime {
             env: Some(env.clone()),
             setup_complete: false,
             wants_input_events,
+            is_opaque,
             msaa_samples,
             prefers_hdr,
             output_format: wgpu::TextureFormat::Rgba8Unorm,
@@ -723,6 +731,16 @@ impl EmbeddedGpuSurfaceRuntime {
     /// Whether this surface's view handles its own input.
     pub(crate) const fn wants_input_events(&self) -> bool {
         self.wants_input_events
+    }
+
+    /// Whether this surface's view declares that it fills every pixel opaquely.
+    ///
+    /// Only such a view may be rendered straight into the window's target,
+    /// which arrives uncleared and still holding the previous frame; a view
+    /// that leaves any pixel alone is composited over the window's base colour
+    /// instead.
+    pub(crate) const fn is_opaque(&self) -> bool {
+        self.is_opaque
     }
 
     /// Delivers one backend-neutral input event to the view.
@@ -1082,6 +1100,25 @@ impl EmbeddedGpuSurfaceRuntime {
     }
 }
 
+/// The one texture format an embedded surface's view is set up for and renders
+/// into, whichever path carries it to the window.
+///
+/// An SDR surface takes the *target's own linear format* — `Bgra8Unorm` for a
+/// `Bgra8Unorm` or `Bgra8UnormSrgb` window, `Rgba8Unorm` for an `Rgba8Unorm`
+/// one — rather than a fixed `Rgba8Unorm`. That is what lets the direct path
+/// hand the view the window texture itself without the format under it
+/// changing: [`HydrolysisRenderer::render_scene_to_surface`] takes that path
+/// only when this format already equals the target's, and Hydrolysis
+/// normalizes every swapchain to its linear variant when the surface offers
+/// one (`normalize_surface_format`), so it does. A window that can only be
+/// configured sRGB keeps its surfaces composed; viewing such a swapchain
+/// texture through its linear variant instead would need that variant declared
+/// in `SurfaceConfiguration::view_formats`, which rests on
+/// `DownlevelFlags::VIEW_FORMATS` and is not universal.
+///
+/// HDR is unchanged: an HDR target under a view that wants HDR renders
+/// `Rgba16Float`, and one that asked for SDR renders the target's linear
+/// format and is therefore composited.
 fn select_embedded_surface_format(
     target_format: wgpu::TextureFormat,
     prefers_hdr_override: Option<bool>,
@@ -1094,7 +1131,10 @@ fn select_embedded_surface_format(
     if target_hdr && prefers_hdr {
         return wgpu::TextureFormat::Rgba16Float;
     }
-    wgpu::TextureFormat::Rgba8Unorm
+    if target_hdr {
+        return wgpu::TextureFormat::Rgba8Unorm;
+    }
+    target_format.remove_srgb_suffix()
 }
 
 fn point_to_clip(point: vello::kurbo::Point, width: u32, height: u32) -> [f32; 2] {
@@ -1122,6 +1162,74 @@ fn point_to_clip(point: vello::kurbo::Point, width: u32, height: u32) -> [f32; 2
 /// matches what the browser widgets already publish to their own viewports.
 fn layer_device_scale(transform: vello::kurbo::Affine) -> f64 {
     transform.determinant().abs().sqrt()
+}
+
+/// Where a layer's bounds land on the window's physical pixel grid, when its
+/// transform is one the direct-to-target path can honour at all.
+///
+/// Direct rendering replaces the window's whole pass with the view's own, so
+/// the view is handed the target's axis-aligned pixel rectangle and nothing
+/// else: there is no quad to map its output through the way
+/// [`encode_compositor_uniform`] maps a composited layer's. A rotation, a skew,
+/// a mirrored axis or a collapsed one all describe output this path cannot
+/// place, so they answer `None` and the surface composites instead.
+///
+/// A *pure scale* does survive, which is the whole point — the window root's
+/// transform is `Affine::scale(scale_factor)`, so on every HiDPI display a
+/// full-window surface arrives here scaled by 2 or 3 rather than as the
+/// identity. Translation is not rejected outright either; it simply has to come
+/// out matching the viewport, which the caller checks against the rect returned
+/// here.
+fn direct_target_rect(
+    transform: vello::kurbo::Affine,
+    bounds: vello::kurbo::Rect,
+) -> Option<vello::kurbo::Rect> {
+    let [x_scale, shear_y, shear_x, y_scale, ..] = transform.as_coeffs();
+    // Comparing the transform's linear part against a pure non-uniform scale is
+    // the "no rotation, no skew" test, taken at the same tolerance every other
+    // affine comparison in the renderer uses. The translation is dropped from
+    // both sides: where the surface lands is the caller's question, not this
+    // one's.
+    if !affine_near(
+        vello::kurbo::Affine::new([x_scale, shear_y, shear_x, y_scale, 0.0, 0.0]),
+        vello::kurbo::Affine::scale_non_uniform(x_scale, y_scale),
+    ) {
+        return None;
+    }
+    // A mirrored axis would flip the view's output, and a collapsed one leaves
+    // it no pixels at all; neither is something handing over the window texture
+    // can express.
+    if x_scale <= 0.0 || y_scale <= 0.0 {
+        return None;
+    }
+    Some(transform.transform_rect_bbox(bounds))
+}
+
+/// Whether a layer's transformed bounds cover `viewport` exactly, in physical
+/// pixels — the geometric half of the direct-to-target decision.
+pub(crate) fn covers_viewport_directly(
+    transform: vello::kurbo::Affine,
+    bounds: vello::kurbo::Rect,
+    viewport: vello::kurbo::Rect,
+) -> bool {
+    direct_target_rect(transform, bounds).is_some_and(|rect| rect_near(rect, viewport))
+}
+
+/// The whole-pixel size of a direct-to-target layer, taken from the same
+/// transformed bounds the decision was made on rather than assumed from the
+/// window.
+fn direct_target_size(transform: vello::kurbo::Affine, bounds: vello::kurbo::Rect) -> (u32, u32) {
+    let rect = direct_target_rect(transform, bounds)
+        .expect("hydrolysis direct GpuSurface layer must have a direct-renderable transform");
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "the rect was accepted only after matching the window's own pixel viewport"
+    )]
+    (
+        rect.width().round().max(1.0) as u32,
+        rect.height().round().max(1.0) as u32,
+    )
 }
 
 fn edge_length_in_pixels(
@@ -1513,6 +1621,7 @@ impl HydrolysisRenderer {
         );
 
         self.flush_vello_scene_layer();
+        self.frame_direct_gpu_surfaces = 0;
         let fullscreen_uniform =
             encode_compositor_uniform([[-1.0, 1.0], [1.0, 1.0], [1.0, -1.0], [-1.0, -1.0]], true);
         let mut render_layers = core::mem::take(&mut self.compositor.render_layers);
@@ -1527,31 +1636,50 @@ impl HydrolysisRenderer {
             self.clear_target_surface(target.device, target.queue, target.view, target.base_color);
             return;
         }
+        // The last condition is the one the layer could not answer for itself:
+        // the format a view is set up for is fixed for its lifetime (see
+        // [`select_embedded_surface_format`]), so it may only be handed the
+        // window's own texture when that texture already carries that format.
+        // Anything else would re-run `GpuView::setup` on every switch between
+        // this path and the composited one.
         if let [RenderLayer::GpuSurface(layer)] = render_layers.as_slice()
             && layer.direct_to_target
+            && let GpuSurfaceSource::Owned(runtime) = &layer.source
+            && runtime.borrow().output_format_for(target.format) == target.format
         {
             let texture = target
                 .texture
                 .expect("hydrolysis direct GpuSurface render requires target texture");
+            // The surface's pixel size comes from the same transformed bounds
+            // the direct decision was taken on, not from the window: the two
+            // agree by construction, and deriving it here is what makes that
+            // checkable.
+            let (width, height) = direct_target_size(layer.transform, layer.bounds);
+            assert!(
+                width == target.width && height == target.height,
+                "hydrolysis direct GpuSurface layer covers {width}x{height} device pixels but its \
+                 window target is {}x{}",
+                target.width,
+                target.height
+            );
             let direct_target = DirectGpuSurfaceTarget {
                 device: target.device,
                 queue: target.queue,
                 texture,
                 view: target.view.clone(),
                 format: target.format,
-                width: target.width,
-                height: target.height,
+                width,
+                height,
                 scale: layer_device_scale(layer.transform),
                 pointer: project_pointer_into_surface(
                     self.hit_test.pointer_position,
                     self.hit_test.pointer_press_origin,
                     layer.hit_rect,
-                    target.width,
-                    target.height,
+                    width,
+                    height,
                 ),
                 now: self.frame_instant(),
             };
-            let GpuSurfaceSource::Owned(runtime) = &layer.source;
             if !EmbeddedGpuSurfaceRuntime::ensure_setup(
                 runtime,
                 self.embedded_gpu_surface_setup(target.adapter, target.device, target.queue),
@@ -1567,6 +1695,7 @@ impl HydrolysisRenderer {
                 self.compositor.render_layers = render_layers;
                 return;
             }
+            self.frame_direct_gpu_surfaces = 1;
             let needs_redraw = runtime.borrow_mut().render_direct_to_target(direct_target);
             self.compositor.render_layers = render_layers;
             if needs_redraw {

--- a/backends/hydrolysis/src/renderer/render/mod.rs
+++ b/backends/hydrolysis/src/renderer/render/mod.rs
@@ -16,7 +16,7 @@ pub(crate) use compositor::NativeViewLayer;
 pub(crate) use compositor::take_gpu_surface_redraw_request;
 pub(crate) use compositor::{
     ActiveSceneLayer, Compositor, EmbeddedGpuSurfaceRuntime, GpuSurfaceLayer, GpuSurfaceSource,
-    LayerShape, RenderLayer,
+    LayerShape, RenderLayer, covers_viewport_directly,
 };
 pub(crate) use measurement::*;
 pub(crate) use measurement_cache::MeasurementCaches;

--- a/backends/hydrolysis/src/renderer/tests/gpu_surface_direct.rs
+++ b/backends/hydrolysis/src/renderer/tests/gpu_surface_direct.rs
@@ -1,0 +1,439 @@
+//! Rendering a full-window GPU surface straight into the window's own target.
+//!
+//! Three things are pinned here, and each of them was broken:
+//!
+//! * the path is taken on a HiDPI window, not only at scale 1 — the window root
+//!   transform is `Affine::scale(scale_factor)`, so a test for the identity
+//!   transform was false on every Retina display and this path was dead code
+//!   there;
+//! * a view sees one texture format for its whole lifetime, so moving between
+//!   this path and the composited one does not rebuild its GPU resources;
+//! * only a view that declares itself opaque is handed the window's target,
+//!   which arrives uncleared and still holding the previous frame.
+//!
+//! Every test drives the real runner path and reads the frame report's own
+//! counters, so "it rendered directly" means the render pass took that branch,
+//! not that the layer looked eligible.
+
+use core::cell::Cell;
+use core::cell::RefCell;
+use core::time::Duration;
+use std::rc::Rc;
+use std::time::Instant;
+
+use waterui::Binding;
+use waterui_core::AnyView;
+use waterui_core::handler::AnyViewBuilder;
+use waterui_graphics::{GpuContext, GpuFrame, GpuSurface, GpuView};
+use waterui_layout::frame::Frame;
+
+use super::pumped_test_environment;
+use crate::HeadlessRuntime;
+
+const WINDOW_WIDTH: u32 = 160;
+const WINDOW_HEIGHT: u32 = 120;
+
+/// Written into every pixel of the surface, by both paths, as a literal texel
+/// value: an `Rgba8Unorm` clear takes the colour as given, so the two paths are
+/// comparable byte for byte.
+const FILL: wgpu::Color = wgpu::Color {
+    r: 0.125,
+    g: 0.5,
+    b: 0.75,
+    a: 1.0,
+};
+
+/// Where this module's visual evidence is written.
+const IMAGE_DIR: &str = "/tmp/waterui_direct_to_target";
+
+/// What a probe recorded about its own lifetime: how often it was set up, how
+/// often it drew, and which format it was handed each time.
+#[derive(Clone, Default)]
+struct ProbeLog {
+    setups: Rc<Cell<u32>>,
+    renders: Rc<Cell<u32>>,
+    formats: Rc<RefCell<Vec<wgpu::TextureFormat>>>,
+}
+
+impl ProbeLog {
+    fn setups(&self) -> u32 {
+        self.setups.get()
+    }
+
+    fn renders(&self) -> u32 {
+        self.renders.get()
+    }
+
+    /// Every distinct format the view was asked to render into, in order.
+    fn formats(&self) -> Vec<wgpu::TextureFormat> {
+        let mut formats = self.formats.borrow().clone();
+        formats.dedup();
+        formats
+    }
+}
+
+/// A view that fills whatever it is handed with [`FILL`], and that answers
+/// [`GpuView::is_opaque`] as the test tells it to.
+struct FillProbe {
+    log: ProbeLog,
+    opaque: bool,
+}
+
+impl GpuView for FillProbe {
+    async fn setup(&mut self, _ctx: &GpuContext<'_>, _env: &mut waterui_core::Environment) {
+        self.log.setups.set(
+            self.log
+                .setups
+                .get()
+                .checked_add(1)
+                .expect("setup overflow"),
+        );
+    }
+
+    fn render(&mut self, frame: &mut GpuFrame) {
+        self.log.renders.set(
+            self.log
+                .renders
+                .get()
+                .checked_add(1)
+                .expect("render overflow"),
+        );
+        self.log.formats.borrow_mut().push(frame.format);
+        let mut encoder = frame
+            .device
+            .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("hydrolysis_direct_to_target_probe_encoder"),
+            });
+        drop(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("hydrolysis_direct_to_target_probe_pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &frame.view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    load: wgpu::LoadOp::Clear(FILL),
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        }));
+        frame.queue.submit([encoder.finish()]);
+    }
+
+    fn is_opaque(&self) -> bool {
+        self.opaque
+    }
+}
+
+/// A window whose entire content is one GPU surface, sized by the test.
+///
+/// The size is a `Binding` rather than a rebuild so the surface's node — and
+/// therefore the `GpuView` inside it and everything `setup` gave it — survives
+/// every change the tests make.
+fn runtime_with(
+    log: &ProbeLog,
+    opaque: bool,
+    width: &Binding<f32>,
+    height: &Binding<f32>,
+    scale_factor: f64,
+) -> HeadlessRuntime {
+    let parts = RefCell::new(Some((log.clone(), width.clone(), height.clone())));
+    let builder = AnyViewBuilder::<AnyView>::new(move || {
+        let (log, width, height) = parts
+            .borrow_mut()
+            .take()
+            .expect("the probe window is built once");
+        AnyView::new(
+            Frame::new(GpuSurface::new(FillProbe { log, opaque }))
+                .width(width)
+                .height(height),
+        )
+    });
+    HeadlessRuntime::new_for_tests(
+        pumped_test_environment(),
+        builder,
+        WINDOW_WIDTH,
+        WINDOW_HEIGHT,
+    )
+    .with_scale_factor(scale_factor)
+}
+
+/// Pumps window frames on a fixed 16ms cadence, so the frame clock is the
+/// test's rather than the wall's.
+struct Frames {
+    start: Instant,
+    next: u64,
+}
+
+impl Frames {
+    fn new() -> Self {
+        Self {
+            start: Instant::now(),
+            next: 0,
+        }
+    }
+
+    fn at(&mut self) -> Instant {
+        let at = self.start + Duration::from_millis(self.next * 16);
+        self.next += 1;
+        at
+    }
+
+    fn pump(&mut self, runtime: &mut HeadlessRuntime, count: u64) {
+        for _ in 0..count {
+            let at = self.at();
+            let _ = runtime.pump_at(false, at);
+        }
+    }
+
+    /// One frame that certainly runs the window's render pass, and reports what
+    /// that pass did.
+    ///
+    /// A capturing pump is how a test asks for that unconditionally: a window
+    /// whose content asks for nothing is entitled to sit a frame out, and a
+    /// skipped frame reports the default counters — zero of everything, which
+    /// reads exactly like "it was composited" and would make these assertions
+    /// depend on whether the previous pump happened to leave a request behind.
+    fn render(&mut self, runtime: &mut HeadlessRuntime) -> RenderedFrame {
+        let at = self.at();
+        let result = runtime.pump_at(true, at);
+        RenderedFrame {
+            counters: result.profile.counters,
+            snapshot: result
+                .snapshot
+                .expect("a capturing pump must produce a snapshot"),
+        }
+    }
+}
+
+/// One frame's render pass: what it did, and what it left on screen.
+struct RenderedFrame {
+    counters: crate::runner::FrameCounters,
+    snapshot: crate::runner::HeadlessSnapshot,
+}
+
+/// Pumps until the surface's async setup has completed and it has drawn once.
+fn settled(runtime: &mut HeadlessRuntime, frames: &mut Frames, log: &ProbeLog) {
+    for _ in 0..12u32 {
+        if log.renders() > 0 {
+            break;
+        }
+        frames.pump(runtime, 1);
+    }
+    assert_eq!(
+        log.setups(),
+        1,
+        "the surface's view is set up exactly once for the surface's lifetime"
+    );
+    assert!(
+        log.renders() > 0,
+        "the surface must have drawn before a test measures which path drew it"
+    );
+}
+
+fn full_window_bindings() -> (Binding<f32>, Binding<f32>) {
+    (
+        Binding::f32(WINDOW_WIDTH as f32),
+        Binding::f32(WINDOW_HEIGHT as f32),
+    )
+}
+
+fn write_png(name: &str, snapshot: &crate::runner::HeadlessSnapshot) -> std::path::PathBuf {
+    std::fs::create_dir_all(IMAGE_DIR).expect("the image directory must be creatable");
+    let path = std::path::Path::new(IMAGE_DIR).join(name);
+    let image = image::RgbaImage::from_raw(snapshot.width, snapshot.height, snapshot.rgba8.clone())
+        .expect("snapshot dimensions must match the rgba buffer");
+    image.save(&path).expect("snapshot png must be writable");
+    path
+}
+
+#[test]
+fn an_opaque_full_window_surface_renders_directly_at_every_scale() {
+    for scale in [1.0_f64, 2.0] {
+        let log = ProbeLog::default();
+        let (width, height) = full_window_bindings();
+        let mut runtime = runtime_with(&log, true, &width, &height, scale);
+        let mut frames = Frames::new();
+        settled(&mut runtime, &mut frames, &log);
+
+        let counters = frames.render(&mut runtime).counters;
+        assert_eq!(
+            counters.direct_gpu_surfaces, 1,
+            "an opaque surface covering the whole window renders straight into the \
+             window target at scale {scale}, where the window root transform is \
+             Affine::scale({scale})"
+        );
+        assert_eq!(
+            counters.gpu_surface_layers, 0,
+            "nothing is left for the compositor to draw at scale {scale}"
+        );
+        assert_eq!(
+            counters.scene_layers, 0,
+            "and there is no composite pass at all at scale {scale}"
+        );
+    }
+}
+
+#[test]
+fn a_non_opaque_full_window_surface_is_composited_at_every_scale() {
+    for scale in [1.0_f64, 2.0] {
+        let log = ProbeLog::default();
+        let (width, height) = full_window_bindings();
+        let mut runtime = runtime_with(&log, false, &width, &height, scale);
+        let mut frames = Frames::new();
+        settled(&mut runtime, &mut frames, &log);
+
+        let counters = frames.render(&mut runtime).counters;
+        assert_eq!(
+            counters.direct_gpu_surfaces, 0,
+            "a view that has not declared itself opaque never gets the window's own \
+             uncleared texture, however exactly it covers the window (scale {scale})"
+        );
+        assert_eq!(
+            counters.gpu_surface_layers, 1,
+            "it is composited over the window's cleared base colour instead (scale {scale})"
+        );
+    }
+}
+
+#[test]
+fn moving_between_the_two_paths_never_re_runs_setup() {
+    let log = ProbeLog::default();
+    let (width, height) = full_window_bindings();
+    let mut runtime = runtime_with(&log, true, &width, &height, 2.0);
+    let mut frames = Frames::new();
+    settled(&mut runtime, &mut frames, &log);
+
+    assert_eq!(
+        frames.render(&mut runtime).counters.direct_gpu_surfaces,
+        1,
+        "the surface starts out covering the window"
+    );
+
+    // Inset the surface: its transformed bounds no longer match the viewport,
+    // so the window has to composite it. Nothing structural changed — the same
+    // node, the same runtime, the same view.
+    width.set(WINDOW_WIDTH as f32 - 20.0);
+    height.set(WINDOW_HEIGHT as f32 - 20.0);
+    frames.pump(&mut runtime, 2);
+    let counters = frames.render(&mut runtime).counters;
+    assert_eq!(
+        counters.direct_gpu_surfaces, 0,
+        "an inset surface does not cover the viewport and is composited"
+    );
+    assert_eq!(counters.gpu_surface_layers, 1);
+    assert_eq!(
+        log.setups(),
+        1,
+        "moving onto the composited path must not rebuild the view's GPU resources"
+    );
+
+    width.set(WINDOW_WIDTH as f32);
+    height.set(WINDOW_HEIGHT as f32);
+    frames.pump(&mut runtime, 2);
+    assert_eq!(
+        frames.render(&mut runtime).counters.direct_gpu_surfaces,
+        1,
+        "and it goes back to rendering directly once it covers the window again"
+    );
+    assert_eq!(
+        log.setups(),
+        1,
+        "setup runs exactly once across both switches"
+    );
+    assert_eq!(
+        log.formats(),
+        vec![wgpu::TextureFormat::Rgba8Unorm],
+        "and the view saw one format the whole way through — the target's own \
+         linear format, on both paths"
+    );
+}
+
+/// The two paths must produce the same window. This is what the opacity
+/// contract buys: the direct path skips the clear to the window's base colour,
+/// which is only sound because the view fills every pixel — and a missing clear
+/// would show up here as a difference against the composited render of the very
+/// same scene.
+#[test]
+fn the_direct_and_composited_paths_agree_pixel_for_pixel() {
+    let scale = 2.0;
+
+    let direct_log = ProbeLog::default();
+    let (direct_width, direct_height) = full_window_bindings();
+    let mut direct_runtime = runtime_with(&direct_log, true, &direct_width, &direct_height, scale);
+    let mut direct_frames = Frames::new();
+    settled(&mut direct_runtime, &mut direct_frames, &direct_log);
+    let direct = direct_frames.render(&mut direct_runtime);
+    assert_eq!(direct.counters.direct_gpu_surfaces, 1);
+    let direct = direct.snapshot;
+
+    let composed_log = ProbeLog::default();
+    let (composed_width, composed_height) = full_window_bindings();
+    let mut composed_runtime = runtime_with(
+        &composed_log,
+        false,
+        &composed_width,
+        &composed_height,
+        scale,
+    );
+    let mut composed_frames = Frames::new();
+    settled(&mut composed_runtime, &mut composed_frames, &composed_log);
+    let composed = composed_frames.render(&mut composed_runtime);
+    assert_eq!(composed.counters.direct_gpu_surfaces, 0);
+    let composed = composed.snapshot;
+
+    let direct_path = write_png("direct_scale2.png", &direct);
+    let composed_path = write_png("composed_scale2.png", &composed);
+    eprintln!(
+        "wrote {} and {}",
+        direct_path.display(),
+        composed_path.display()
+    );
+
+    assert_eq!(
+        (direct.width, direct.height),
+        (WINDOW_WIDTH * 2, WINDOW_HEIGHT * 2),
+        "a 2x window captures at twice its logical size"
+    );
+    assert_eq!(
+        (composed.width, composed.height),
+        (direct.width, direct.height)
+    );
+    assert_eq!(
+        direct.rgba8, composed.rgba8,
+        "the direct path draws the same window as the composite it replaces"
+    );
+
+    // Agreeing is not enough on its own — both paths agreeing on the wrong
+    // thing would pass that. What the surface drew has to actually be there,
+    // over the whole window, with none of the window's base colour left
+    // anywhere: the direct path skips the clear that would have painted it.
+    let (pixels, _) = direct.rgba8.as_chunks::<4>();
+    let expected = *pixels.first().expect("the capture must have pixels");
+    assert!(
+        near_fill(expected),
+        "the captured colour {expected:?} must be the fill the probe cleared to"
+    );
+    assert!(
+        pixels.iter().all(|pixel| *pixel == expected),
+        "every pixel of the window belongs to the surface, at both ends of the comparison"
+    );
+}
+
+/// Whether a captured `Rgba8Unorm` texel is [`FILL`], allowing the one step of
+/// slack that rounding a float clear colour onto 8 bits leaves.
+fn near_fill(pixel: [u8; 4]) -> bool {
+    #[expect(
+        clippy::cast_possible_truncation,
+        clippy::cast_sign_loss,
+        reason = "each component is a clear colour in 0..=1 scaled onto 0..=255"
+    )]
+    let expected = [FILL.r, FILL.g, FILL.b, FILL.a].map(|component| (component * 255.0) as u8);
+    pixel
+        .iter()
+        .zip(expected)
+        .all(|(actual, expected)| actual.abs_diff(expected) <= 1)
+}

--- a/backends/hydrolysis/src/renderer/tests/mod.rs
+++ b/backends/hydrolysis/src/renderer/tests/mod.rs
@@ -7,6 +7,7 @@ use std::rc::Rc;
 use executor_core::LocalExecutor;
 use executor_core::async_task::{self, AsyncTask, Runnable};
 
+mod gpu_surface_direct;
 mod gpu_surface_idle;
 mod gpu_surface_input;
 mod perf_full_rebuild;
@@ -872,7 +873,6 @@ fn capture_root_window<V: waterui_core::View>(
     env: &Environment,
     bounds: Rect,
 ) {
-    renderer.set_window_bounds(bounds);
     renderer.reset_scene();
     renderer.begin_rebuild_frame();
     renderer.capture_window_tree(
@@ -2304,7 +2304,6 @@ fn bare_text_at_window_root_renders_into_scene() {
     let env = test_environment();
 
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(Rect::new(0.0, 0.0, 160.0, 160.0));
     renderer.capture_window_tree(
         AnyView::new(waterui_text::text("probe")),
         &env,
@@ -2325,7 +2324,6 @@ fn bare_str_at_window_root_renders_into_scene() {
     let env = test_environment();
 
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(Rect::new(0.0, 0.0, 160.0, 160.0));
     renderer.capture_window_tree(
         AnyView::new(Str::from("probe")),
         &env,
@@ -2399,7 +2397,6 @@ fn bare_str_renders_into_scene() {
 
     let bounds = Rect::new(0.0, 0.0, 160.0, 160.0);
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(bounds);
     renderer.capture_window_tree(
         AnyView::new(Str::from("probe")),
         &env,

--- a/backends/hydrolysis/src/renderer/tests/tree.rs
+++ b/backends/hydrolysis/src/renderer/tests/tree.rs
@@ -167,7 +167,6 @@ fn capture_window_tree_renders_mixed_widgets() {
     let bounds = Rect::new(0.0, 0.0, 220.0, 200.0);
 
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(bounds);
     renderer.capture_window_tree(view, &env, bounds, Affine::IDENTITY, Affine::IDENTITY);
     assert!(
         !renderer.scene_is_empty(),
@@ -187,7 +186,6 @@ fn flush_window_tree_reuses_retained_tree() {
         button("Tap").action(|| {}),
     )));
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(bounds);
     renderer.capture_window_tree(view, &env, bounds, Affine::IDENTITY, Affine::IDENTITY);
     renderer.finish_rebuild_frame();
 
@@ -196,7 +194,7 @@ fn flush_window_tree_reuses_retained_tree() {
     // scene into the compositor's layer stack), so verify a Vello layer resulted.
     let flushed = renderer.flush_window_tree(&env, bounds, Affine::IDENTITY, Affine::IDENTITY);
     assert!(flushed, "a retained tree must be present to flush");
-    let (_, vello_layers, _) = renderer.render_layer_stats();
+    let vello_layers = renderer.render_layer_stats().vello_scene_layers;
     assert!(
         vello_layers > 0,
         "re-flushing the retained tree must produce a Vello scene layer"
@@ -1024,7 +1022,6 @@ fn lifecycle_hooks_fire_after_first_flush_and_on_drop() {
 
     renderer.reset_scene();
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(bounds);
     renderer.capture_window_tree(
         AnyView::new(()),
         &env,
@@ -1090,7 +1087,6 @@ fn lifecycle_appear_updates_animate_after_initial_signal_binding() {
 
     renderer.reset_scene();
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(bounds);
     renderer.capture_window_tree(
         AnyView::new(()),
         &env,
@@ -1133,7 +1129,6 @@ fn applied_filter_renders_through_retained_tree() {
     let bounds = Rect::new(0.0, 0.0, 120.0, 120.0);
 
     renderer.begin_rebuild_frame();
-    renderer.set_window_bounds(bounds);
     renderer.capture_window_tree(
         blurred_box(),
         &env,

--- a/backends/hydrolysis/src/renderer/tree/flush.rs
+++ b/backends/hydrolysis/src/renderer/tree/flush.rs
@@ -450,9 +450,14 @@ impl HydrolysisRenderer {
         let parent_render_layers = core::mem::take(&mut self.compositor.render_layers);
         let parent_active_layers = core::mem::take(&mut self.compositor.active_scene_layers);
         let parent_transient_scene = self.transient_scene.take();
-        let parent_window_bounds = core::mem::replace(
-            &mut self.window_bounds,
+        // The captured subtree is flushed under identity transforms into a
+        // pixel-sized texture, so its viewport is that texture and its root
+        // transform is the identity — not the window's.
+        let parent_window_bounds = self.window_bounds;
+        let parent_window_root_transform = self.window_root_transform;
+        self.set_window_viewport(
             vello::kurbo::Rect::new(0.0, 0.0, f64::from(target.width), f64::from(target.height)),
+            vello::kurbo::Affine::IDENTITY,
         );
 
         let local_ctx = ctx.with_identity_transforms(vello::kurbo::Rect::new(
@@ -486,6 +491,6 @@ impl HydrolysisRenderer {
         self.compositor.render_layers = parent_render_layers;
         self.compositor.active_scene_layers = parent_active_layers;
         self.transient_scene = parent_transient_scene;
-        self.window_bounds = parent_window_bounds;
+        self.set_window_viewport(parent_window_bounds, parent_window_root_transform);
     }
 }

--- a/backends/hydrolysis/src/renderer/tree/window.rs
+++ b/backends/hydrolysis/src/renderer/tree/window.rs
@@ -160,6 +160,12 @@ impl HydrolysisRenderer {
         hit_transform: vello::kurbo::Affine,
     ) {
         let size = Size::new(bounds.width() as f32, bounds.height() as f32);
+        // The viewport is recorded here rather than by each caller: every host
+        // that builds a window tree — the runner, and a `HydrolysisGpuView`
+        // embedding one in someone else's surface — has to agree on where the
+        // window lands in device pixels, and forgetting to say so left the
+        // embedded host reading a stale one.
+        self.set_window_viewport(bounds, transform);
         let ctx = RenderContext::with_transforms(bounds, transform, hit_transform);
         // The tree is built once and persists. A later "rebuild" request reuses
         // it — applying pending Dynamic patches, relaying out, and re-flushing —
@@ -194,9 +200,9 @@ impl HydrolysisRenderer {
         let Some(mut tree) = self.render_tree.take() else {
             return false;
         };
-        // Track the live window bounds every frame: text-context-menu clamping and
-        // effect-rect checks read the stored bounds.
-        self.set_window_bounds(bounds);
+        // Track the live window viewport every frame: text-context-menu clamping,
+        // effect-rect checks and the direct-to-target test read it.
+        self.set_window_viewport(bounds, transform);
         // Roll over this frame's Retain watcher guards exactly like the build path:
         // every re-encode re-reads and re-subscribes reactive visual inputs.
         self.lifecycle.begin_rebuild_frame();

--- a/backends/hydrolysis/src/runner/window.rs
+++ b/backends/hydrolysis/src/runner/window.rs
@@ -216,6 +216,11 @@ pub struct FrameCounters {
     pub vello_scene_layers: u32,
     /// Number of embedded GPU surface layers submitted for this frame.
     pub gpu_surface_layers: u32,
+    /// Number of GPU surfaces that rendered straight into the window's own
+    /// target this frame, skipping the offscreen intermediate and the
+    /// compositor pass. At most one: the path exists only for a surface that is
+    /// the window's whole content.
+    pub direct_gpu_surfaces: u32,
     /// Number of Vello clip layers pushed while building this frame.
     pub clip_layers: u32,
     /// Maximum nested Vello clip depth while building this frame.
@@ -387,7 +392,6 @@ fn build_window_scene<P: PlatformWindow>(
 ) {
     runtime.renderer.reset_scene();
     runtime.renderer.begin_rebuild_frame();
-    runtime.renderer.set_window_bounds(bounds);
     let build_content_started_at = Instant::now();
     let content = runtime.window.build_content();
     phases.build_content += build_content_started_at.elapsed();
@@ -782,8 +786,7 @@ pub(super) fn render_window_with_capture<P: PlatformWindow>(
                 runtime.platform.request_redraw();
                 let (measurement_cache_hits, measurement_cache_misses) =
                     runtime.renderer.measurement_cache_stats();
-                let (scene_layers, vello_scene_layers, gpu_surface_layers) =
-                    runtime.renderer.render_layer_stats();
+                let layer_stats = runtime.renderer.render_layer_stats();
                 let (clip_layers, max_clip_depth) = runtime.renderer.clip_layer_stats();
                 let (applied_filter_count, applied_filter_capture_us, applied_filter_effect_us) =
                     runtime.renderer.applied_filter_stats();
@@ -802,9 +805,10 @@ pub(super) fn render_window_with_capture<P: PlatformWindow>(
                             rebuild_iterations: u32::from(pump_outcome.built),
                             measurement_cache_hits,
                             measurement_cache_misses,
-                            scene_layers,
-                            vello_scene_layers,
-                            gpu_surface_layers,
+                            scene_layers: layer_stats.composited_scene_layers,
+                            vello_scene_layers: layer_stats.vello_scene_layers,
+                            gpu_surface_layers: layer_stats.gpu_surface_layers,
+                            direct_gpu_surfaces: layer_stats.direct_gpu_surfaces,
                             clip_layers,
                             max_clip_depth,
                             applied_filter_count,
@@ -828,8 +832,7 @@ pub(super) fn render_window_with_capture<P: PlatformWindow>(
         runtime.renderer.clear_frame_resources();
         let (measurement_cache_hits, measurement_cache_misses) =
             runtime.renderer.measurement_cache_stats();
-        let (scene_layers, vello_scene_layers, gpu_surface_layers) =
-            runtime.renderer.render_layer_stats();
+        let layer_stats = runtime.renderer.render_layer_stats();
         let (clip_layers, max_clip_depth) = runtime.renderer.clip_layer_stats();
         let (applied_filter_count, applied_filter_capture_us, applied_filter_effect_us) =
             runtime.renderer.applied_filter_stats();
@@ -848,9 +851,10 @@ pub(super) fn render_window_with_capture<P: PlatformWindow>(
                 rebuild_iterations: u32::from(pump_outcome.built),
                 measurement_cache_hits,
                 measurement_cache_misses,
-                scene_layers,
-                vello_scene_layers,
-                gpu_surface_layers,
+                scene_layers: layer_stats.composited_scene_layers,
+                vello_scene_layers: layer_stats.vello_scene_layers,
+                gpu_surface_layers: layer_stats.gpu_surface_layers,
+                direct_gpu_surfaces: layer_stats.direct_gpu_surfaces,
                 clip_layers,
                 max_clip_depth,
                 applied_filter_count,

--- a/components/platform/browser-cef/src/input.rs
+++ b/components/platform/browser-cef/src/input.rs
@@ -256,6 +256,10 @@ impl<V: GpuView> GpuView for CefInputGpuView<V> {
         self.view.preferred_surface_hdr()
     }
 
+    fn is_opaque(&self) -> bool {
+        self.view.is_opaque()
+    }
+
     fn wants_input_events(&self) -> bool {
         true
     }

--- a/components/platform/browser-wpe/src/input.rs
+++ b/components/platform/browser-wpe/src/input.rs
@@ -274,6 +274,10 @@ impl<V: GpuView> GpuView for WpeInputGpuView<V> {
         self.view.preferred_surface_hdr()
     }
 
+    fn is_opaque(&self) -> bool {
+        self.view.is_opaque()
+    }
+
     fn wants_input_events(&self) -> bool {
         true
     }

--- a/components/visual/graphics/src/gpu/gpu_surface.rs
+++ b/components/visual/graphics/src/gpu/gpu_surface.rs
@@ -648,6 +648,26 @@ pub trait GpuView: 'static {
         None
     }
 
+    /// Whether every pixel this view is handed comes back fully opaque.
+    ///
+    /// A view returning `true` promises that [`GpuView::render`] writes the
+    /// whole of `frame.view` on every frame it is asked for — a clear that
+    /// covers the surface, or geometry that provably does — with alpha `1`
+    /// everywhere. Nothing that was in the texture beforehand may show
+    /// through, because a backend is then free to hand this view the window's
+    /// own swapchain texture, uncleared and holding the previous frame, and
+    /// skip both the offscreen intermediate and the composite that would have
+    /// cleared it to the window's base colour.
+    ///
+    /// The default is `false`: a view that leaves any pixel untouched, or
+    /// writes translucent colour anywhere, is composited over the window's
+    /// cleared base colour like any other layer. Declaring opacity a view does
+    /// not have shows the previous frame through the gaps, so leave this alone
+    /// unless the promise above is unconditional.
+    fn is_opaque(&self) -> bool {
+        false
+    }
+
     /// Whether this view handles its own keyboard, IME, pointer and scroll
     /// input.
     ///
@@ -1051,6 +1071,7 @@ trait GpuViewImpl: 'static {
     fn stretch_axis(&self) -> StretchAxis;
     fn priority(&self) -> i32;
     fn preferred_surface_hdr(&self) -> Option<bool>;
+    fn is_opaque(&self) -> bool;
     fn wants_input_events(&self) -> bool;
     fn input(&mut self, event: &SurfaceInputEvent);
     fn ime_caret(&self) -> Option<kurbo::Rect>;
@@ -1083,6 +1104,10 @@ impl<T: GpuView> GpuViewImpl for T {
 
     fn preferred_surface_hdr(&self) -> Option<bool> {
         GpuView::preferred_surface_hdr(self)
+    }
+
+    fn is_opaque(&self) -> bool {
+        GpuView::is_opaque(self)
     }
 
     fn wants_input_events(&self) -> bool {
@@ -1478,6 +1503,17 @@ impl GpuSurface {
     #[must_use]
     pub fn priority(&self) -> i32 {
         self.renderer.priority()
+    }
+
+    /// Whether the GPU view fills every pixel it is handed opaquely.
+    ///
+    /// See [`GpuView::is_opaque`]: a backend asks this to decide whether the
+    /// view may be given the window's own target texture, uncleared, instead
+    /// of an offscreen intermediate that is composited over the window's base
+    /// colour.
+    #[must_use]
+    pub fn is_opaque(&self) -> bool {
+        self.renderer.is_opaque()
     }
 
     /// Whether the GPU view handles its own input.


### PR DESCRIPTION
Fixes #171

`direct_to_target` lets a GPU surface that is the whole window render straight
into the window's target, skipping the offscreen intermediate and the compositor
pass. Three things stopped that from being either reachable or sound.

### The geometric rule

The test was `affine_near(transform, Affine::IDENTITY)`. The window root
transform is `Affine::scale(scale_factor)`, so the condition was false on every
display with a scale other than 1 — every modern macOS, Windows and mobile
screen — and the path was dead code there.

It is now a pure-scale test (`direct_target_rect` in `compositor.rs`):

* the transform's linear part must equal a non-uniform scale at the renderer's
  usual affine tolerance — no rotation, no skew;
* both scale factors must be positive — no mirrored axis, no collapsed one;
* the transformed bounds must match the window's device-pixel viewport, which is
  where translation is allowed exactly insofar as the result still lands on the
  viewport origin.

To know that viewport, the renderer now records the window's root transform
beside its bounds (`set_window_viewport`), and `capture_window_tree` /
`flush_window_tree` set it themselves rather than relying on each host to
remember — `HydrolysisGpuView`, which embeds a window tree in someone else's
surface, never did, and was reading a stale one.

The surface's pixel size is derived from those same transformed bounds rather
than assumed from the window.

### The format rule

The composed path rendered into a linear `Rgba8Unorm` intermediate while the
direct path handed over the swapchain's own (typically `Bgra8Unorm`) format, so
switching between the two re-ran `GpuView::setup` and rebuilt the view's GPU
resources.

An SDR surface now takes **the target's own linear format**
(`target_format.remove_srgb_suffix()`), and the direct path is taken only when
that already equals the target's format. Hydrolysis normalizes every swapchain
to its linear variant when the surface offers one
(`platform::normalize_surface_format`), so it does. A window that can only be
configured sRGB keeps its surfaces composed: viewing such a swapchain texture
through its linear variant instead would need that variant declared in
`SurfaceConfiguration::view_formats`, which rests on
`DownlevelFlags::VIEW_FORMATS` and is not universal. HDR is unchanged.

A view therefore sees one format for its whole lifetime, on either path.

### The opacity contract

Direct rendering handed over a raw, uncleared swapchain texture — still holding
the previous frame — while the composed path cleared to the window's base
colour, with nothing in the contract saying the view would cover it.

`GpuView::is_opaque` now states it, defaulting to `false`, and only a view that
declares it is given the window's target. Wrapping views (`CefInputGpuView`,
`WpeInputGpuView`) forward it. No `GpuView` in the tree declares opacity yet, so
this closes the path for views that never promised to fill it — including at
scale 1, where it used to be taken.

### Instrumentation

`FrameCounters` gains `direct_gpu_surfaces`, recorded by the render pass as it
decides rather than re-derived from the layer flag, so the report says what
happened rather than what was eligible. `render_layer_stats` returns a named
`RenderLayerStats` instead of a widening tuple.

### Tests

`backends/hydrolysis/src/renderer/tests/gpu_surface_direct.rs`, driving the real
runner through `HeadlessRuntime`:

* an opaque full-window surface renders directly at scale **1.0 and 2.0**
  (`direct_gpu_surfaces == 1`, no composite pass at all);
* a non-opaque one is composited at both scales;
* resizing between full-window and inset moves between the two paths in both
  directions while `setup()` runs exactly once and the view is handed one format
  throughout;
* at scale 2.0 the two paths' captures are byte-identical, every pixel is the
  surface's own fill, and none of the window's base colour survives anywhere —
  which is what makes skipping the clear safe. The PNGs are exported to
  `/tmp/waterui_direct_to_target/` and were read back and compared.

### Verification

```
cargo +stable clippy -p hydrolysis -p waterui-graphics --all-targets -- -D warnings   # clean
cargo +stable nextest run -p hydrolysis -p waterui-graphics                           # 241 passed
cargo +stable test --doc -p waterui-graphics                                          # 13 passed
cargo +stable check -p waterui-ffi -p waterui-browser-cef -p waterui-browser-wpe      # clean
```

The C surface is untouched, so `ffi/waterui.h` needs no regeneration.
