### PR TITLE
release: kit pin and Linux native deps for the Release jobs (cherry-picks from dev)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,12 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      # `cargo publish` verifies each package by building it with its default
+      # features, so the native libraries the workspace links have to be here
+      # as they are in the test workflow: without them the Linux-only
+      # `cros-libva` build script, reached through `waterkit-codec`, fails the
+      # `waterui-image` verify build on the missing `libva-dev`.
+      - uses: ./.github/actions/setup-linux-deps
       - uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release
@@ -60,6 +66,9 @@ jobs:
           fetch-depth: 0
           submodules: recursive
       - uses: dtolnay/rust-toolchain@stable
+      # The same native libraries as above: computing the next versions also
+      # builds the workspace's metadata against every crate's dependencies.
+      - uses: ./.github/actions/setup-linux-deps
       - uses: MarcoIeni/release-plz-action@v0.5
         with:
           command: release-pr


### PR DESCRIPTION
The Release run on `main` (33724698270) failed both of its jobs, for two independent reasons fixed on `dev` this morning. `release.yml` runs from `main`, so — as with #286 — the fixes are cherry-picked here:

| commit | fixes | what |
| --- | --- | --- |
| `8aa82bdc4` (#293) | #294 | `kit` submodule pinned at waterkit `7d8b386`, where the tracked-and-ignored `Info.plist` release-plz refused is gone |
| `f1cee464e` (#296) | #295 | both Release jobs run `./.github/actions/setup-linux-deps` before release-plz, so the `waterui-image` verify build finds `libva-dev` |

Once merged, `main`'s CI runs and the Release workflow fires from its completion, resuming the 0.3 publish where it stopped (`waterui-image` onward).
