### PR TITLE
fix(ffi): keep a frame skipped as occluded pending

### DIFF
--- a/ffi/src/components/visual/applied_filter.rs
+++ b/ffi/src/components/visual/applied_filter.rs
@@ -608,7 +608,11 @@ pub unsafe extern "C" fn waterui_applied_filter_render(
         output_config,
         "waterui_applied_filter_render",
     ) else {
-        return false;
+        // Nothing was drawn, so the frame this call was asked for is still
+        // pending: the host must come back for it once the surface can be
+        // acquired again. Reporting it done here would strand a view whose only
+        // clock is its own render loop.
+        return true;
     };
 
     // Get input texture after setup so mutable borrows of `state` are finished.

--- a/ffi/src/components/visual/gpu_surface.rs
+++ b/ffi/src/components/visual/gpu_surface.rs
@@ -774,7 +774,11 @@ pub unsafe extern "C" fn waterui_gpu_surface_render(
         attached_config(state, "waterui_gpu_surface_render"),
         "waterui_gpu_surface_render",
     ) else {
-        return false;
+        // Nothing was drawn, so the frame this call was asked for is still
+        // pending: the host must come back for it once the surface can be
+        // acquired again. Reporting it done here would strand a view whose only
+        // clock is its own render loop.
+        return true;
     };
     let view = output.texture.create_view(&wgpu::TextureViewDescriptor {
         label: Some("GpuSurface Frame View"),

--- a/ffi/src/components/visual/mod.rs
+++ b/ffi/src/components/visual/mod.rs
@@ -10,6 +10,13 @@ pub mod gpu_surface_input;
 pub mod view_effect;
 pub mod view_renderer;
 
+/// Acquires the next texture of a configured surface, reconfiguring once when
+/// the swapchain is lost or outdated.
+///
+/// `None` means the frame was skipped because the surface is occluded: nothing
+/// was drawn, and the caller must report the frame as still pending so the host
+/// comes back for it — a view whose only clock is its own render loop has no
+/// other way to be woken.
 #[cfg(feature = "gpu")]
 fn acquire_surface_texture(
     surface: &wgpu::Surface<'_>,

--- a/ffi/src/components/visual/view_effect.rs
+++ b/ffi/src/components/visual/view_effect.rs
@@ -562,7 +562,11 @@ pub unsafe extern "C" fn waterui_view_effect_render(state: *mut WuiViewEffectSta
         output_config,
         "waterui_view_effect_render",
     ) else {
-        return false;
+        // Nothing was drawn, so the frame this call was asked for is still
+        // pending: the host must come back for it once the surface can be
+        // acquired again. Reporting it done here would strand a view whose only
+        // clock is its own render loop.
+        return true;
     };
 
     let input_texture = state


### PR DESCRIPTION
Fixes #301.

`waterui_gpu_surface_render`, `waterui_view_effect_render` and `waterui_applied_filter_render` returned `false` when `acquire_surface_texture` skipped the frame as occluded, so the host (which had already cleared its own dirty flag) never came back for the frame that was never drawn. A skipped frame now reports itself as still pending.

Found while moving the CEF host onto the generic input carrier (#252): the first frame after attach is regularly skipped because the window is not yet visible, and the CEF presenter's only clock is its own render loop, so the page stayed blank for good. Verified on macOS with `examples/webview-cef`: after this change the surface resumes as soon as the window becomes visible (Swift log showed the display link restarting and the CEF frames importing), without it the surface stayed blank. Pre-existing.
