### PR TITLE
ci: stop caching the Android NDK (evicted at the 10 GiB limit, restores half a toolchain)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -253,7 +253,12 @@ jobs:
           # uses; keeping CI on it means CI compiles against the same sysroot a
           # developer's Android build does.
           ndk-version: r29
-          local-cache: true
+          # Downloaded fresh every run, on purpose. The repository cache sits at
+          # the 10 GiB eviction limit, so a 708 MiB NDK entry is evicted and
+          # re-created continuously, and a restore that races an eviction hands
+          # the probe below a tree with the clang wrappers but no clang (#284).
+          # A miss costs ~79 s against ~53 s for a hit, on a 9-12 minute job.
+          local-cache: false
       # Its own key: this is the only leg that compiles the dependency graph
       # for an Android target, so it shares no artifacts with the others and
       # storing it under theirs would evict a tarball nothing else can use.


### PR DESCRIPTION
Fixes #284.

`nttld/setup-ndk` with `local-cache: true` restored an NDK r29 tree with the clang wrapper scripts but no `clang` on #282's Android FFI leg — the probe step caught it in 53 s. The repository cache is at 10.1 GiB, the eviction limit, so the 708 MiB NDK entry is evicted and re-created continuously and a restore can race an eviction.

Measured: a miss (download + extract + save, #244) is 79 s; the hit that broke was 53 s. The cache saves ~30 s of a 9–12 minute job. This downloads the NDK fresh every run, removing both the entry from the full budget and the failure class. The probe step stays.

Pure CI reliability/perf change; coverage unchanged.