### PR TITLE
chore: refresh Cargo.lock for the kit pin on main

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11950,13 +11950,11 @@ dependencies = [
  "dirs",
  "indexed_db_futures",
  "jni 0.22.4",
- "js-sys",
  "serde",
  "serde_json",
  "swift-bridge",
  "thiserror 2.0.20",
  "tracing",
- "wasm-bindgen",
  "waterkit-build",
  "windows 0.62.2",
 ]


### PR DESCRIPTION
Cherry-pick of 79f2c8858 (#306, Fixes #305 on `dev`) onto `main`, the same release-chain pattern as #286 and #300.

Release run 33807655083 publishes every crate up to `waterui` itself and then fails: `cargo publish` refuses because `Cargo.lock` is dirty — cargo rewrites it on first use because `main`'s lock still lists `js-sys`/`wasm-bindgen` under `waterkit-fs` after the kit pin moved (#305). Subdirectory crates publish regardless because the root lock is not part of their package; the root `waterui` crate is where it bites. With the lock committed, the rerun publishes `waterui` and the CLI.