### PR TITLE
feat(cli): make `water run --logs` raise the app's Rust log filter

### DIFF
--- a/cli/src/terminal/commands/run.rs
+++ b/cli/src/terminal/commands/run.rs
@@ -203,7 +203,8 @@ pub struct Args {
     path: PathBuf,
 
     /// Minimum log level to display (error, warn, info, debug, verbose).
-    /// Streams device logs at or above this level.
+    /// Streams device logs at or above this level and has the application log
+    /// at it, so `debug` shows its `tracing::debug!` output.
     #[arg(long, value_enum)]
     logs: Option<CliLogLevel>,
 

--- a/cli/src/workflows/device.rs
+++ b/cli/src/workflows/device.rs
@@ -18,6 +18,12 @@ use std::collections::BTreeSet;
 #[cfg(target_os = "macos")]
 use std::time::{Duration, Instant};
 
+/// The environment variable that carries the log level to the launched application.
+///
+/// `waterui_ffi` reads it when it installs `tracing`: the CLI names the level
+/// here and the runtime composes its own filter around it.
+const LOG_LEVEL_ENV: &str = "WATERUI_LOG";
+
 /// Minimum log level for streaming device logs.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord)]
 pub enum LogLevel {
@@ -60,6 +66,22 @@ impl LogLevel {
         match self {
             Self::Error | Self::Warn | Self::Info => "default",
             Self::Debug | Self::Verbose => "debug",
+        }
+    }
+
+    /// The `tracing` level the launched application logs at for this setting.
+    ///
+    /// Streaming is only half of `--logs`: the runtime records nothing above
+    /// `error` unless it is told a level, so the same choice travels to the
+    /// process and decides what it emits in the first place.
+    #[must_use]
+    pub const fn to_tracing_level(self) -> &'static str {
+        match self {
+            Self::Error => "error",
+            Self::Warn => "warn",
+            Self::Info => "info",
+            Self::Debug => "debug",
+            Self::Verbose => "trace",
         }
     }
 }
@@ -127,9 +149,16 @@ impl RunOptions {
         self.env_vars.iter().map(|(k, v)| (k.as_str(), v.as_str()))
     }
 
