### PR TITLE
chore(release): make workspace-internal dev-dependencies path-only (main)

### DIFF
--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -100,7 +100,7 @@ waterui-testing = { path = "../../testing" }
 # `waterui-graphics` for its `gpu` feature (`CanvasImage` decodes through it),
 # which is why they are confined to dev-dependencies — the firmware graph,
 # built from the library alone, stays GPU-free.
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../../components/visual/canvas" }
 waterui-svg.workspace = true
 fearless_simd = { version = "0.4", features = ["force_support_fallback"] }
 executor-core.workspace = true

--- a/backends/hydrolysis/Cargo.toml
+++ b/backends/hydrolysis/Cargo.toml
@@ -157,7 +157,7 @@ web-sys = { version = "0.3", optional = true, features = [
 # The renderer itself knows nothing about `Canvas`: it resolves to a
 # `SceneView` before it reaches layout. The tests still author canvases, which
 # is what keeps that resolution honest.
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../../components/visual/canvas" }
 # The wayland examples need a widget theme; m3 is the one this workspace ships.
 # A dev-dependency back onto a crate that depends on this one is a cycle cargo
 # allows, and it keeps the examples next to the renderer they exercise.

--- a/backends/hydrolysis_m3/Cargo.toml
+++ b/backends/hydrolysis_m3/Cargo.toml
@@ -26,7 +26,7 @@ waterui-graphics = { workspace = true, features = ["gpu"] }
 pollster.workspace = true
 # The theme itself draws into the scene directly; only the shape gallery test
 # authors a canvas.
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../../components/visual/canvas" }
 waterui-testing = { path = "../../testing" }
 
 [package.metadata.waterui.assets]

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -28,7 +28,7 @@ serde_json.workspace = true
 [dev-dependencies]
 bitflags.workspace = true
 hydrolysis-m3 = { path = "../backends/hydrolysis_m3" }
-waterui-canvas.workspace = true
+waterui-canvas = { path = "../components/visual/canvas" }
 
 [lints]
 workspace = true


### PR DESCRIPTION
Same fix as #322, applied to `main` where the Release workflow runs. Diagnosis in #321.

The current Release run published 27 packages including `waterui 0.3.0` and `waterui-backend-core 0.1.0`, then stopped at `hydrolysis-m3`: its test-only dependency on `waterui-canvas` carries a version requirement, `waterui-canvas` has never been published, and release-plz orders publishes by normal dependencies so nothing publishes canvas first. Four crates on `main` inherit that versioned entry (`hydrolysis-m3`, `hydrolysis`, `waterui-dew`, `waterui-testing`); each now uses a plain path dependency, as the workspace already does for `waterui-testing` elsewhere. Every rerun stops in the same place until `main` carries this.

**Left unmerged for you.** Merging into `main` re-triggers publishing, and that is your decision. The crates that would then publish are the same set the current run is already working through; this only removes the obstacle.