### PR TITLE
feat(webview)!: specify the raw run_javascript reply as the JSON encoding of the value

### DIFF
--- a/components/platform/webview/Cargo.toml
+++ b/components/platform/webview/Cargo.toml
@@ -24,6 +24,11 @@ base64 = "0.22"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { version = "1.0", features = ["raw_value"] }
 
+[features]
+# The checks an engine's real-engine suite runs against the contracts this
+# crate states; assertions, so off by default and on in test binaries only.
+conformance = []
+
 [dev-dependencies]
 hydrolysis-m3 = { path = "../../../backends/hydrolysis_m3" }
 # `#[js_api]` expands to `::waterui::webview::…` paths, so testing it means

--- a/components/platform/webview/src/conformance.rs
+++ b/components/platform/webview/src/conformance.rs
@@ -1,0 +1,67 @@
+//! The checks every engine runs against the contracts this crate states.
+//!
+//! A backend crate — `waterui-browser-cef`, `waterui-browser-wpe`, the
+//! platform web views — proves its engine against a real page in its own
+//! real-engine suite. The contracts those suites have to agree on live here,
+//! as functions that take the engine's evaluator and assert, so that two
+//! engines cannot quietly satisfy two readings of the same sentence: the raw
+//! evaluation reply once did, with one engine unquoting strings and another
+//! encoding them, and a fixture reading `location.href` could not tell a URL
+//! from a string that happened to look like one.
+//!
+//! Behind the `conformance` feature, because these are assertions and belong
+//! in test binaries.
+
+use serde_json::Value;
+use waterui_core::Str;
+
+/// The raw reply of [`WebViewHandle::run_javascript`](crate::WebViewHandle::run_javascript)
+/// is the JSON encoding of the evaluated value.
+///
+/// `evaluate` is the engine's raw path — `|script| handle.run_javascript(script)`
+/// on a handle, or the same call on a `WebView`, whichever the suite holds —
+/// over a page that has loaded. Panics, naming the reply, when the engine
+/// answers otherwise.
+///
+/// # Panics
+///
+/// When a string arrives unquoted, an object does not parse as JSON with its
+/// fields intact, a number is not its literal, or `undefined` is anything but
+/// `null`.
+#[expect(
+    clippy::future_not_send,
+    reason = "web views are confined to the UI thread, and so is the suite that drives them"
+)]
+pub async fn raw_evaluation_answers_json(evaluate: impl AsyncFn(&str) -> Result<Str, Str>) {
+    let string = evaluate("'waterui'")
+        .await
+        .expect("a string literal evaluates");
+    assert_eq!(
+        string.as_str(),
+        "\"waterui\"",
+        "a string result arrives as JSON, quoted"
+    );
+
+    let number = evaluate("40 + 2")
+        .await
+        .expect("an arithmetic expression evaluates");
+    assert_eq!(number.as_str(), "42", "a number arrives as its literal");
+
+    let object = evaluate("({name: 'waterui', ok: true, items: [1, 2]})")
+        .await
+        .expect("an object literal evaluates");
+    let decoded: Value = serde_json::from_str(&object)
+        .unwrap_or_else(|error| panic!("run_javascript answered `{object}`, not JSON: {error}"));
+    assert_eq!(
+        decoded,
+        serde_json::json!({"name": "waterui", "ok": true, "items": [1, 2]}),
+        "an object arrives as JSON with its fields intact"
+    );
+
+    let nothing = evaluate("undefined").await.expect("undefined evaluates");
+    assert_eq!(
+        nothing.as_str(),
+        "null",
+        "JSON has no undefined; the typed path is where it stays distinct"
+    );
+}

--- a/components/platform/webview/src/handler.rs
+++ b/components/platform/webview/src/handler.rs
@@ -166,8 +166,19 @@ webview_handle! {
         ///
         /// Returns the result of the script execution, or an error message.
         ///
-        /// This is the raw path: the value comes back however the engine
-        /// marshals it. Everything typed — [`WebView::eval`](crate::WebView::eval),
+        /// This is the raw path, and its reply is the **JSON encoding of the
+        /// evaluated value**, on every engine: a string arrives quoted, a
+        /// number or boolean as its literal, an object or array as JSON, and
+        /// `undefined` — which JSON has no spelling for — as `null`. Unquoted,
+        /// a reply is ambiguous: a page at `first` and a page that returned
+        /// the string `"first"` would be the same bytes, and the caller would
+        /// have to guess which it got. An engine that describes a value it
+        /// cannot serialize, such as a function, answers `null` for it too.
+        /// `conformance::raw_evaluation_answers_json` (behind the `conformance`
+        /// feature) is the check every engine's real-engine suite runs against
+        /// this.
+        ///
+        /// Everything typed — [`WebView::eval`](crate::WebView::eval),
         /// [`WebView::exec`](crate::WebView::exec) and the mirrored-state
         /// push — goes through [`call_async_javascript`](Self::call_async_javascript)
         /// instead, because it needs the promise awaited.

--- a/components/platform/webview/src/lib.rs
+++ b/components/platform/webview/src/lib.rs
@@ -31,6 +31,8 @@ use std::{cell::Cell, fmt, rc::Rc};
 mod handle_layers;
 mod handler;
 pub use handler::*;
+#[cfg(feature = "conformance")]
+pub mod conformance;
 mod no_engine;
 mod proxy;
 pub use proxy::WebViewProxy;


### PR DESCRIPTION
Fixes #287.

## The contract

`WebViewHandle::run_javascript` said its reply came back "however the engine marshals it". Two engines read that two ways — CEF unwrapped strings to bare text, WPE (since water-rs/browsers#27) answers `jsc_value_to_json` — and the raw path was ambiguous: a page at `first` and a page that returned the string `"first"` were the same bytes, so a fixture reading `location.href` could not tell a URL from a string that looked like one.

The trait now states it: **the raw reply is the JSON encoding of the evaluated value, on every engine.**

| value | reply |
| --- | --- |
| `'waterui'` | `"waterui"` (quoted) |
| `40 + 2` | `42` |
| `({name: 'waterui', ok: true, items: [1, 2]})` | that object, as JSON |
| `undefined`, or a value the engine can only describe (a function) | `null` |

The typed `eval!` / `exec!` envelope and the mirrored-state push go through `call_async_javascript` and are unaffected.

## The conformance check

`waterui_webview::conformance::raw_evaluation_answers_json(&handle)` runs those four evaluations against a loaded page and panics naming the reply when the engine answers otherwise. It sits behind a new `conformance` feature — it is assertions, and belongs in test binaries — and every engine's real-engine suite is meant to call it, so two engines cannot again satisfy two readings of one sentence.

Consumers:

- WPE already conforms; its suite gains the shared call in the browsers follow-up.
- CEF does not: water-rs/browsers#33 brings it onto the contract (JSON-encode the DevTools value, `null` when there is none; its two unquoted assertions change) and runs this check.

## Verification

In the workspace slot, on stable:

| Command | Result |
| --- | --- |
| `cargo clippy -p waterui-webview --all-targets --features conformance -- -D warnings` | clean |
| `cargo clippy -p waterui-webview --all-targets -- -D warnings` | clean |
| `cargo nextest run -p waterui-webview --features conformance` | 60 passed |
| `RUSTDOCFLAGS=-D warnings cargo doc -p waterui-webview --no-deps --features conformance` | clean |
| `cargo test --doc -p waterui-webview` | ok |

Nothing under `src/js/` changed, so the JavaScript half's `bun test` is not affected.
