### PR TITLE
fix(graphics): keep the wgpu instance for the life of the process

### DIFF
--- a/components/visual/graphics/src/gpu/shared_context.rs
+++ b/components/visual/graphics/src/gpu/shared_context.rs
@@ -6,6 +6,7 @@
 
 use std::error::Error;
 use std::fmt;
+use std::mem::ManuallyDrop;
 use std::sync::{Arc, Mutex, OnceLock};
 
 use shaderloom::WgslModuleCache;
@@ -41,7 +42,17 @@ impl Error for SharedContextError {}
 /// GPU resources shared by every clone of one [`GpuRuntime`].
 pub struct SharedGpuContext {
     /// The shared wgpu instance.
-    pub instance: wgpu::Instance,
+    ///
+    /// Never dropped: it lives as long as the process. Dropping a wgpu
+    /// `Instance` drops wgpu-hal's `libloading` handles for `libEGL` /
+    /// `libvulkan`, which `dlclose`s the driver they loaded. Mesa's software
+    /// drivers (llvmpipe, lavapipe — every GPU-less CI runner, container and
+    /// VM) and the LLVM inside them register `atexit` destructors, and once
+    /// the mapping is gone the process dies inside `exit()` after the last
+    /// context has been torn down cleanly. A driver has to outlive the process
+    /// by construction, so this is not a leak; the device is still drained and
+    /// destroyed in [`Drop`] exactly as before.
+    pub instance: ManuallyDrop<wgpu::Instance>,
     /// The selected GPU adapter.
     pub adapter: wgpu::Adapter,
     /// The shared GPU device.
@@ -290,7 +301,7 @@ impl SharedGpuContext {
             GpuSubmissionCompletionDriver::new(Arc::clone(&device), Arc::clone(&queue));
 
         Ok(Self {
-            instance,
+            instance: ManuallyDrop::new(instance),
             adapter,
             device,
             queue,

--- a/components/visual/graphics/tests/runtime_teardown.rs
+++ b/components/visual/graphics/tests/runtime_teardown.rs
@@ -1,0 +1,22 @@
+//! A dropped `GpuRuntime` leaves the process able to exit.
+//!
+//! wgpu unloads its driver libraries when the last `Instance` drops. Under
+//! Mesa's software drivers — llvmpipe and lavapipe, which is every GPU-less
+//! CI runner, container and VM — the driver and the LLVM inside it register
+//! `atexit` destructors, so once the mapping is gone the process dies inside
+//! `exit()` after everything has been torn down cleanly (water-rs/waterui#281,
+//! found as a core dump of a smoke test whose teardown had already logged
+//! completion). `SharedGpuContext` therefore keeps its instance for the life
+//! of the process.
+//!
+//! nextest runs every test in a process of its own, so returning from this
+//! test is exactly the exit that used to crash.
+
+use waterui_graphics::GpuRuntime;
+
+#[test]
+fn a_dropped_runtime_leaves_the_process_able_to_exit() {
+    let runtime = pollster::block_on(GpuRuntime::new())
+        .expect("the teardown test needs a working GPU runtime");
+    drop(runtime);
+}


### PR DESCRIPTION
Fixes #281.

## The crash

`SharedGpuContext` owned its `wgpu::Instance` by value and let it drop after draining the device. Dropping the instance drops wgpu-hal's `libloading` handles for `libEGL` / `libvulkan`, which `dlclose`s the driver they loaded. Under Mesa's software drivers — llvmpipe and lavapipe, which is every GPU-less CI runner, container and VM — the driver and the LLVM inside it register `atexit` destructors, so once the mapping is gone the process dies inside `exit()` after everything has been torn down cleanly:

```
_start → __libc_start_main → exit → libc → 0x00007f6d0522ea60 in ?? ()
```

an address no loaded library owns, every other thread parked normally (water-rs/browsers run 33673460113, a core of the WPE runtime smoke taken after `smoke teardown complete`). Pinning the `GpuRuntime` for the process lifetime in that smoke (browsers #27) was the confirmation.

## The change

| | before | after |
| --- | --- | --- |
| `SharedGpuContext::instance` | `wgpu::Instance` | `ManuallyDrop<wgpu::Instance>`, with the reason above on the field |
| `Drop` | drains the device, then the instance drops | drains the device exactly as before; the instance is never dropped |
| readers | `gpu.instance.create_surface(...)`, `create_surface_unsafe(...)` in Hydrolysis | unchanged — `ManuallyDrop` derefs |

Not a `static`: the instance still belongs to the context, it just outlives it. Not a leak: a driver has to outlive the process by construction, which is what the `atexit` registrations already assume.

## The test

`components/visual/graphics/tests/runtime_teardown.rs` creates a `GpuRuntime`, drops it, and returns. nextest runs every test in a process of its own, so returning from this test *is* the exit that used to crash — on the ubuntu leg, which renders through llvmpipe, this is the reproduction; on a host with a real driver it passes either way.

## Verification

In the workspace slot, on stable:

| Command | Result |
| --- | --- |
| `cargo clippy -p waterui-graphics --all-targets -- -D warnings` | clean |
| `cargo nextest run -p waterui-graphics` | 48 passed (includes the new test) |
| `cargo check -p hydrolysis` | Finished |
| `rustfmt --edition 2024 --check` on the two files | clean |

Pre-existing; found while landing water-rs/browsers#27.
