### PR TITLE
docs(skill): list waterui-mermaid and its install() step

### DIFF
--- a/.claude/skills/waterui/SKILL.md
+++ b/.claude/skills/waterui/SKILL.md
@@ -209,9 +209,13 @@ use waterui::task::{sleep, spawn_local};               // async utilities
 
 Components behind cargo features are also absent until you enable them. `waterui`'s
 defaults are `gpu`, `assets`, `media`, `inspector`, `snackbar`; `webview` and
-`flow-markdown` are opt-in in `Cargo.toml`. Charts, maps, barcodes and particles are not
+`flow-markdown` are opt-in in `Cargo.toml`. Charts, maps, barcodes, particles and Mermaid diagrams are not
 features but crates of their own — `waterui-chart`, `waterui-map`, `waterui-barcode`,
-`waterui-particle` — added as direct dependencies and imported as `waterui_chart::…`. Keep
+`waterui-particle`, `waterui-mermaid` — added as direct dependencies and imported as
+`waterui_chart::…`. Mermaid additionally needs one call at the root of the app: a
+```` ```mermaid ```` fence in Markdown stays plain code until the environment has
+`waterui_mermaid::install(&mut env)` (do it inside `use_env` at the root view, as
+`examples/markdown` does, so `water preview` gets it too). Keep
 the generated `dev = ["waterui/dynamic_linking"]` feature — it is what makes `water preview`
 and the fast dev loop link dynamically ([references/project.md](references/project.md)).
 


### PR DESCRIPTION
Fixes #298

Adds `waterui-mermaid` to the standalone-crates list in the skill and one sentence saying a mermaid fence renders as plain code until `waterui_mermaid::install(&mut env)` runs at the app root (as `examples/markdown` does). Prose only, no new rust fence, so `skill_snippets` is unchanged.