### PR TITLE
ci(release): install the native libraries the verify builds link

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      # `cargo publish` verifies each package by building it with its default
+      # features, so the native libraries the workspace links have to be here
+      # as they are in the test workflow: without them the Linux-only
+      # `cros-libva` build script, reached through `waterkit-codec`, fails the
+      # `waterui-image` verify build on the missing `libva-dev`.
+      - uses: ./.github/actions/setup-linux-deps
       - uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release
@@ -60,6 +66,9 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      # The same native libraries as above: computing the next versions also
+      # builds the workspace's metadata against every crate's dependencies.
+      - uses: ./.github/actions/setup-linux-deps
       - uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release-pr


### PR DESCRIPTION
Fixes #295.

The Release run on `main` (33724698270) failed its "Release unpublished packages" job at `waterui-image`:

```
Verifying waterui-image v0.3.0
error: failed to run custom build command for `cros-libva v0.0.12`
error: failed to verify package tarball
```

`cargo publish` verifies each package by building it with its default features. The release jobs installed no native libraries, so the Linux-only `cros-libva` build script (reached through `waterkit-codec`) died on the missing `libva-dev` — the failure `ci.yml`'s Android FFI job documents and avoids with `./.github/actions/setup-linux-deps`. Both Release jobs now run that composite action before `release-plz`; waterkit's release workflow made the same fix in water-rs/waterkit#33.

`actionlint .github/workflows/release.yml`: clean. The workflow runs from `main`, so this reaches it the way #286 did, together with #293, once both are on `dev`.
