### PR TITLE
fix(map): let the Apple backend declare its MapKit realization so the GPU map yields at runtime

### DIFF
--- a/examples/map/src/lib.rs
+++ b/examples/map/src/lib.rs
@@ -181,7 +181,6 @@ pub fn app(mut env: Environment) -> App {
     env.insert(MapGpuOptions::new(Url::new(
         "https://tiles.openfreemap.org/styles/positron",
     )));
-    #[cfg(not(target_vendor = "apple"))]
     waterui_map_gpu::install(&mut env);
     let state = MapExampleState::new();
     App::new(move || content(state.clone()), env)

--- a/ffi/src/components/data/map.rs
+++ b/ffi/src/components/data/map.rs
@@ -6,8 +6,24 @@
 use crate::reactive::{WuiBinding, WuiComputed};
 use crate::{IntoFFI, WuiStr};
 use alloc::vec::Vec;
+#[cfg(target_vendor = "apple")]
+use waterui_core::{Environment, view::ViewConfiguration as _};
 use waterui_map::{Annotation, Coordinate, Location, MapConfig, MapStatus, MapStyle, Region};
 use waterui_str::Str;
+
+/// Announces the Apple backend's `MapKit` bridge as this app's map realization.
+///
+/// A `Hook<MapConfig>` in the environment is the signal `waterui_map_gpu::install`
+/// reads to yield: a map realization is already spoken for. `MapKit` needs no
+/// transformation of the configuration, so the hook renders it into the raw view
+/// unchanged and that view reaches the backend through [`waterui_force_as_map`]
+/// exactly as before.
+/// Nothing is declared on platforms without a platform map, where the GPU map is
+/// the realization the application installs itself.
+#[cfg(target_vendor = "apple")]
+pub(crate) fn declare_native_realization(env: &mut Environment) {
+    env.insert_hook::<MapConfig, _>(|_env, config| config.render());
+}
 
 // =============================================================================
 // Coordinate FFI

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -102,7 +102,7 @@ macro_rules! export {
                 let inspector = unsafe { $crate::__init() };
                 let mut env = waterui::configure_environment!(waterui::Environment::new());
                 waterui::inspector::install(&mut env, inspector);
-                $crate::__configure_browser_environment(&mut env);
+                $crate::__configure_native_realizations(&mut env);
                 $crate::IntoFFI::into_ffi(env)
             }
 
@@ -160,21 +160,34 @@ macro_rules! export {
     };
 }
 
-/// Installs optional packaged browser runtimes selected by the generated FFI crate.
+/// Declares, in the environment a native backend is about to hand the app, the
+/// realizations that backend brings with it.
+///
+/// This runs before the application's own `app(env)`, which is what lets a
+/// Rust-side realization yield to a native one: `waterui_map_gpu::install`
+/// installs nothing when a `Hook<MapConfig>` is already present, and the Apple
+/// backend's `MapKit` bridge is announced here as exactly that hook. Packaged
+/// browser runtimes selected by the generated FFI crate are installed here too.
 ///
 /// Not `const`: the CEF arm installs a runtime. It compiled as `const` only
 /// because the CEF features were previously reached through cbindgen's macro
 /// expansion, which never type-checks the body.
 #[allow(
     clippy::missing_const_for_fn,
-    reason = "the body is empty only in the feature configuration being linted; enabling the capability makes it install a realization"
+    reason = "the body is empty only in the feature configuration being linted; enabling a capability makes it install a realization"
 )]
 #[doc(hidden)]
 #[inline]
-pub fn __configure_browser_environment(env: &mut waterui::Environment) {
+pub fn __configure_native_realizations(env: &mut waterui::Environment) {
+    #[cfg(all(feature = "map", target_vendor = "apple"))]
+    components::data::map::declare_native_realization(env);
     #[cfg(any(feature = "cef-runtime", feature = "cef-header"))]
     components::platform::browser_cef::configure_environment(env);
-    #[cfg(not(any(feature = "cef-runtime", feature = "cef-header")))]
+    #[cfg(not(any(
+        all(feature = "map", target_vendor = "apple"),
+        feature = "cef-runtime",
+        feature = "cef-header"
+    )))]
     let _ = env;
 }
 


### PR DESCRIPTION
Fixes #173

`examples/map` gated `waterui_map_gpu::install` behind `cfg(not(target_vendor = "apple"))` because nothing told the environment that the Apple backend brings a native map, so on macOS under Hydrolysis the example rendered the placeholder widget instead of GPU vector tiles.

- The FFI init the native backends call (`waterui_init`) now runs `__configure_native_realizations`, which declares the realizations that backend brings: on Apple with the `map` feature it inserts the `Hook<MapConfig>` that `waterui_map_gpu::install` already documents as its yield signal — the hook renders the configuration into the raw view unchanged, so MapKit is reached through `waterui_force_as_map` exactly as before. The CEF runtime installation moves under the same function. Hydrolysis never runs that init, so there the application's GPU map installs.
- `examples/map` installs the GPU map unconditionally.

Verified on macOS, both realizations, by screenshot: `water run --platform macos` shows Apple Maps (MapKit) with the Manhattan overlay; `water run --platform macos --backend hydrolysis` shows the OpenFreeMap positron vector tiles with the Rust-drawn controls. Clippy on `waterui-ffi` with `--features map` and `--features map,cef-header` is clean, and `map-example` checks.

Note: both runs needed the managed crates' lockfiles pinned back to the workspace's `tinyvec 1.12.0` by hand — see #312.
