### PR TITLE
chore: refresh Cargo.lock for the kit pin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12139,13 +12139,11 @@ dependencies = [
  "dirs",
  "indexed_db_futures",
  "jni 0.22.4",
- "js-sys",
  "serde",
  "serde_json",
  "swift-bridge",
  "thiserror 2.0.20",
  "tracing",
- "wasm-bindgen",
  "waterkit-build",
  "windows 0.62.2",
 ]


### PR DESCRIPTION
Fixes #305. Two deletions under `waterkit-fs`, exactly what a plain `cargo build` on dev writes back today.