### PR TITLE
chore(apple): pin apple-backend a676865 and demo the text-field selection menu

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ waterui-preview-version = "0.1.0"
 waterui-preview-protocol-version = "0.1.0"
 android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
-apple-backend-commit = "268576c03838dc3d8a793bbe2e410f76c9d97814"
+apple-backend-commit = "a676865ba7315170aa964c89773e1f6543108aab"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
 android-backend-commit = "f4649a3641f0442bcbbfd1de2994af111d234c2f"
 

--- a/examples/menu/src/lib.rs
+++ b/examples/menu/src/lib.rs
@@ -191,6 +191,34 @@ fn context_menu_section(context_action: &Binding<String>) -> impl View {
     .padding()
 }
 
+fn selection_menu_section(selection_action: &Binding<String>) -> impl View {
+    let draft = binding(Str::from("Select some of this text, then open the menu"));
+    vstack((
+        text("Selection Menu").sub_headline(),
+        text("Select text in the field and use its context menu")
+            .body()
+            .foreground(MutedForeground),
+        spacer().height(12.0),
+        field("Draft", &draft).selection_menu((
+            "Shout"
+                .action(|State(action): State<Binding<String>>| {
+                    action.set("Shouted the selection!".to_string())
+                })
+                .state(selection_action),
+            "Whisper"
+                .action(|State(action): State<Binding<String>>| {
+                    action.set("Whispered the selection!".to_string())
+                })
+                .state(selection_action),
+        )),
+        spacer().height(12.0),
+        text!("{selection_action}")
+            .font(font::Caption)
+            .foreground(MutedForeground),
+    ))
+    .padding()
+}
+
 fn context_menu_views_section(view_action: &Binding<String>) -> impl View {
     vstack((
         text("Context Menu on Views").sub_headline(),
@@ -263,6 +291,7 @@ fn scene(toolbar_status: Binding<String>) -> impl View {
     let styled_action = Binding::container(String::from("No action yet"));
     let context_action = Binding::container(String::from("No action yet"));
     let view_action = Binding::container(String::from("No action yet"));
+    let selection_action = Binding::container(String::from("No action yet"));
 
     scroll(
         vstack((
@@ -278,7 +307,11 @@ fn scene(toolbar_status: Binding<String>) -> impl View {
             Divider,
             context_menu_section(&context_action),
             Divider,
-            context_menu_views_section(&view_action),
+            vstack((
+                context_menu_views_section(&view_action),
+                Divider,
+                selection_menu_section(&selection_action),
+            )),
             Divider,
             toolbar_scene_section(&toolbar_status),
             spacer().height(40.0),


### PR DESCRIPTION
Moves `backends/apple` and the scaffold pin (`cli/Cargo.toml`) to apple-backend `dev` a676865, which carries apple-backend #8 (SwiftFormat 0.60 drift and the non-Sendable WuiList observer), #9 (text-field selection menu, #324), #10 (toolbar tabs centred, #325) and #11 (periphery clean, #311).

`examples/menu` gains a "Selection Menu" section with a text field whose selection menu carries two actions; #324 had no example exercising the feature. Verified on macOS: the items appear in the field's context menu and choosing one updates the caption. The section is nested in its own `vstack` because the page already held the 16-element view-tuple maximum.

Related: #311, #324, #325 (all closed by the apple-backend PRs).