### PR TITLE
feat(markdown): make fenced code claimable so mermaid fences become diagrams

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6645,6 +6645,7 @@ name = "markdown-example"
 version = "0.1.0"
 dependencies = [
  "waterui",
+ "waterui-mermaid",
 ]
 
 [[package]]
@@ -11255,56 +11256,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tree-sitter-bash"
-version = "0.25.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5ec769279cc91b561d3df0d8a5deb26b0ad40d183127f409494d6d8fc53062"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-go"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8560a4d2f835cc0d4d2c2e03cbd0dde2f6114b43bc491164238d333e28b16ea"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-java"
-version = "0.23.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0aa6cbcdc8c679b214e616fd3300da67da0e492e066df01bcf5a5921a71e90d6"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-javascript"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68204f2abc0627a90bdf06e605f5c470aa26fdcb2081ea553a04bdad756693f5"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-json"
-version = "0.24.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d727acca406c0020cffc6cf35516764f36c8e3dc4408e5ebe2cb35a947ec471"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
 name = "tree-sitter-language"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11315,56 +11266,6 @@ name = "tree-sitter-md"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2efd398be546456c814598ee56c0f51769a77241511b4a58077815d120afa882"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-python"
-version = "0.25.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf85fd39652e740bf60f46f4cda9492c3a9ad75880575bf14960f775cb74a1c"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-rust"
-version = "0.24.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "439e577dbe07423ec2582ac62c7531120dbfccfa6e5f92406f93dd271a120e45"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-sequel"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d198ad3c319c02e43c21efa1ec796b837afcb96ffaef1a40c1978fbdcec7d17"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-swift"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe36052155b9dd69ca82b3b8f1b4ccfb2d867125ac1a4db1dd7331829242668c"
-dependencies = [
- "cc",
- "tree-sitter-language",
-]
-
-[[package]]
-name = "tree-sitter-typescript"
-version = "0.23.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c5f76ed8d947a75cc446d5fccd8b602ebf0cde64ccf2ffa434d873d7a575eff"
 dependencies = [
  "cc",
  "tree-sitter-language",
@@ -13041,17 +12942,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tree-sitter",
- "tree-sitter-bash",
- "tree-sitter-go",
- "tree-sitter-java",
- "tree-sitter-javascript",
- "tree-sitter-json",
  "tree-sitter-md",
- "tree-sitter-python",
- "tree-sitter-rust",
- "tree-sitter-sequel",
- "tree-sitter-swift",
- "tree-sitter-typescript",
  "wasm-bindgen-futures",
  "waterkit-haptic",
  "waterkit-screen",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12927,8 +12927,6 @@ dependencies = [
 name = "waterui-internal"
 version = "0.3.0"
 dependencies = [
- "android_clipboard",
- "arboard",
  "async-channel",
  "cpu-time",
  "executor-core",
@@ -12943,7 +12941,6 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-md",
- "wasm-bindgen-futures",
  "waterkit-haptic",
  "waterkit-screen",
  "waterui",
@@ -12969,7 +12966,6 @@ dependencies = [
  "waterui-video",
  "waterui-video-gpu",
  "waterui-webview",
- "web-sys",
 ]
 
 [[package]]
@@ -13290,19 +13286,26 @@ dependencies = [
 name = "waterui-text"
 version = "0.3.0"
 dependencies = [
+ "android_clipboard",
+ "arboard",
+ "executor-core",
  "nami",
  "pulldown-cmark",
  "smallvec",
  "syntect",
+ "tracing",
  "two-face",
+ "wasm-bindgen-futures",
  "waterui",
  "waterui-core",
  "waterui-graphics",
+ "waterui-layout",
  "waterui-locale",
  "waterui-macros",
  "waterui-str",
  "waterui-testing",
  "waterui-text",
+ "web-sys",
 ]
 
 [[package]]

--- a/components/data/mermaid/Cargo.toml
+++ b/components/data/mermaid/Cargo.toml
@@ -11,13 +11,6 @@ keywords = ["mermaid", "diagram", "flowchart", "waterui"]
 categories = ["gui", "visualization"]
 
 [dependencies]
-# `install` claims a fenced code block, and `CodeConfig` — the configuration a
-# fence is hooked through — lives with the `Code` widget in the root crate.
-# Only the `highlight` feature that widget sits behind is selected; the GPU,
-# media and asset stacks a diagram never touches stay out.
-waterui = { path = "../../..", default-features = false, features = [
-    "highlight",
-] }
 waterui-core.workspace = true
 waterui-canvas.workspace = true
 waterui-graphics.workspace = true
@@ -45,3 +38,9 @@ hydrolysis-m3 = { path = "../../../backends/hydrolysis_m3" }
 
 [lints]
 workspace = true
+
+[package.metadata.cargo-machete]
+# The crate-level example is a doctest, and doctests are the one place
+# `cargo machete` does not look. `waterui` is what its `use waterui::prelude::*`
+# resolves against.
+ignored = ["waterui"]

--- a/components/data/mermaid/Cargo.toml
+++ b/components/data/mermaid/Cargo.toml
@@ -11,6 +11,13 @@ keywords = ["mermaid", "diagram", "flowchart", "waterui"]
 categories = ["gui", "visualization"]
 
 [dependencies]
+# `install` claims a fenced code block, and `CodeConfig` — the configuration a
+# fence is hooked through — lives with the `Code` widget in the root crate.
+# Only the `highlight` feature that widget sits behind is selected; the GPU,
+# media and asset stacks a diagram never touches stay out.
+waterui = { path = "../../..", default-features = false, features = [
+    "highlight",
+] }
 waterui-core.workspace = true
 waterui-canvas.workspace = true
 waterui-graphics.workspace = true
@@ -30,15 +37,11 @@ parley = { workspace = true, features = ["system"] }
 thiserror.workspace = true
 
 [dev-dependencies]
-waterui = { path = "../../.." }
+# The tests mount real Markdown, so they need the Markdown stack on top of the
+# `highlight` feature the library half selects.
+waterui = { path = "../../..", features = ["flow-markdown"] }
 waterui-testing = { path = "../../../testing" }
 hydrolysis-m3 = { path = "../../../backends/hydrolysis_m3" }
 
 [lints]
 workspace = true
-
-[package.metadata.cargo-machete]
-# The crate-level example is a doctest, and doctests are the one place
-# `cargo machete` does not look. `waterui` is what its `use waterui::prelude::*`
-# resolves against.
-ignored = ["waterui"]

--- a/components/data/mermaid/src/lib.rs
+++ b/components/data/mermaid/src/lib.rs
@@ -107,8 +107,8 @@ pub fn mermaid(source: impl Into<Str>) -> Mermaid {
 ///
 /// A fence tagged anything else keeps the ordinary [`Code`](waterui::widget::Code)
 /// rendering: `Hook::from` hands the closure an environment with this hook
-/// already removed, so [`ViewConfiguration::render`] cannot recurse back into
-/// it.
+/// already removed, so [`ViewConfiguration::render`](waterui_core::view::ViewConfiguration::render)
+/// cannot recurse back into it.
 pub fn install(env: &mut Environment) {
     if env.get::<Hook<CodeConfig>>().is_some() {
         return;

--- a/components/data/mermaid/src/lib.rs
+++ b/components/data/mermaid/src/lib.rs
@@ -45,8 +45,10 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use nami::SignalExt as _;
+use waterui::widget::code::CodeConfig;
 use waterui_canvas::Canvas;
 use waterui_core::layout::{Layout, Point, ProposalSize, Rect, Size, StretchAxis, SubView};
+use waterui_core::view::{Hook, ViewConfiguration as _};
 use waterui_core::{AnyView, Environment, View, resolve::Resolvable as _};
 use waterui_layout::container::FixedContainer;
 use waterui_str::Str;
@@ -93,6 +95,30 @@ impl Mermaid {
 #[must_use]
 pub fn mermaid(source: impl Into<Str>) -> Mermaid {
     Mermaid::new(source)
+}
+
+/// Installs the realization that turns a `mermaid` fence into a diagram.
+///
+/// Call it from the application's `app(env)`, as with any component that lives
+/// in its own crate — the `waterui` crate does not depend on this one, so
+/// nothing installs this on an application's behalf. A `Hook<CodeConfig>`
+/// already present — a platform bridge, another realization — wins, and this
+/// is a no-op.
+///
+/// A fence tagged anything else keeps the ordinary [`Code`](waterui::widget::Code)
+/// rendering: `Hook::from` hands the closure an environment with this hook
+/// already removed, so [`ViewConfiguration::render`] cannot recurse back into
+/// it.
+pub fn install(env: &mut Environment) {
+    if env.get::<Hook<CodeConfig>>().is_some() {
+        return;
+    }
+    env.insert_hook::<CodeConfig, AnyView>(|_env, config| match config.info.as_deref() {
+        // `mmd` is Mermaid's own file extension, and the tag editors emit for a
+        // Mermaid block alongside the spelled-out one.
+        Some("mermaid" | "mmd") => AnyView::new(Mermaid::new(config.content)),
+        _ => AnyView::new(config.render()),
+    });
 }
 
 impl View for Mermaid {

--- a/components/data/mermaid/src/lib.rs
+++ b/components/data/mermaid/src/lib.rs
@@ -45,13 +45,13 @@ use alloc::format;
 use alloc::vec::Vec;
 
 use nami::SignalExt as _;
-use waterui::widget::code::CodeConfig;
 use waterui_canvas::Canvas;
 use waterui_core::layout::{Layout, Point, ProposalSize, Rect, Size, StretchAxis, SubView};
 use waterui_core::view::{Hook, ViewConfiguration as _};
 use waterui_core::{AnyView, Environment, View, resolve::Resolvable as _};
 use waterui_layout::container::FixedContainer;
 use waterui_str::Str;
+use waterui_text::code::CodeConfig;
 use waterui_text::text;
 
 mod draw;
@@ -105,7 +105,7 @@ pub fn mermaid(source: impl Into<Str>) -> Mermaid {
 /// already present — a platform bridge, another realization — wins, and this
 /// is a no-op.
 ///
-/// A fence tagged anything else keeps the ordinary [`Code`](waterui::widget::Code)
+/// A fence tagged anything else keeps the ordinary [`Code`](waterui_text::code::Code)
 /// rendering: `Hook::from` hands the closure an environment with this hook
 /// already removed, so [`ViewConfiguration::render`](waterui_core::view::ViewConfiguration::render)
 /// cannot recurse back into it.

--- a/components/data/mermaid/tests/e2e_markdown_fence.rs
+++ b/components/data/mermaid/tests/e2e_markdown_fence.rs
@@ -1,0 +1,87 @@
+//! `install` claiming a fence inside a real Markdown document.
+//!
+//! The unit of work here is the whole path: `pulldown-cmark` keeps the info
+//! token, `Code` offers it to the hook, and the hook turns it into a diagram —
+//! while every other fence in the same document is declined and comes back as
+//! an ordinary code block.
+
+use hydrolysis_m3::install as install_m3;
+use waterui::env::use_env;
+use waterui::metadata::Metadata;
+use waterui::prelude::*;
+use waterui::widget::RichText;
+use waterui::widget::code::CodeConfig;
+use waterui_testing::{OffscreenApp, Role, ui as test_ui};
+
+const DOC: &str = "\
+# Pipeline
+
+```mermaid
+flowchart LR
+    Parse --> Layout
+    Layout --> Draw
+```
+
+```rust
+fn main() {}
+```
+";
+
+fn app() -> OffscreenApp {
+    test_ui()
+        .viewport(900, 900)
+        .theme(install_m3)
+        .mount_offscreen(|| {
+            use_env(|mut env: Environment| {
+                waterui_mermaid::install(&mut env);
+                Metadata::new(RichText::from_markdown(DOC), env)
+            })
+        })
+}
+
+#[core::prelude::v1::test]
+fn a_mermaid_fence_becomes_a_diagram() {
+    let mut app = app();
+    for label in ["Parse", "Layout", "Draw"] {
+        app.query().role(Role::LABEL).label(label).assert_exists();
+    }
+}
+
+/// The hook declines every other token, so the `rust` fence keeps the code
+/// block's header. Without this the test above would still pass with a hook
+/// that swallowed the whole document.
+#[core::prelude::v1::test]
+fn every_other_fence_is_still_a_code_block() {
+    let mut app = app();
+    app.query().role(Role::LABEL).label("Rust").assert_exists();
+}
+
+/// A hook already on the environment is the platform's, and wins.
+#[core::prelude::v1::test]
+fn install_yields_to_a_hook_that_is_already_there() {
+    let mut app = test_ui()
+        .viewport(600, 400)
+        .theme(install_m3)
+        .mount_offscreen(|| {
+            use_env(|mut env: Environment| {
+                env.insert_hook::<CodeConfig, AnyView>(|_env, _config| {
+                    AnyView::new(text("bridged"))
+                });
+                waterui_mermaid::install(&mut env);
+                Metadata::new(RichText::from_markdown(DOC), env)
+            })
+        });
+
+    app.query()
+        .role(Role::LABEL)
+        .label("bridged")
+        .assert_exists();
+    assert!(
+        app.query()
+            .role(Role::LABEL)
+            .label("Parse")
+            .all()
+            .is_empty(),
+        "the hook already installed must keep the fence, not hand it to Mermaid"
+    );
+}

--- a/components/foundation/text/Cargo.toml
+++ b/components/foundation/text/Cargo.toml
@@ -21,15 +21,49 @@ syntect = { version = "5", default-features = false, features = ["default-themes
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"], optional = true }
 pulldown-cmark = { version = "0.13", optional = true }
 smallvec.workspace = true
+# `Code`, the fenced-code widget, composes its block out of the layout
+# primitives and reports clipboard failures through `tracing`. Both sit behind
+# `highlight`, the feature the widget itself is behind.
+waterui-layout = { workspace = true, optional = true }
+tracing = { workspace = true, optional = true }
+
+[target.'cfg(target_os = "android")'.dependencies]
+android_clipboard = { version = "0.1.0", optional = true }
+
+# The system clipboard (arboard, via X11 on Linux) does not exist on bare
+# embedded; espidf uses a no-op clipboard in src/code.rs.
+#
+# `code.rs` only ever puts *text* on the pasteboard, so arboard's default
+# `image-data` feature — an image codec plus CoreGraphics on Apple and
+# `Win32_Graphics_Gdi` on Windows — is not built.
+[target.'cfg(all(not(target_os = "android"), not(target_arch = "wasm32"), not(target_os = "espidf")))'.dependencies]
+arboard = { version = "3.6.1", default-features = false, optional = true }
+
+[target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = { version = "0.4", optional = true }
+web-sys = { version = "0.3", features = ["Clipboard", "Navigator", "Window"], optional = true }
+executor-core = { workspace = true, optional = true }
 
 [features]
 default = ["highlight"]
 # `DefaultHighlighter`, the bundled syntect/two-face syntax highlighter, and
-# with it the syntax and theme definitions those two crates carry. `Language`,
-# the `Highlighter` trait and `HighlightChunk` stay unconditional, so an
+# with it the syntax and theme definitions those two crates carry, plus `Code`,
+# the fenced-code widget built on it, with the layout primitives it composes
+# and the platform clipboard its copy button writes to. `Language`, the
+# `Highlighter` trait and `HighlightChunk` stay unconditional, so an
 # application that installs its own highlighter — or renders code plain — can
 # drop the bundled one without losing the vocabulary the rest of the API speaks.
-highlight = ["dep:syntect", "dep:two-face"]
+highlight = [
+    "dep:syntect",
+    "dep:two-face",
+    "dep:waterui-layout",
+    "dep:tracing",
+    "dep:arboard",
+    "dep:android_clipboard",
+    "dep:wasm-bindgen-futures",
+    "dep:web-sys",
+    "dep:executor-core",
+]
 # Markdown parsing: `StyledStr::from_markdown` and the `pulldown-cmark` types
 # its inline builder is driven by.
 markdown = ["dep:pulldown-cmark"]

--- a/components/foundation/text/src/code.rs
+++ b/components/foundation/text/src/code.rs
@@ -1,27 +1,38 @@
+//! A fenced code block: a header naming the language, a copy button, and the
+//! highlighted source.
+//!
+//! `Code` is a text-presentation widget, so it lives beside [`Language`],
+//! [`DefaultHighlighter`] and [`StyledStr`] rather than in the root crate. That
+//! is what lets a component crate claim a fence — install a
+//! [`Hook<CodeConfig>`] — without depending on the aggregator.
+
+use alloc::{
+    rc::Rc,
+    string::{String, ToString},
+};
 use core::error::Error;
-#[cfg(feature = "snackbar")]
-use waterui_core::State;
+use core::fmt;
+
+#[cfg(target_arch = "wasm32")]
+use executor_core::spawn_local;
+use waterui_core::gesture::{GestureObserver, TapGesture};
 use waterui_core::view::{ConfigurableView, Hook, ViewConfiguration};
-use waterui_core::{AnyView, Environment, View};
+use waterui_core::{AnyView, Environment, Metadata, View};
 use waterui_graphics::color::Color;
 use waterui_layout::{
+    background::background,
+    padding::{EdgeInsets, Padding},
     spacer,
     stack::{HorizontalAlignment, VStack, hstack},
 };
 use waterui_str::Str;
-use waterui_text::{
+
+use crate::{
     font::{Body, Font},
     highlight::{DefaultHighlighter, Highlighter, Language},
     styled::{Style, StyledStr},
     text,
 };
-
-#[cfg(target_arch = "wasm32")]
-use executor_core::spawn_local;
-
-use crate::ViewExt;
-#[cfg(feature = "snackbar")]
-use crate::snackbar::{Snackbar, SnackbarManager};
 
 /// Copies text to the system clipboard.
 #[cfg(all(
@@ -72,12 +83,35 @@ fn copy_to_clipboard(text: &str) {
     .detach();
 }
 
+/// What runs after a block's text has landed on the clipboard.
+///
+/// `Code` owns the copy; what to tell the user about it is the caller's — a
+/// snackbar, a status line, nothing. The closure is erased here so
+/// [`Code::on_copied`] can take a plain generic and [`CodeConfig`] can carry
+/// it through a hook that declines the fence.
+#[derive(Clone)]
+pub struct OnCopied(Rc<dyn Fn(&Environment)>);
+
+impl OnCopied {
+    /// Runs the callback against the environment the copy happened in.
+    pub fn call(&self, env: &Environment) {
+        (self.0)(env);
+    }
+}
+
+impl fmt::Debug for OnCopied {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("OnCopied(..)")
+    }
+}
+
 /// View that renders syntax-highlighted code snippets.
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, Clone)]
 pub struct Code {
     info: Option<Str>,
     language: Language,
     content: Str,
+    on_copied: Option<OnCopied>,
 }
 
 impl Code {
@@ -91,6 +125,7 @@ impl Code {
             info: None,
             language: language.try_into().expect("Invalid language"),
             content: content.into(),
+            on_copied: None,
         }
     }
 
@@ -102,6 +137,16 @@ impl Code {
     #[must_use]
     pub fn info(mut self, info: impl Into<Str>) -> Self {
         self.info = Some(info.into());
+        self
+    }
+
+    /// Runs after the block's text has been copied to the clipboard.
+    ///
+    /// `Code` owns the copy; what to tell the user about it is the caller's —
+    /// a snackbar, a status line, nothing. Without one, copying is silent.
+    #[must_use]
+    pub fn on_copied(mut self, callback: impl Fn(&Environment) + 'static) -> Self {
+        self.on_copied = Some(OnCopied(Rc::new(callback)));
         self
     }
 }
@@ -120,6 +165,9 @@ pub struct CodeConfig {
     pub language: Language,
     /// The block's text, verbatim.
     pub content: Str,
+    /// The caller's feedback for a copy, if it asked for any. Carried so a hook
+    /// that declines the fence and renders the default keeps it.
+    pub on_copied: Option<OnCopied>,
 }
 
 impl ViewConfiguration for CodeConfig {
@@ -130,6 +178,7 @@ impl ViewConfiguration for CodeConfig {
             info: self.info,
             language: self.language,
             content: self.content,
+            on_copied: self.on_copied,
         }
     }
 }
@@ -142,6 +191,7 @@ impl ConfigurableView for Code {
             info: self.info,
             language: self.language,
             content: self.content,
+            on_copied: self.on_copied,
         }
     }
 }
@@ -168,6 +218,7 @@ fn default_rendering(config: CodeConfig) -> impl View {
         info: _,
         language,
         content,
+        on_copied,
     } = config;
     let lang_name = language.to_string();
     let content_for_copy = content.to_string();
@@ -185,42 +236,37 @@ fn default_rendering(config: CodeConfig) -> impl View {
         s
     });
 
-    // Code block with dark background, left-aligned content. Copy
-    // feedback is presented through the window's SnackbarManager (a
-    // semantic object owned by the runtime) instead of view-local state.
-    VStack::new(
+    // Code block with dark background, left-aligned content.
+    let block = VStack::new(
         HorizontalAlignment::Leading,
         8.0,
         (
             hstack((
                 text(lang_name)
                     .bold()
-                    .foreground(Color::srgb_f32(0.85, 0.86, 0.9)),
+                    .color(Color::srgb_f32(0.85, 0.86, 0.9)),
                 spacer(),
-                copy_button(content_for_copy),
+                copy_button(content_for_copy, on_copied),
             )),
             text(styled),
         ),
+    );
+    background(
+        Padding::new(EdgeInsets::all(14.0), block),
+        Color::srgb_f32(0.15, 0.15, 0.18),
     )
-    .padding()
-    .background(Color::srgb_f32(0.15, 0.15, 0.18))
 }
 
-#[cfg(feature = "snackbar")]
-fn copy_button(content: String) -> impl View {
-    text("Copy")
-        .foreground(Color::srgb_f32(0.72, 0.74, 0.8))
-        .on_tap(move |State(snackbar): State<SnackbarManager>| {
+fn copy_button(content: String, on_copied: Option<OnCopied>) -> impl View {
+    Metadata::new(
+        text("Copy").color(Color::srgb_f32(0.72, 0.74, 0.8)),
+        GestureObserver::new(TapGesture::new(), move |env: Environment| {
             copy_to_clipboard(&content);
-            snackbar.show(Snackbar::new("Copied to clipboard"));
-        })
-}
-
-#[cfg(not(feature = "snackbar"))]
-fn copy_button(content: String) -> impl View {
-    text("Copy")
-        .foreground(Color::srgb_f32(0.72, 0.74, 0.8))
-        .on_tap(move || copy_to_clipboard(&content))
+            if let Some(on_copied) = &on_copied {
+                on_copied.call(&env);
+            }
+        }),
+    )
 }
 
 /// Convenience constructor for creating a [`Code`] view inline.

--- a/components/foundation/text/src/lib.rs
+++ b/components/foundation/text/src/lib.rs
@@ -10,6 +10,8 @@
 
 extern crate alloc;
 
+#[cfg(feature = "highlight")]
+pub mod code;
 /// Font utilities and definitions.
 pub mod font;
 /// Syntax highlighting support.
@@ -19,5 +21,7 @@ pub mod styled;
 
 /// Core text component.
 pub mod text;
+#[cfg(feature = "highlight")]
+pub use code::{Code, CodeConfig, OnCopied, code};
 pub use styled::StyledStr;
 pub use text::{Formatter, IntoText, Text, TextConfig, text};

--- a/examples/markdown/Cargo.toml
+++ b/examples/markdown/Cargo.toml
@@ -16,3 +16,6 @@ dev = ["waterui/dynamic_linking"]
 [dependencies]
 # `include_markdown!` and `RichText` live behind `flow-markdown`.
 waterui = { workspace = true, features = ["flow-markdown"] }
+# The realization that turns a ```mermaid fence into a diagram. `waterui` does
+# not depend on it — the example installs it, which is the point of the hook.
+waterui-mermaid.workspace = true

--- a/examples/markdown/src/example.md
+++ b/examples/markdown/src/example.md
@@ -29,6 +29,18 @@ struct ContentView: View {
 }
 ```
 
+## Diagrams
+
+A fence tagged `mermaid` is claimed by `waterui-mermaid` and drawn as a diagram;
+every other fence stays a code block.
+
+```mermaid
+flowchart TD
+    A[Markdown] --> B{Fence tagged?}
+    B -->|mermaid| C([Diagram])
+    B -->|rust| D[Code block]
+```
+
 ## Lists
 
 ### Unordered List

--- a/examples/markdown/src/lib.rs
+++ b/examples/markdown/src/lib.rs
@@ -1,11 +1,21 @@
 //! Markdown example for WaterUI.
 use waterui::app::App;
+use waterui::env::use_env;
+use waterui::metadata::Metadata;
 use waterui::prelude::*;
 use waterui::preview;
 
 #[preview]
 pub fn demo() -> impl View {
-    scroll(include_markdown!("example.md").padding())
+    // Installing the Mermaid realization is the application's job — `waterui`
+    // has no dependency on `waterui-mermaid`, which is what lets a build that
+    // does not want diagrams render the fence as plain code. It goes here
+    // rather than in `app` because `water preview` renders this function
+    // directly, so one site serves both entry points.
+    use_env(|mut env: Environment| {
+        waterui_mermaid::install(&mut env);
+        Metadata::new(scroll(include_markdown!("example.md").padding()), env)
+    })
 }
 
 pub fn app(env: Environment) -> App {

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -55,18 +55,11 @@ waterkit-haptic = { workspace = true, optional = true }
 waterui-video-gpu = { workspace = true, optional = true }
 
 pastey.workspace = true
+# The document parser `FlowMarkdown` re-parses incrementally as a stream
+# arrives. Only the Markdown grammar: fenced code is highlighted by the `Code`
+# widget through syntect, not by a per-language tree-sitter grammar.
 tree-sitter = { version = "0.26", optional = true }
 tree-sitter-md = { version = "0.5.3", optional = true }
-tree-sitter-rust = { version = "0.24", optional = true }
-tree-sitter-javascript = { version = "0.25", optional = true }
-tree-sitter-typescript = { version = "0.23", optional = true }
-tree-sitter-python = { version = "0.25", optional = true }
-tree-sitter-go = { version = "0.25", optional = true }
-tree-sitter-java = { version = "0.23", optional = true }
-tree-sitter-swift = { version = "0.7", optional = true }
-tree-sitter-json = { version = "0.24", optional = true }
-tree-sitter-bash = { version = "0.25", optional = true }
-tree-sitter-sequel = { version = "0.3.11", optional = true }
 
 [target.'cfg(target_os = "android")'.dependencies]
 android_clipboard = "0.1.0"
@@ -151,9 +144,9 @@ webview = ["dep:waterui-webview"]
 navigation-restoration = ["waterui-navigation/serde"]
 # Markdown rendering: `RichText` and `include_markdown!`, which parse CommonMark
 # with `pulldown-cmark`, plus `FlowMarkdown`'s streaming renderer, which
-# re-highlights fenced code with tree-sitter grammars. Off by default — a
-# CommonMark parser and a dozen grammars are a lot of binary for an application
-# that shows no Markdown.
+# re-parses the document incrementally with the tree-sitter Markdown grammar.
+# Off by default — a CommonMark parser and a document grammar are a lot of
+# binary for an application that shows no Markdown.
 flow-markdown = [
     "dep:pulldown-cmark",
     "waterui-text/markdown",
@@ -161,16 +154,6 @@ flow-markdown = [
     "highlight",
     "dep:tree-sitter",
     "dep:tree-sitter-md",
-    "dep:tree-sitter-rust",
-    "dep:tree-sitter-javascript",
-    "dep:tree-sitter-typescript",
-    "dep:tree-sitter-python",
-    "dep:tree-sitter-go",
-    "dep:tree-sitter-java",
-    "dep:tree-sitter-swift",
-    "dep:tree-sitter-json",
-    "dep:tree-sitter-bash",
-    "dep:tree-sitter-sequel",
 ]
 # Mathematical formulas in Markdown: `$…$` and `$$…$$` are parsed and typeset
 # through `waterui-math`. Off by default, and deliberately so — it brings a

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -61,18 +61,6 @@ pastey.workspace = true
 tree-sitter = { version = "0.26", optional = true }
 tree-sitter-md = { version = "0.5.3", optional = true }
 
-[target.'cfg(target_os = "android")'.dependencies]
-android_clipboard = "0.1.0"
-
-# The system clipboard (arboard, via X11 on Linux) does not exist on bare
-# embedded; espidf uses a no-op clipboard in widget/code.rs.
-#
-# `widget/code.rs` only ever puts *text* on the pasteboard, so arboard's
-# default `image-data` feature — an image codec plus CoreGraphics on Apple and
-# `Win32_Graphics_Gdi` on Windows — is not built.
-[target.'cfg(all(not(target_os = "android"), not(target_arch = "wasm32"), not(target_os = "espidf")))'.dependencies]
-arboard = { version = "3.6.1", default-features = false }
-
 # Opening a URL in a system handler (robius-open) has no meaning on bare
 # embedded; espidf uses a no-op in component/link.rs.
 [target.'cfg(not(target_os = "espidf"))'.dependencies]
@@ -82,10 +70,6 @@ robius-open.workspace = true
 # newlib; the runtime guard uses a zero-cost fallback there.
 [target.'cfg(all(any(unix, windows), not(target_os = "espidf")))'.dependencies]
 cpu-time.workspace = true
-
-[target.'cfg(target_arch = "wasm32")'.dependencies]
-wasm-bindgen-futures = "0.4"
-web-sys = { version = "0.3", features = ["Clipboard", "Navigator", "Window"] }
 
 [features]
 default = [

--- a/src/widget/code.rs
+++ b/src/widget/code.rs
@@ -1,7 +1,8 @@
 use core::error::Error;
 #[cfg(feature = "snackbar")]
 use waterui_core::State;
-use waterui_core::View;
+use waterui_core::view::{ConfigurableView, Hook, ViewConfiguration};
+use waterui_core::{AnyView, Environment, View};
 use waterui_graphics::color::Color;
 use waterui_layout::{
     spacer,
@@ -74,6 +75,7 @@ fn copy_to_clipboard(text: &str) {
 /// View that renders syntax-highlighted code snippets.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Code {
+    info: Option<Str>,
     language: Language,
     content: Str,
 }
@@ -86,50 +88,122 @@ impl Code {
     /// Panics if the language cannot be converted into a supported [`Language`].
     pub fn new(language: impl TryInto<Language, Error: Error>, content: impl Into<Str>) -> Self {
         Self {
+            info: None,
             language: language.try_into().expect("Invalid language"),
             content: content.into(),
+        }
+    }
+
+    /// Records the fence's info token as the author wrote it.
+    ///
+    /// Markdown calls this so a realization can claim a token no [`Language`]
+    /// answers to — `mermaid`, `plantuml`, `vega` — which would otherwise be
+    /// indistinguishable from a fence carrying no info string at all.
+    #[must_use]
+    pub fn info(mut self, info: impl Into<Str>) -> Self {
+        self.info = Some(info.into());
+        self
+    }
+}
+
+/// Everything a fenced code block is, before anything decides how to show it.
+///
+/// An application claims a fence by installing a [`Hook<CodeConfig>`] on its
+/// environment; a hook that does not recognise [`info`](Self::info) calls
+/// [`ViewConfiguration::render`] to get the ordinary code block back.
+#[derive(Debug, Clone)]
+pub struct CodeConfig {
+    /// The fence's info token as written (`mermaid`, `rust`, …), if it had one.
+    pub info: Option<Str>,
+    /// The language that token resolved to; [`Language::Plaintext`] when it
+    /// resolved to nothing.
+    pub language: Language,
+    /// The block's text, verbatim.
+    pub content: Str,
+}
+
+impl ViewConfiguration for CodeConfig {
+    type View = Code;
+
+    fn render(self) -> Self::View {
+        Code {
+            info: self.info,
+            language: self.language,
+            content: self.content,
+        }
+    }
+}
+
+impl ConfigurableView for Code {
+    type Config = CodeConfig;
+
+    fn config(self) -> Self::Config {
+        CodeConfig {
+            info: self.info,
+            language: self.language,
+            content: self.content,
         }
     }
 }
 
 impl View for Code {
-    fn body(self, _env: &waterui_core::Environment) -> impl View {
-        let lang_name = self.language.to_string();
-        let content_for_copy = self.content.to_string();
-        let mut highlighter = DefaultHighlighter::new();
-        let chunks = highlighter.highlight(self.language, &self.content);
-
-        let code_font = Font::from(Body).size(14.0);
-        let styled = chunks.into_iter().fold(StyledStr::empty(), |mut s, chunk| {
-            s.push(
-                chunk.text.to_string(),
-                Style::default()
-                    .foreground(chunk.color)
-                    .font(code_font.clone()),
-            );
-            s
-        });
-
-        // Code block with dark background, left-aligned content. Copy
-        // feedback is presented through the window's SnackbarManager (a
-        // semantic object owned by the runtime) instead of view-local state.
-        VStack::new(
-            HorizontalAlignment::Leading,
-            8.0,
-            (
-                hstack((
-                    text(lang_name)
-                        .bold()
-                        .foreground(Color::srgb_f32(0.85, 0.86, 0.9)),
-                    spacer(),
-                    copy_button(content_for_copy),
-                )),
-                text(styled),
-            ),
-        )
-        .padding()
-        .background(Color::srgb_f32(0.15, 0.15, 0.18))
+    fn body(self, env: &Environment) -> impl View {
+        let config = self.config();
+        // `Hook::from` removes the hook from the environment it hands to the
+        // closure, so a realization that does not recognise the info token can
+        // call `config.render()` and get this default rendering back without
+        // recursing into itself.
+        if let Some(hook) = env.get::<Hook<CodeConfig>>() {
+            AnyView::new(hook.apply(env, config))
+        } else {
+            AnyView::new(default_rendering(config))
+        }
     }
+}
+
+/// What a fence looks like when nothing claims it: a header naming the
+/// language, a copy button, and the highlighted source.
+fn default_rendering(config: CodeConfig) -> impl View {
+    let CodeConfig {
+        info: _,
+        language,
+        content,
+    } = config;
+    let lang_name = language.to_string();
+    let content_for_copy = content.to_string();
+    let mut highlighter = DefaultHighlighter::new();
+    let chunks = highlighter.highlight(language, &content);
+
+    let code_font = Font::from(Body).size(14.0);
+    let styled = chunks.into_iter().fold(StyledStr::empty(), |mut s, chunk| {
+        s.push(
+            chunk.text.to_string(),
+            Style::default()
+                .foreground(chunk.color)
+                .font(code_font.clone()),
+        );
+        s
+    });
+
+    // Code block with dark background, left-aligned content. Copy
+    // feedback is presented through the window's SnackbarManager (a
+    // semantic object owned by the runtime) instead of view-local state.
+    VStack::new(
+        HorizontalAlignment::Leading,
+        8.0,
+        (
+            hstack((
+                text(lang_name)
+                    .bold()
+                    .foreground(Color::srgb_f32(0.85, 0.86, 0.9)),
+                spacer(),
+                copy_button(content_for_copy),
+            )),
+            text(styled),
+        ),
+    )
+    .padding()
+    .background(Color::srgb_f32(0.15, 0.15, 0.18))
 }
 
 #[cfg(feature = "snackbar")]

--- a/src/widget/flow_markdown.rs
+++ b/src/widget/flow_markdown.rs
@@ -20,17 +20,11 @@ use waterui_core::{
     dynamic::{Dynamic, DynamicHandler},
     id::Identifiable,
 };
-use waterui_graphics::color::Srgb;
 use waterui_layout::stack::{HorizontalAlignment, VStack};
 use waterui_str::Str;
-use waterui_text::{
-    highlight::Language,
-    styled::{Style, StyledStr},
-    text,
-};
+use waterui_text::styled::StyledStr;
 
 use crate::{
-    ViewExt,
     animation::Animation,
     widget::rich_text::{RichText, RichTextElement},
 };
@@ -1513,12 +1507,7 @@ fn build_flow_block_view(
 }
 
 fn push_rich_text_element_view(views: &mut Vec<AnyView>, element: RichTextElement) {
-    match element {
-        RichTextElement::Code { code, language } => {
-            views.push(AnyView::new(flow_code_view(&language, code.as_str())));
-        }
-        _ => views.push(AnyView::new(element)),
-    }
+    views.push(AnyView::new(element));
 }
 
 fn has_typewriter_policy_for_kind(kind: FlowElementKind, config: &FlowMarkdownConfig) -> bool {
@@ -1687,123 +1676,6 @@ fn truncate_styled(styled: &StyledStr, max_chars: usize) -> StyledStr {
     out
 }
 
-fn flow_code_view(language: &Language, code: &str) -> impl View {
-    let highlighted = highlight_code_with_tree_sitter(language, code);
-    VStack::new(
-        HorizontalAlignment::Leading,
-        6.0,
-        (text("Code").caption(), text(highlighted)),
-    )
-    .padding()
-    .background(Srgb::new_u8(23, 26, 30))
-}
-
-fn highlight_code_with_tree_sitter(language: &Language, code: &str) -> StyledStr {
-    let Some(ts_language) = language_to_tree_sitter(language) else {
-        return code_monospace_plain(code);
-    };
-
-    let mut parser = Parser::new();
-    if parser.set_language(&ts_language).is_err() {
-        return code_monospace_plain(code);
-    }
-
-    let Some(tree) = parser.parse(code, None) else {
-        return code_monospace_plain(code);
-    };
-
-    let mut tokens = Vec::new();
-    collect_leaf_tokens(tree.root_node(), &mut tokens);
-    tokens.sort_by_key(|(start, _, _)| *start);
-
-    let mut styled = StyledStr::empty();
-    let mut cursor = 0usize;
-    for (start, end, kind) in tokens {
-        if start > cursor
-            && let Some(fragment) = code.get(cursor..start)
-        {
-            styled.push(fragment.to_string(), code_base_style());
-        }
-        if end > start
-            && let Some(fragment) = code.get(start..end)
-        {
-            styled.push(fragment.to_string(), style_for_token_kind(&kind));
-            cursor = end;
-        }
-    }
-
-    if cursor < code.len()
-        && let Some(fragment) = code.get(cursor..)
-    {
-        styled.push(fragment.to_string(), code_base_style());
-    }
-
-    if styled.is_empty() {
-        code_monospace_plain(code)
-    } else {
-        styled
-    }
-}
-
-fn collect_leaf_tokens(node: tree_sitter::Node<'_>, out: &mut Vec<(usize, usize, String)>) {
-    if node.child_count() == 0 {
-        out.push((node.start_byte(), node.end_byte(), node.kind().to_string()));
-        return;
-    }
-
-    let mut cursor = node.walk();
-    for child in node.children(&mut cursor) {
-        collect_leaf_tokens(child, out);
-    }
-}
-
-fn code_monospace_plain(code: &str) -> StyledStr {
-    let mut styled = StyledStr::empty();
-    styled.push(code.to_string(), code_base_style());
-    styled
-}
-
-fn code_base_style() -> Style {
-    Style::default()
-        .font(waterui_text::font::Font::from(waterui_text::font::Body).family("monospace"))
-        .foreground(Srgb::new_u8(224, 232, 240))
-}
-
-fn style_for_token_kind(kind: &str) -> Style {
-    let base = code_base_style();
-    if kind.contains("comment") {
-        base.foreground(Srgb::new_u8(141, 153, 168))
-    } else if kind.contains("string") {
-        base.foreground(Srgb::new_u8(152, 195, 121))
-    } else if kind.contains("number") {
-        base.foreground(Srgb::new_u8(209, 154, 102))
-    } else if kind.contains("keyword")
-        || kind.contains("operator")
-        || kind.contains("modifier")
-        || kind.contains("type")
-    {
-        base.foreground(Srgb::new_u8(97, 175, 239))
-    } else {
-        base
-    }
-}
-
-fn language_to_tree_sitter(language: &Language) -> Option<tree_sitter::Language> {
-    match language {
-        Language::Rust => Some(tree_sitter_rust::LANGUAGE.into()),
-        Language::Javascript => Some(tree_sitter_javascript::LANGUAGE.into()),
-        Language::Typescript => Some(tree_sitter_typescript::LANGUAGE_TYPESCRIPT.into()),
-        Language::Python => Some(tree_sitter_python::LANGUAGE.into()),
-        Language::Go => Some(tree_sitter_go::LANGUAGE.into()),
-        Language::Java => Some(tree_sitter_java::LANGUAGE.into()),
-        Language::Swift => Some(tree_sitter_swift::LANGUAGE.into()),
-        Language::Json => Some(tree_sitter_json::LANGUAGE.into()),
-        Language::Bash => Some(tree_sitter_bash::LANGUAGE.into()),
-        Language::Sql => Some(tree_sitter_sequel::LANGUAGE.into()),
-        _ => None,
-    }
-}
-
 fn is_incomplete_table(markdown: &str) -> bool {
     let lines: Vec<&str> = markdown
         .lines()
@@ -1922,6 +1794,8 @@ fn advance_point(mut point: Point, text: &str) -> Point {
 
 #[cfg(test)]
 mod tests {
+    use waterui_text::styled::Style;
+
     use super::*;
 
     #[test]

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -10,9 +10,11 @@ pub use card::{Card, CardStyle, CardStyleTokens, CardTheme, card};
 pub use suspense::{Suspense, suspense};
 // pub use tree::{TreeNode, TreeView, tree_view};
 
-/// Syntax highlighted code widget.
+/// Syntax highlighted code widget. It lives in `waterui-text` so a component
+/// crate can claim a fence through `Hook<CodeConfig>` without depending on
+/// this crate; the path here is kept for application code.
 #[cfg(feature = "highlight")]
-pub mod code;
+pub use waterui_text::code;
 /// Rich text widget support.
 #[cfg(feature = "flow-markdown")]
 #[macro_use]
@@ -20,8 +22,10 @@ pub mod rich_text;
 #[cfg(feature = "flow-markdown")]
 /// Streaming Markdown renderer with incremental flow animations.
 pub mod flow_markdown;
+// `waterui_text::code` is both the module and the `code(..)` constructor, so
+// the `use` above already brings the function in; only the type is left.
 #[cfg(feature = "highlight")]
-pub use code::{Code, code};
+pub use code::Code;
 #[cfg(feature = "flow-markdown")]
 pub use flow_markdown::{
     FlowAnimationPolicy, FlowAnimationPreset, FlowElementKind, FlowMarkdown, FlowStreamMode,

--- a/src/widget/rich_text.rs
+++ b/src/widget/rich_text.rs
@@ -2,6 +2,8 @@ use std::{mem, num::NonZeroUsize, str::FromStr};
 
 use pulldown_cmark::{Alignment, CodeBlockKind, Event, Options, Parser, Tag};
 use waterui_core::{AnyView, Environment, View};
+#[cfg(feature = "snackbar")]
+use waterui_core::{State, extract::Extractor as _};
 use waterui_graphics::color::Blue;
 use waterui_layout::{
     Layout, Point, ProposalSize, Rect, Size, StretchAxis, SubView, ViewDimensions,
@@ -18,6 +20,8 @@ use waterui_text::{
     text,
 };
 
+#[cfg(feature = "snackbar")]
+use crate::snackbar::{Snackbar, SnackbarManager};
 use crate::{ViewExt, widget::Divider};
 
 /// Rich text widget for displaying formatted content.
@@ -192,10 +196,21 @@ impl View for RichTextElement {
                 language,
             } => {
                 let view = crate::widget::code(language, code);
-                AnyView::new(match info {
+                let view = match info {
                     Some(info) => view.info(info),
                     None => view,
-                })
+                };
+                // Copy feedback goes through the window's `SnackbarManager`, a
+                // semantic object the runtime owns. `Code` cannot name it — it
+                // lives in `waterui-text` — and this is the one place a fence
+                // is rendered from Markdown, so the snackbar coupling is here.
+                #[cfg(feature = "snackbar")]
+                let view = view.on_copied(|env| {
+                    let State(snackbar) = State::<SnackbarManager>::extract(env)
+                        .expect("the window's environment carries its SnackbarManager");
+                    snackbar.show(Snackbar::new("Copied to clipboard"));
+                });
+                AnyView::new(view)
             }
             Self::Quote { content } => AnyView::new(quote(content)),
             Self::Group { elements, inline } => {

--- a/src/widget/rich_text.rs
+++ b/src/widget/rich_text.rs
@@ -127,6 +127,14 @@ pub enum RichTextElement {
     Code {
         /// The code content.
         code: Str,
+        /// The fence's info token as written, before it was resolved to a
+        /// [`Language`]; what a realization dispatches on.
+        ///
+        /// `None` for an indented block and for a fence with an empty info
+        /// string. A token no [`Language`] recognises — `mermaid`, say —
+        /// survives here even though `language` resolved to
+        /// [`Language::Plaintext`].
+        info: Option<Str>,
         /// Optional language specification.
         language: Language,
     },
@@ -178,7 +186,17 @@ impl View for RichTextElement {
                 ordered,
                 start,
             } => AnyView::new(render_list(items.as_slice(), ordered, start)),
-            Self::Code { code, language } => AnyView::new(crate::widget::code(language, code)),
+            Self::Code {
+                code,
+                info,
+                language,
+            } => {
+                let view = crate::widget::code(language, code);
+                AnyView::new(match info {
+                    Some(info) => view.info(info),
+                    None => view,
+                })
+            }
             Self::Quote { content } => AnyView::new(quote(content)),
             Self::Group { elements, inline } => {
                 if inline {
@@ -572,6 +590,7 @@ fn parse_markdown(markdown: &str) -> Vec<RichTextElement> {
                     flush_list_item_inline(&mut stack);
                     let language = language_from_kind(&kind);
                     stack.push(Container::CodeBlock {
+                        info: info_from_kind(&kind),
                         language,
                         code: String::new(),
                     });
@@ -694,10 +713,16 @@ fn parse_markdown(markdown: &str) -> Vec<RichTextElement> {
                     }
                 }
                 pulldown_cmark::TagEnd::CodeBlock => {
-                    if let Some(Container::CodeBlock { language, code }) = stack.pop() {
+                    if let Some(Container::CodeBlock {
+                        info,
+                        language,
+                        code,
+                    }) = stack.pop()
+                    {
                         push_to_parent(
                             &mut stack,
                             RichTextElement::Code {
+                                info,
                                 language,
                                 code: code.into(),
                             },
@@ -883,6 +908,22 @@ fn parse_markdown(markdown: &str) -> Vec<RichTextElement> {
     match stack.pop() {
         Some(Container::Root(elements)) => elements,
         _ => Vec::new(),
+    }
+}
+
+/// The fence's info token as the author wrote it.
+///
+/// `language_from_kind` throws this away whenever no [`Language`] answers to
+/// it, which is exactly the case a realization needs to see: a ` ```mermaid `
+/// fence and an untagged one both resolve to [`Language::Plaintext`] and are
+/// told apart only by this token.
+fn info_from_kind(kind: &CodeBlockKind) -> Option<Str> {
+    match kind {
+        CodeBlockKind::Fenced(info) => info
+            .split_whitespace()
+            .next()
+            .map(|token| Str::from(token.to_owned())),
+        CodeBlockKind::Indented => None,
     }
 }
 
@@ -1091,6 +1132,7 @@ enum Container {
         alt: MarkdownInlineBuilder,
     },
     CodeBlock {
+        info: Option<Str>,
         language: Language,
         code: String,
     },
@@ -1319,6 +1361,46 @@ fn main() {
             .iter()
             .any(|el| matches!(el, RichTextElement::Code { .. }));
         assert!(has_code, "Expected a Code element in the parsed markdown");
+    }
+
+    /// The fence's info token, not the [`Language`] it resolved to.
+    ///
+    /// `mermaid` is the case that matters: no [`Language`] answers to it, so
+    /// the resolved language is [`Language::Plaintext`] — exactly what an
+    /// untagged fence resolves to. Only the preserved token tells the two
+    /// apart, and a realization has nothing else to dispatch on.
+    fn only_code_block(markdown: &str) -> (Option<Str>, Language) {
+        RichText::from_markdown(markdown)
+            .elements()
+            .iter()
+            .find_map(|el| match el {
+                RichTextElement::Code { info, language, .. } => {
+                    Some((info.clone(), language.clone()))
+                }
+                _ => None,
+            })
+            .expect("expected a code block")
+    }
+
+    #[test]
+    fn an_unrecognised_info_token_survives_as_written() {
+        let (info, language) = only_code_block("```mermaid\nflowchart TD\n  A --> B\n```\n");
+        assert_eq!(info.as_deref(), Some("mermaid"));
+        assert_eq!(language, Language::Plaintext);
+    }
+
+    #[test]
+    fn a_recognised_info_token_is_kept_alongside_its_language() {
+        let (info, language) = only_code_block("```rust\nfn main() {}\n```\n");
+        assert_eq!(info.as_deref(), Some("rust"));
+        assert_eq!(language, Language::Rust);
+    }
+
+    #[test]
+    fn an_indented_block_has_no_info_token() {
+        let (info, language) = only_code_block("    fn main() {}\n");
+        assert_eq!(info, None);
+        assert_eq!(language, Language::Plaintext);
     }
 
     #[test]

--- a/tests/markdown_code_fences.rs
+++ b/tests/markdown_code_fences.rs
@@ -1,0 +1,72 @@
+//! Who gets to decide what a fenced code block looks like.
+//!
+//! A fence carries an info token the author wrote — `rust`, `mermaid`,
+//! `puzzle` — and only one of those resolves to a `Language`. Before
+//! `CodeConfig`, the other two were indistinguishable from a fence with no info
+//! string at all, so nothing could claim them. These assertions are about the
+//! token surviving far enough for a hook to dispatch on it, and about the
+//! default rendering staying exactly what it was for every fence a hook
+//! declines.
+#![cfg(feature = "flow-markdown")]
+
+use hydrolysis_m3::install as install_m3;
+use waterui::ViewExt as _;
+use waterui::env::use_env;
+use waterui::metadata::Metadata;
+use waterui::prelude::*;
+use waterui::view::ViewConfiguration as _;
+use waterui::widget::code::CodeConfig;
+use waterui::widget::{RichText, flow_markdown};
+use waterui_testing::UiBuilder;
+
+/// One fence a `Language` answers to and one it does not.
+const DOC: &str = "\
+```rust
+fn main() {}
+```
+
+```puzzle
+this is not a programming language
+```
+";
+
+/// The `Code` widget names its language in its header, which is the assertion
+/// `FlowMarkdown`'s old parallel path could never have passed: it captioned
+/// every block \"Code\" and put the language nowhere.
+#[waterui::test(viewport = (700, 900), theme = install_m3)]
+fn an_unclaimed_fence_names_its_language(ui: UiBuilder) {
+    let mut app = ui.mount(|| RichText::from_markdown(DOC));
+
+    app.query().label("Rust").assert_exists();
+    app.query().label("Copy").assert_exists();
+}
+
+/// A hook sees the token as written and claims the one it recognises. The
+/// `rust` fence in the same document goes through the same hook, is declined,
+/// and comes back as the ordinary code block — `Hook::from` having removed the
+/// hook from the environment it handed the closure, so `render()` does not
+/// recurse.
+#[waterui::test(viewport = (700, 900), theme = install_m3)]
+fn a_hook_claims_only_the_token_it_recognises(ui: UiBuilder) {
+    let mut app = ui.mount(|| {
+        use_env(|mut env: Environment| {
+            env.insert_hook::<CodeConfig, AnyView>(|_env, config| match config.info.as_deref() {
+                Some("puzzle") => AnyView::new(text("solved").a11y_label("claimed")),
+                _ => AnyView::new(config.render()),
+            });
+            Metadata::new(RichText::from_markdown(DOC), env)
+        })
+    });
+
+    app.query().label("claimed").assert_exists();
+    app.query().label("Rust").assert_exists();
+}
+
+/// A streamed document renders its fences through the same `Code` widget, so
+/// the hook covers it too and the language reaches the accessibility tree.
+#[waterui::test(viewport = (700, 900), theme = install_m3)]
+fn a_fence_in_flow_markdown_names_its_language(ui: UiBuilder) {
+    let mut app = ui.mount(|| flow_markdown(DOC));
+
+    app.query().label("Rust").assert_exists();
+}


### PR DESCRIPTION
Fixes #216. Fixes #262.

A fence tagged ` ```mermaid ` now becomes a diagram, without the root `waterui`
crate depending on `waterui-mermaid`.

## The info string was being thrown away

`language_from_kind` resolved the fence's info string to a `Language` and
discarded the token. `Language` is a closed enum with no `mermaid` variant, so
` ```mermaid ` resolved to `Language::Plaintext` — the same thing an untagged
fence resolves to. Nothing downstream had anything left to dispatch on.

`Container::CodeBlock` and `RichTextElement::Code` now carry
`info: Option<Str>` alongside the `Language`, which is unchanged. Indented
blocks and empty info strings are `None`.

## `Code` is a `ConfigurableView`

`CodeConfig { info, language, content }`, with `Code`'s body consulting
`Hook<CodeConfig>`. Hand-written on the `Button` pattern rather than generated
by `configurable!`, whose fallback wraps the config in `Native::new(..)` —
`Code` is a Rust-side composition, not a native leaf. `Hook::from` removes the
hook from the environment it hands the closure, so a realization that declines
a token calls `config.render()` and gets the default back without recursing.
With no hook installed, the rendering is what it was.

## FlowMarkdown's second path is gone (#262)

`flow_code_view` captioned every block "Code" at 1.02:1 contrast on a
hard-coded background, and highlighted with a tree-sitter table that knew ten
languages. It was not incremental — `recompute` rebuilds every element's view
on each update, so it re-highlighted the whole block on every change exactly as
`Code` does. Deleted, along with `highlight_code_with_tree_sitter`,
`language_to_tree_sitter` and the four helpers only they used. Streamed
documents now go through `Code`, so the hook covers them too.

The ten grammar crates that existed only for that table are removed from
`src/Cargo.toml` and from the `flow-markdown` feature: `tree-sitter-rust`,
`-javascript`, `-typescript`, `-python`, `-go`, `-java`, `-swift`, `-json`,
`-bash`, `-sequel`. `tree-sitter` and `tree-sitter-md` stay — they are the
document parser, not a highlighter.

## `waterui-mermaid` claims the fence

`waterui_mermaid::install(&mut env)`, on the `waterui-map-gpu` shape:
app-level, idempotent, yielding to a hook that is already there so a platform
bridge wins. Not wired into `src/runtime/realization.rs` — `waterui` depends on
no diagram crate, which is the point.

`examples/markdown` proves it end to end: a `mermaid` flowchart next to the
existing `rust` and `swift` fences, rendered through
`water preview demo --backend hydrolysis --theme material3`. The diagram draws
as boxes, a diamond and labelled arrows; the `rust` fence keeps its "Rust"
header and syntax colours.

## Tests

- `rich_text.rs`: an unrecognised token survives as written, a recognised one
  is kept alongside its language, an indented block has none.
- `tests/markdown_code_fences.rs`: an unclaimed fence names its language; a
  hook claims only the token it recognises and the `rust` fence in the same
  document still gets the default; a fence in `FlowMarkdown` names its
  language — the assertion that would have caught #262, since the old path put
  the language nowhere.
- `waterui-mermaid`: a `mermaid` fence in real Markdown becomes a diagram whose
  node labels are accessible, every other fence stays a code block, and
  `install` yields to a hook already present.


## Layering: `Code` moved into `waterui-text`

Review raised that this PR made `waterui-mermaid` the only component crate
with `waterui` as a normal dependency, because `CodeConfig` lived in
`src/widget/code.rs`. A component depending on the aggregator inverts the
layering and would block extracting the crate into its own repository.

Resolved in the same PR: `Code`, `CodeConfig` and the clipboard code move to
`waterui-text` (`components/foundation/text/src/code.rs`, behind
`highlight`), beside `Language`, `DefaultHighlighter` and `StyledStr`. The
root crate re-exports the module, so `waterui::widget::code::{Code,
CodeConfig, code}` and `waterui::widget::{Code, code}` keep resolving. The
snackbar coupling is replaced by `Code::on_copied(impl Fn(&Environment))`,
carried on `CodeConfig`; the `RichTextElement::Code` arm in `rich_text.rs`
attaches the "Copied to clipboard" snackbar under the `snackbar` feature.
`arboard`, `android_clipboard`, `web-sys` and `wasm-bindgen-futures` leave
`src/Cargo.toml` and join `waterui-text` with the same cfg gates, optional
behind `highlight`. `waterui-mermaid` now takes `CodeConfig` from
`waterui_text::code` and has no `waterui` dependency outside dev.

No component crate lists `waterui` under `[dependencies]` any more.
