### PR TITLE
fix(apple): attach the native capture fence's completion handler before committing it

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ waterui-preview-version = "0.1.0"
 waterui-preview-protocol-version = "0.1.0"
 android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
-apple-backend-commit = "9799defb87f4c3b15dd8e26f44ac2381adbeee18"
+apple-backend-commit = "268576c03838dc3d8a793bbe2e410f76c9d97814"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
 android-backend-commit = "f4649a3641f0442bcbbfd1de2994af111d234c2f"
 


### PR DESCRIPTION
Fixes #308

Pins `backends/apple` to https://github.com/water-rs/apple-backend/pull/7 (and the CLI scaffold pin with it). Pre-existing defect: `renderNativeLayer` committed the fence command buffer and `capture()` then added a completed handler to it, which Metal rejects with an assertion, so every `WuiAppliedFilter` / `WuiViewEffect` aborted the app on its first captured frame.

Verified on macOS with `water run --platform macos --logs debug` on `examples/image`: the process that previously died at `Capture started` after two seconds now stays up, logs `Capture composition complete` per frame, and the window renders (checked visually).