### PR TITLE
fix(text): draw Code from theme tokens and follow the colour scheme

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13289,6 +13289,7 @@ dependencies = [
  "android_clipboard",
  "arboard",
  "executor-core",
+ "hydrolysis-m3",
  "nami",
  "pulldown-cmark",
  "smallvec",

--- a/components/foundation/text/Cargo.toml
+++ b/components/foundation/text/Cargo.toml
@@ -71,6 +71,8 @@ markdown = ["dep:pulldown-cmark"]
 [dev-dependencies]
 waterui = { path = "../../.." }
 waterui-testing = { path = "../../../testing" }
+# The offscreen code-block tests render under the Material 3 widget theme, light and dark.
+hydrolysis-m3.workspace = true
 # This crate's own tests cover the Markdown parser, which is not in `default`.
 # A dev-dependency on itself turns the feature on for this crate's test targets
 # without turning it on for anything that depends on the crate.

--- a/components/foundation/text/README.md
+++ b/components/foundation/text/README.md
@@ -161,9 +161,10 @@ let blue_text = styled.foreground(Color::blue());
 ```rust
 use waterui_text::highlight::{DefaultHighlighter, Language, highlight_text};
 use waterui_core::Str;
+use waterui_graphics::color::ColorScheme;
 
-// Create highlighter
-let mut highlighter = DefaultHighlighter::new();
+// Create highlighter with the palette for the surface it is read against
+let mut highlighter = DefaultHighlighter::new(ColorScheme::Light);
 
 // Highlight code
 let code = Str::from("fn main() { println!(\"Hello\"); }");

--- a/components/foundation/text/src/code.rs
+++ b/components/foundation/text/src/code.rs
@@ -15,10 +15,14 @@ use core::fmt;
 
 #[cfg(target_arch = "wasm32")]
 use executor_core::spawn_local;
+use nami::SignalExt;
 use waterui_core::gesture::{GestureObserver, TapGesture};
+use waterui_core::resolve::Resolvable;
 use waterui_core::view::{ConfigurableView, Hook, ViewConfiguration};
 use waterui_core::{AnyView, Environment, Metadata, View};
-use waterui_graphics::color::Color;
+use waterui_graphics::color::{
+    AccentColor, Color, CurrentColorScheme, MutedForegroundColor, SurfaceVariantColor,
+};
 use waterui_layout::{
     background::background,
     padding::{EdgeInsets, Padding},
@@ -29,8 +33,7 @@ use waterui_str::Str;
 
 use crate::{
     font::{Body, Font},
-    highlight::{DefaultHighlighter, Highlighter, Language},
-    styled::{Style, StyledStr},
+    highlight::{DefaultHighlighter, Language, highlight_text},
     text,
 };
 
@@ -206,14 +209,20 @@ impl View for Code {
         if let Some(hook) = env.get::<Hook<CodeConfig>>() {
             AnyView::new(hook.apply(env, config))
         } else {
-            AnyView::new(default_rendering(config))
+            AnyView::new(default_rendering(env, config))
         }
     }
 }
 
 /// What a fence looks like when nothing claims it: a header naming the
 /// language, a copy button, and the highlighted source.
-fn default_rendering(config: CodeConfig) -> impl View {
+///
+/// Every colour is a theme token, so the block is a surface-variant inset on
+/// whatever the application's surface is. The highlighter's palette is the
+/// one exception a token cannot express — syntect ships a light and a dark
+/// set — so it follows the installed colour scheme and re-highlights when
+/// that flips, without the block itself being rebuilt.
+fn default_rendering(env: &Environment, config: CodeConfig) -> impl View {
     let CodeConfig {
         info: _,
         language,
@@ -222,21 +231,18 @@ fn default_rendering(config: CodeConfig) -> impl View {
     } = config;
     let lang_name = language.to_string();
     let content_for_copy = content.to_string();
-    let mut highlighter = DefaultHighlighter::new();
-    let chunks = highlighter.highlight(language, &content);
 
-    let code_font = Font::from(Body).size(14.0);
-    let styled = chunks.into_iter().fold(StyledStr::empty(), |mut s, chunk| {
-        s.push(
-            chunk.text.to_string(),
-            Style::default()
-                .foreground(chunk.color)
-                .font(code_font.clone()),
-        );
-        s
-    });
+    let highlighted = CurrentColorScheme
+        .resolve(env)
+        .map(move |scheme| {
+            highlight_text(
+                language.clone(),
+                &content,
+                &mut DefaultHighlighter::new(scheme),
+            )
+        })
+        .computed();
 
-    // Code block with dark background, left-aligned content.
     let block = VStack::new(
         HorizontalAlignment::Leading,
         8.0,
@@ -244,22 +250,22 @@ fn default_rendering(config: CodeConfig) -> impl View {
             hstack((
                 text(lang_name)
                     .bold()
-                    .color(Color::srgb_f32(0.85, 0.86, 0.9)),
+                    .color(Color::new(MutedForegroundColor)),
                 spacer(),
                 copy_button(content_for_copy, on_copied),
             )),
-            text(styled),
+            text(highlighted).font(Font::from(Body).size(14.0)),
         ),
     );
     background(
         Padding::new(EdgeInsets::all(14.0), block),
-        Color::srgb_f32(0.15, 0.15, 0.18),
+        Color::new(SurfaceVariantColor),
     )
 }
 
 fn copy_button(content: String, on_copied: Option<OnCopied>) -> impl View {
     Metadata::new(
-        text("Copy").color(Color::srgb_f32(0.72, 0.74, 0.8)),
+        text("Copy").color(Color::new(AccentColor)),
         GestureObserver::new(TapGesture::new(), move |env: Environment| {
             copy_to_clipboard(&content);
             if let Some(on_copied) = &on_copied {

--- a/components/foundation/text/src/highlight.rs
+++ b/components/foundation/text/src/highlight.rs
@@ -14,6 +14,8 @@ use syntect::{
 };
 #[cfg(feature = "highlight")]
 use two_face::syntax::extra_newlines;
+#[cfg(feature = "highlight")]
+use waterui_graphics::color::ColorScheme;
 use waterui_graphics::color::Srgb;
 
 use crate::styled::{Style, StyledStr};
@@ -164,11 +166,23 @@ impl Display for ParseLanguageError {
 
 impl Error for ParseLanguageError {}
 
+/// Lets [`code`](crate::code) take the fence's token as written — `"rust"`,
+/// `"c++"`, `"yml"` — through its `TryInto<Language>` argument.
+impl TryFrom<&str> for Language {
+    type Error = ParseLanguageError;
+
+    fn try_from(token: &str) -> Result<Self, Self::Error> {
+        token.parse()
+    }
+}
+
 /// Default syntax highlighter implementation using the syntect library.
 #[cfg(feature = "highlight")]
 pub struct DefaultHighlighter {
     syntax_set: SyntaxSet,
     theme: Theme,
+    /// The theme's own text colour, for chunks the grammar assigns no scope.
+    foreground: Srgb,
 }
 
 #[cfg(feature = "highlight")]
@@ -179,22 +193,33 @@ impl Debug for DefaultHighlighter {
 }
 
 #[cfg(feature = "highlight")]
-impl Default for DefaultHighlighter {
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-#[cfg(feature = "highlight")]
 impl DefaultHighlighter {
-    /// Creates a new highlighter backed by syntect with extended syntax support.
+    /// Creates a highlighter backed by syntect with extended syntax support,
+    /// using the palette that reads against a light or a dark surface.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the bundled syntect theme declares no default foreground.
     #[must_use]
-    pub fn new() -> Self {
+    pub fn new(scheme: ColorScheme) -> Self {
         // Use two-face's extended syntax set which includes Swift and many more languages
         let syntax_set = extra_newlines();
         let theme_set = ThemeSet::load_defaults();
-        let theme = theme_set.themes["base16-ocean.dark"].clone();
-        Self { syntax_set, theme }
+        let name = match scheme {
+            ColorScheme::Light => "base16-ocean.light",
+            ColorScheme::Dark => "base16-ocean.dark",
+        };
+        let theme = theme_set.themes[name].clone();
+        let foreground = theme
+            .settings
+            .foreground
+            .map(|color| Srgb::new_u8(color.r, color.g, color.b))
+            .expect("syntect theme declares no default foreground");
+        Self {
+            syntax_set,
+            theme,
+            foreground,
+        }
     }
 
     fn find_syntax(&self, language: &Language) -> &SyntaxReference {
@@ -218,7 +243,7 @@ impl Highlighter for DefaultHighlighter {
                 // Fallback: return the whole line with default color
                 chunks.push(HighlightChunk {
                     text: line,
-                    color: Srgb::new_u8(200, 200, 200),
+                    color: self.foreground,
                 });
                 continue;
             };
@@ -236,7 +261,7 @@ impl Highlighter for DefaultHighlighter {
             if text.contains('\n') {
                 chunks.push(HighlightChunk {
                     text: "\n",
-                    color: Srgb::new_u8(200, 200, 200),
+                    color: self.foreground,
                 });
             }
         }
@@ -286,10 +311,27 @@ mod tests {
 
     #[test]
     fn test_swift_highlighting() {
-        let mut highlighter = DefaultHighlighter::new();
+        let mut highlighter = DefaultHighlighter::new(ColorScheme::Dark);
         let code = "import SwiftUI\nstruct ContentView: View { }";
         let chunks = highlighter.highlight(Language::Swift, code);
         // Should have multiple chunks with different colors (not all plain text)
         assert!(chunks.len() > 1, "Swift code should be tokenized");
+    }
+
+    #[test]
+    fn palette_follows_the_colour_scheme() {
+        let code = "import SwiftUI\nstruct ContentView: View { }";
+        let colours = |scheme| {
+            DefaultHighlighter::new(scheme)
+                .highlight(Language::Swift, code)
+                .into_iter()
+                .map(|chunk| chunk.color)
+                .collect::<Vec<_>>()
+        };
+        assert_ne!(
+            colours(ColorScheme::Light),
+            colours(ColorScheme::Dark),
+            "a light surface and a dark surface need different ink"
+        );
     }
 }

--- a/components/foundation/text/tests/e2e_visual.rs
+++ b/components/foundation/text/tests/e2e_visual.rs
@@ -1,10 +1,11 @@
 //! End-to-end visual-rendering tests for the `text` component.
 
-use waterui::ViewExt as _;
+use hydrolysis_m3::{MaterialColorScheme, install, install_with_colors};
 use waterui::accessibility::AccessibilityRole;
 use waterui::graphics::color::Srgb;
-use waterui::text::{styled, text};
-use waterui_testing::{Role, SemanticApp};
+use waterui::text::{code, styled, text};
+use waterui::{Environment, ViewExt as _};
+use waterui_testing::{OffscreenApp, Role, SemanticApp};
 
 fn plain_text_view() -> impl waterui::View {
     text("Visible content")
@@ -40,4 +41,31 @@ fn styled_text_renders_multiple_styles(app: &mut SemanticApp) {
         .role(Role::LABEL)
         .label("Plain italic bold code")
         .assert_exists();
+}
+
+fn code_block() -> impl waterui::View {
+    code("rust", include_str!("fixtures/code_sample.rs")).padding_with(16.0)
+}
+
+/// The Material 3 baseline dark scheme, so a code block has to read every
+/// colour from the environment to stay legible.
+fn dark_theme(env: &mut Environment) {
+    install_with_colors(env, MaterialColorScheme::baseline_dark());
+}
+
+fn assert_code_block_semantics(app: &mut OffscreenApp) {
+    app.query().role(Role::LABEL).label("Rust").assert_exists();
+    app.query().role(Role::LABEL).label("Copy").assert_exists();
+}
+
+#[waterui::test(code_block, theme = install, viewport = (480, 300), offscreen)]
+fn a_code_block_draws_from_the_light_theme(app: &mut OffscreenApp) {
+    assert_code_block_semantics(app);
+    let _ = app.capture_snapshot("text", "code_block", "light");
+}
+
+#[waterui::test(code_block, theme = dark_theme, viewport = (480, 300), offscreen)]
+fn a_code_block_draws_from_the_dark_theme(app: &mut OffscreenApp) {
+    assert_code_block_semantics(app);
+    let _ = app.capture_snapshot("text", "code_block", "dark");
 }

--- a/components/foundation/text/tests/fixtures/code_sample.rs
+++ b/components/foundation/text/tests/fixtures/code_sample.rs
@@ -1,0 +1,9 @@
+/// Greets every name once, keeping the order the caller gave.
+pub fn greet(names: &[&str]) -> Vec<String> {
+    let mut greetings = Vec::with_capacity(names.len());
+    for (index, name) in names.iter().enumerate() {
+        // Index from one: humans do not count from zero.
+        greetings.push(format!("{}. Hello, {name}!", index + 1));
+    }
+    greetings
+}

--- a/components/visual/graphics/src/color/mod.rs
+++ b/components/visual/graphics/src/color/mod.rs
@@ -732,6 +732,38 @@ environment_color!(
     "Selection-foreground color key for environment queries."
 );
 
+/// The light or dark appearance the application is drawn in.
+///
+/// A backend installs the system appearance, or a theme installs a fixed or
+/// reactive preference, next to the colour tokens above. Components that
+/// choose between two palettes of their own — a syntax-highlighting theme,
+/// a map style — resolve [`CurrentColorScheme`] so the choice follows a
+/// switch instead of being made once.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum ColorScheme {
+    /// Light appearance (light backgrounds, dark text).
+    #[default]
+    Light,
+    /// Dark appearance (dark backgrounds, light text).
+    Dark,
+}
+
+impl_constant!(ColorScheme);
+
+/// Environment key that resolves to the installed [`ColorScheme`].
+#[derive(Debug, Clone, Copy)]
+pub struct CurrentColorScheme;
+
+impl Resolvable for CurrentColorScheme {
+    type Resolved = ColorScheme;
+
+    fn resolve(&self, env: &Environment) -> impl Signal<Output = Self::Resolved> {
+        env.query::<ColorScheme, Computed<ColorScheme>>()
+            .cloned()
+            .expect("ColorScheme is not installed in the environment")
+    }
+}
+
 /// Implements `View` for a color type, allowing it to be used directly as a background.
 macro_rules! impl_color_view {
     ($($ty:ty),* $(,)?) => {

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -101,7 +101,7 @@
 
 use core::{any::TypeId, marker::PhantomData};
 
-use nami::{Computed, SignalExt, impl_constant, signal::IntoSignal};
+use nami::{Computed, SignalExt, signal::IntoSignal};
 use waterui_core::{Environment, env::Store, plugin::Plugin};
 
 use crate::{
@@ -115,8 +115,9 @@ use crate::{
 
 /// The color scheme preference for the UI.
 ///
-/// This is used to switch between light and dark appearances. Native backends
-/// typically bind this to the system appearance setting.
+/// Defined beside the colour tokens in `waterui_graphics::color` so component
+/// crates can resolve it through [`CurrentColorScheme`] without depending on
+/// this crate; installed and read here.
 ///
 /// # Example
 ///
@@ -131,16 +132,7 @@ use crate::{
 /// let system_scheme = binding(ColorScheme::Light);
 /// Theme::new().color_scheme(system_scheme);
 /// ```
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
-pub enum ColorScheme {
-    /// Light appearance (light backgrounds, dark text).
-    #[default]
-    Light,
-    /// Dark appearance (dark backgrounds, light text).
-    Dark,
-}
-
-impl_constant!(ColorScheme);
+pub use waterui_graphics::color::{ColorScheme, CurrentColorScheme};
 
 // ============================================================================
 // ColorSettings - All color overrides
@@ -500,7 +492,7 @@ impl Plugin for Theme {
     fn install(self, env: &mut Environment) {
         // Install color scheme if specified
         if let Some(scheme) = self.color_scheme {
-            env.insert(ColorSchemeSignal(scheme));
+            install_color_scheme(env, scheme);
         }
 
         // Install color settings if specified
@@ -586,10 +578,6 @@ pub mod color {
 // Internal: Storage and Resolution
 // ============================================================================
 
-/// Storage for the color scheme signal.
-#[derive(Clone)]
-struct ColorSchemeSignal(Computed<ColorScheme>);
-
 /// Internal storage for a color signal in the environment.
 #[derive(Clone)]
 struct ColorSlotValue<T> {
@@ -636,8 +624,7 @@ pub fn current_color_scheme(env: &Environment) -> Computed<ColorScheme> {
 /// Returns the color-scheme signal installed by the active backend or theme.
 #[must_use]
 pub fn installed_color_scheme(env: &Environment) -> Option<Computed<ColorScheme>> {
-    env.get::<ColorSchemeSignal>()
-        .map(|signal| signal.0.clone())
+    env.query::<ColorScheme, Computed<ColorScheme>>().cloned()
 }
 
 /// Installs an explicit color signal for a specific slot.
@@ -733,7 +720,7 @@ pub fn install_font_signal<T: 'static>(env: &mut Environment, signal: Computed<R
 /// This is used by native backends to inject a reactive color scheme that
 /// tracks the system appearance setting.
 pub fn install_color_scheme(env: &mut Environment, signal: Computed<ColorScheme>) {
-    env.insert(ColorSchemeSignal(signal));
+    env.insert(Store::<ColorScheme, Computed<ColorScheme>>::new(signal));
 }
 
 // ============================================================================


### PR DESCRIPTION
Fixes #280

`Code`'s default rendering hard-coded a grey surface, grey header, blue Copy label and grey unscoped text, so it ignored the theme and was unreadable on a dark surface (Principle 6). It now reads `SurfaceVariant`, `MutedForeground` and `Accent`, and its syntect palette follows the installed colour scheme (light/dark base16-ocean, theme foreground for unscoped chunks). The highlighted text is a `Computed` over the scheme, so a switch re-highlights without rebuilding the block.

To let a component resolve the scheme, `ColorScheme` moves from the root crate into `waterui-graphics` with a `CurrentColorScheme` resolvable key; the root theme re-exports it and every install/query helper keeps its signature. `Language` gains `TryFrom<&str>` so `code("rust", …)` compiles through the existing `TryInto` bound.

Verified: clippy clean for graphics, text, root, hydrolysis-m3; text/graphics/hydrolysis-m3 tests pass; ffi, gtk, examples and skill_snippets compile; FFI header unchanged. New offscreen tests render the block under Material 3 light and baseline-dark, and both PNGs were reviewed by eye.

Found while landing this, filed separately: #288 (code text is drawn in the proportional Body font; no monospaced font design exists).