-    /// Set the minimum log level to stream.
-    pub const fn set_log_level(&mut self, level: LogLevel) {
+    /// Set the minimum log level to stream, and have the application log at it.
+    ///
+    /// The level reaches the process through [`LOG_LEVEL_ENV`] on every launch
+    /// path, since each of them forwards [`Self::env_vars`].
+    pub fn set_log_level(&mut self, level: LogLevel) {
         self.log_level = Some(level);
+        self.insert_env_var(
+            String::from(LOG_LEVEL_ENV),
+            String::from(level.to_tracing_level()),
+        );
     }
 
     /// Get the log level if set.

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -273,66 +273,67 @@ unsafe fn __init_impl() -> Option<waterui::inspector::InspectorRuntime> {
     inspector
 }
 
+/// The environment variable a launcher sets to name the level the application
+/// logs at.
+///
+/// `water run --logs <level>` writes it so the process it starts emits what the
+/// terminal then streams. The value is a `tracing` level such as `debug`.
+#[cfg(feature = "std")]
+const LOG_LEVEL_ENV: &str = "WATERUI_LOG";
+
+/// The `tracing` filter this process runs with.
+///
+/// `RUST_LOG` is a developer's complete directive and wins outright. Otherwise
+/// [`LOG_LEVEL_ENV`] names the level the launcher asked for, while the crates
+/// in `quiet` — the graphics stack, whose own chatter would drown the
+/// application's at any level above `error` — stay at `error`. With neither
+/// variable set, only errors are recorded.
+#[cfg(feature = "std")]
+fn env_filter(quiet: &str) -> tracing_subscriber::EnvFilter {
+    use tracing_subscriber::EnvFilter;
+
+    if let Ok(filter) = EnvFilter::try_from_default_env() {
+        return filter;
+    }
+    let level = std::env::var(LOG_LEVEL_ENV).unwrap_or_else(|_| String::from("error"));
+    EnvFilter::try_new(format!("{level},{quiet}"))
+        .unwrap_or_else(|error| panic!("{LOG_LEVEL_ENV}={level:?} is not a tracing level: {error}"))
+}
+
 /// Sends `tracing` records to the platform logger, and to the inspector when one
 /// is attached.
 ///
-/// The three platform arms differ only in which logger they attach, so the
-/// inspector layer is wired once here rather than in each of them.
+/// The three platform arms differ only in which logger they attach and which
+/// crates they quieten, so the filter and the inspector layer are wired once
+/// here rather than in each of them.
 #[cfg(feature = "std")]
 fn init_tracing(inspector: Option<waterui::inspector::InspectorLayer>) {
-    {
-        // Forwards tracing to platform's logging system
-        #[cfg(target_os = "android")]
-        {
-            use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+    use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
-            let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-                .or_else(|_| {
-                    tracing_subscriber::EnvFilter::try_new(
-                        "error,wgpu_core=error,wgpu_hal=error,naga=error,jni=error",
-                    )
-                })
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("error"));
+    #[cfg(target_os = "android")]
+    tracing_subscriber::registry()
+        .with(env_filter(
+            "wgpu_core=error,wgpu_hal=error,naga=error,jni=error",
+        ))
+        .with(tracing_android::layer("WaterUI").expect("Failed to create Android log layer"))
+        .with(inspector)
+        .init();
 
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(
-                    tracing_android::layer("WaterUI").expect("Failed to create Android log layer"),
-                )
-                .with(inspector)
-                .init();
-        }
+    #[cfg(target_vendor = "apple")]
+    tracing_subscriber::registry()
+        .with(env_filter(
+            "wgpu_core=error,wgpu_hal=error,naga=error,metal=error",
+        ))
+        .with(tracing_oslog::OsLogger::new("dev.waterui", "default"))
+        .with(inspector)
+        .init();
 
-        #[cfg(target_vendor = "apple")]
-        {
-            use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-            let env_filter = tracing_subscriber::EnvFilter::try_from_default_env()
-                .or_else(|_| {
-                    tracing_subscriber::EnvFilter::try_new(
-                        "error,wgpu_core=error,wgpu_hal=error,naga=error,metal=error",
-                    )
-                })
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("error"));
-
-            tracing_subscriber::registry()
-                .with(env_filter)
-                .with(tracing_oslog::OsLogger::new("dev.waterui", "default"))
-                .with(inspector)
-                .init();
-        }
-
-        #[cfg(not(any(target_os = "android", target_vendor = "apple")))]
-        {
-            use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
-
-            tracing_subscriber::registry()
-                .with(tracing_subscriber::EnvFilter::from_default_env())
-                .with(tracing_subscriber::fmt::layer())
-                .with(inspector)
-                .init();
-        }
-    }
+    #[cfg(not(any(target_os = "android", target_vendor = "apple")))]
+    tracing_subscriber::registry()
+        .with(env_filter("wgpu_core=error,wgpu_hal=error,naga=error"))
+        .with(tracing_subscriber::fmt::layer())
+        .with(inspector)
+        .init();
 }
 
 /// Defines a trait for converting Rust types to FFI-compatible representations.


### PR DESCRIPTION
Fixes #304

`water run --logs debug` only widened the terminal's `log stream` / logcat filter; the launched process still recorded nothing above `error` unless `RUST_LOG` was set by hand, so Rust `tracing::debug!` output never appeared.

- The CLI now hands the chosen level to the application as `WATERUI_LOG` (`LogLevel::to_tracing_level`, inserted by `RunOptions::set_log_level`), so every launch path that forwards `env_vars()` — local macOS `open --env`, spawned child, simulator `SIMCTL_CHILD_*`, Android intent extras — carries it.
- The FFI composes its filter from it: `RUST_LOG` still wins outright; otherwise `WATERUI_LOG` sets the level while the graphics stack stays at `error` as before; with neither, `error`. The three platform arms of `init_tracing` duplicated that logic and now share one `env_filter` helper.

Verified on macOS with `water run --platform macos --logs debug` on `examples/image`: the stream now shows the Rust `[ImageRenderer] setup() called …` debug lines and the `selected WaterUI GPU adapter` info line, both previously filtered out; the process environment shows `WATERUI_LOG=debug`. Clippy (`waterui-cli`, `waterui-ffi`) and the CLI tests pass.