### PR TITLE
chore(release): make workspace-internal dev-dependencies path-only

### DIFF
--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -119,13 +119,13 @@ waterui = { path = "../..", default-features = false }
 # `waterui-graphics` for its `gpu` feature (`CanvasImage` decodes through it),
 # which is why they are confined to dev-dependencies — the firmware graph,
 # built from the library alone, stays GPU-free.
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../../components/visual/canvas" }
 waterui-svg.workspace = true
 # The component issue #180 is actually about: an interactive chart wraps its
 # canvas in `Metadata<GestureObserver>` and `Metadata<OnEvent>`, and every one
 # of those wrappers used to abort dew's dispatch. Test-only, like the scene
 # crates above and for the same reason.
-waterui-chart.workspace = true
+waterui-chart = { path = "../../components/data/chart" }
 fearless_simd = { version = "0.4", features = ["force_support_fallback"] }
 executor-core.workspace = true
 native-executor.workspace = true

--- a/backends/hydrolysis/Cargo.toml
+++ b/backends/hydrolysis/Cargo.toml
@@ -157,7 +157,7 @@ web-sys = { version = "0.3", optional = true, features = [
 # The renderer itself knows nothing about `Canvas`: it resolves to a
 # `SceneView` before it reaches layout. The tests still author canvases, which
 # is what keeps that resolution honest.
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../../components/visual/canvas" }
 # The wayland examples need a widget theme; m3 is the one this workspace ships.
 # A dev-dependency back onto a crate that depends on this one is a cycle cargo
 # allows, and it keeps the examples next to the renderer they exercise.

--- a/backends/hydrolysis_m3/Cargo.toml
+++ b/backends/hydrolysis_m3/Cargo.toml
@@ -26,7 +26,7 @@ waterui-graphics = { workspace = true, features = ["gpu"] }
 pollster.workspace = true
 # The theme itself draws into the scene directly; only the shape gallery test
 # authors a canvas.
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../../components/visual/canvas" }
 waterui-testing = { path = "../../testing" }
 
 [package.metadata.waterui.assets]

--- a/components/foundation/text/Cargo.toml
+++ b/components/foundation/text/Cargo.toml
@@ -72,7 +72,7 @@ markdown = ["dep:pulldown-cmark"]
 waterui = { path = "../../.." }
 waterui-testing = { path = "../../../testing" }
 # The offscreen code-block tests render under the Material 3 widget theme, light and dark.
-hydrolysis-m3.workspace = true
+hydrolysis-m3 = { path = "../../../backends/hydrolysis_m3" }
 # This crate's own tests cover the Markdown parser, which is not in `default`.
 # A dev-dependency on itself turns the feature on for this crate's test targets
 # without turning it on for anything that depends on the crate.

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -28,7 +28,7 @@ serde_json.workspace = true
 [dev-dependencies]
 bitflags.workspace = true
 hydrolysis-m3 = { path = "../backends/hydrolysis_m3" }
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../components/visual/canvas" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Fixes #321

The Release run for the post-#318 `main` commit published 27 packages including `waterui 0.3.0`, then stopped at `hydrolysis-m3`: `cargo package` cannot resolve its test-only dependency on `waterui-canvas`, which has never been published. A dev-dependency that carries a version requirement stays in the packaged manifest, and release-plz orders publishes by normal dependencies, so nothing publishes canvas first.

Five publishable crates inherited a versioned workspace entry for a crate that is not on the registry: `hydrolysis-m3`, `hydrolysis` and `waterui-testing` (canvas), `waterui-dew` (canvas and chart), and `waterui-text` (`hydrolysis-m3`). The last one is not merely blocked — `hydrolysis-m3` depends on `waterui`, which depends on `waterui-text`, so the version requirement closes a cycle and no publish order exists.

Each of them now uses a plain path dependency, which is what the workspace already does for `waterui-testing` elsewhere. Cargo drops a path-only dev-dependency when packaging, the tests still build from the path, and no publish order has to satisfy them. The 36 example crates carry the same inherited dev-dependencies but all set `publish = false`, so they are left alone.

Verified: `cargo metadata` resolves the workspace, and `cargo check -p hydrolysis-m3 --tests` builds.
