### PR TITLE
fix(cli): seed the managed FFI crate's Cargo.lock from the project lockfile

### DIFF
--- a/cli/src/project_model/project.rs
+++ b/cli/src/project_model/project.rs
@@ -14,12 +14,24 @@ enum OpenMode {
     PreviewBuild,
 }
 
-fn spawn_target_dir_resolution(
+/// What `cargo metadata` reports about the tree a project builds in.
+///
+/// Resolved once per [`Project`] and shared by everything that needs it, so
+/// one `cargo metadata` run serves the target directory and the lockfile.
+#[derive(Debug, Clone)]
+struct CargoLayout {
+    target_dir: PathBuf,
+    /// Root of the Cargo workspace the project belongs to — the project itself
+    /// when it is not a workspace member. This is where its `Cargo.lock` lives.
+    workspace_root: PathBuf,
+}
+
+fn spawn_cargo_layout_resolution(
     current_dir: &Path,
-) -> Shared<BoxFuture<'static, Result<PathBuf, String>>> {
+) -> Shared<BoxFuture<'static, Result<CargoLayout, String>>> {
     let current_dir = current_dir.to_path_buf();
     smol::spawn(async move {
-        get_target_dir(&current_dir)
+        resolve_cargo_layout(&current_dir)
             .await
             .map_err(|error| error.to_string())
     })
@@ -33,7 +45,7 @@ pub struct Project {
     root: PathBuf,
     manifest: Manifest,
     crate_name: CrateName,
-    target_dir_future: Shared<BoxFuture<'static, Result<PathBuf, String>>>,
+    cargo_layout: Shared<BoxFuture<'static, Result<CargoLayout, String>>>,
     linked_packages: Arc<async_lock::OnceCell<Result<BTreeMap<String, String>, String>>>,
     managed_backends_root: PathBuf,
 }
@@ -149,7 +161,24 @@ impl Project {
     ///
     /// Returns an error when Cargo metadata cannot resolve the target directory.
     pub async fn target_dir(&self) -> eyre::Result<PathBuf> {
-        self.target_dir_future
+        Ok(self.cargo_layout().await?.target_dir)
+    }
+
+    /// The lockfile the application builds against.
+    ///
+    /// The workspace `Cargo.lock` when the project is a workspace member,
+    /// otherwise the project's own. It need not exist yet: a project that has
+    /// never been resolved has none.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when Cargo metadata cannot resolve the workspace.
+    pub async fn lockfile_path(&self) -> eyre::Result<PathBuf> {
+        Ok(self.cargo_layout().await?.workspace_root.join("Cargo.lock"))
+    }
+
+    async fn cargo_layout(&self) -> eyre::Result<CargoLayout> {
+        self.cargo_layout
             .clone()
             .await
             .map_err(|error| eyre::eyre!(error))
@@ -382,11 +411,11 @@ impl Project {
     /// omits a package referenced by that graph.
     pub async fn links_runtime_package(&self, package_name: &str) -> eyre::Result<bool> {
         let project_root = self.root.clone();
-        let target_dir_future = self.target_dir_future.clone();
+        let cargo_layout = self.cargo_layout.clone();
         let packages = self
             .linked_packages
             .get_or_init(|| async move {
-                target_dir_future.await?;
+                cargo_layout.await?;
                 resolve_linked_runtime_packages(project_root)
                     .await
                     .map_err(|error| error.to_string())
@@ -714,6 +743,14 @@ impl Project {
 
         templates::ffi::scaffold(&self.ffi_crate_path(), &ctx, &self.ffi_crate_name())
             .await
+            .map_err(crate::backend::FailToInitBackend::Io)?;
+
+        let lockfile = self
+            .lockfile_path()
+            .await
+            .map_err(crate::backend::FailToInitBackend::Config)?;
+        templates::ffi::seed_lockfile(&self.ffi_crate_path(), &lockfile)
+            .await
             .map_err(crate::backend::FailToInitBackend::Io)
     }
 
@@ -857,12 +894,12 @@ impl Project {
             path.join(manifest.backends.path())
         };
 
-        let target_dir_future = spawn_target_dir_resolution(&path);
+        let cargo_layout = spawn_cargo_layout_resolution(&path);
         Ok(Self {
             root: path,
             manifest,
             crate_name,
-            target_dir_future,
+            cargo_layout,
             linked_packages: Arc::new(async_lock::OnceCell::new()),
             managed_backends_root,
         })
@@ -1190,12 +1227,12 @@ impl Project {
             path.join(manifest.backends.path())
         };
 
-        let target_dir_future = spawn_target_dir_resolution(&path);
+        let cargo_layout = spawn_cargo_layout_resolution(&path);
         let mut project = Self {
             root: path,
             manifest,
             crate_name,
-            target_dir_future,
+            cargo_layout,
             linked_packages: Arc::new(async_lock::OnceCell::new()),
             managed_backends_root,
         };
@@ -1290,7 +1327,7 @@ impl Project {
     }
 }
 
-async fn get_target_dir(current_dir: &Path) -> Result<PathBuf, cargo_metadata::Error> {
+async fn resolve_cargo_layout(current_dir: &Path) -> Result<CargoLayout, cargo_metadata::Error> {
     let current_dir = current_dir.to_path_buf();
     let metadata = unblock(|| {
         cargo_metadata::MetadataCommand::new()
@@ -1300,9 +1337,10 @@ async fn get_target_dir(current_dir: &Path) -> Result<PathBuf, cargo_metadata::E
     })
     .await?;
 
-    let target_dir = metadata.target_directory.as_std_path();
-
-    Ok(target_dir.to_path_buf())
+    Ok(CargoLayout {
+        target_dir: metadata.target_directory.into_std_path_buf(),
+        workspace_root: metadata.workspace_root.into_std_path_buf(),
+    })
 }
 
 async fn resolve_linked_runtime_packages(

--- a/cli/src/project_model/templates.rs
+++ b/cli/src/project_model/templates.rs
@@ -1636,6 +1636,47 @@ mod tests {
     }
 
     #[test]
+    fn ffi_lockfile_seed_follows_the_project_lockfile() {
+        let tempdir = tempdir().expect("temporary ffi seed dir");
+        let project_lock = tempdir.path().join("Cargo.lock");
+        let ffi_dir = tempdir.path().join("managed_backends/ffi");
+        std::fs::create_dir_all(&ffi_dir).expect("ffi dir");
+        let managed_lock = ffi_dir.join("Cargo.lock");
+        let seed = || {
+            smol::block_on(crate::templates::ffi::seed_lockfile(
+                &ffi_dir,
+                &project_lock,
+            ))
+            .expect("seeding the managed lockfile should succeed");
+        };
+        let managed = || std::fs::read_to_string(&managed_lock).expect("managed Cargo.lock");
+
+        // No project lockfile: nothing to pin, the managed crate resolves on its own.
+        seed();
+        assert!(!managed_lock.exists());
+
+        std::fs::write(&project_lock, "pins v1").expect("project lock");
+        seed();
+        assert_eq!(managed(), "pins v1");
+
+        // Cargo rewrote the managed lockfile (pruned the project's unused entries,
+        // added the FFI crate's own); an unchanged project lockfile leaves that alone.
+        std::fs::write(&managed_lock, "pins v1 + ffi entries").expect("managed lock");
+        seed();
+        assert_eq!(managed(), "pins v1 + ffi entries");
+
+        // The project re-resolved: the managed crate follows it.
+        std::fs::write(&project_lock, "pins v2").expect("project lock");
+        seed();
+        assert_eq!(managed(), "pins v2");
+
+        // A managed lockfile that went missing is re-seeded from the current pins.
+        std::fs::remove_file(&managed_lock).expect("remove managed lock");
+        seed();
+        assert_eq!(managed(), "pins v2");
+    }
+
+    #[test]
     fn preview_ffi_scaffold_emits_dylib_only_wrapper() {
         let tempdir = tempdir().expect("temporary preview ffi scaffold dir");
         let project_root = tempdir.path().join("playground");
@@ -3088,6 +3129,62 @@ pub mod ffi {
     ) -> io::Result<()> {
         generate_cargo_toml(base_dir, ctx, package_name).await?;
         scaffold_dir(TemplateNamespace::Ffi, &embedded::FFI, base_dir, ctx).await
+    }
+
+    /// The copy of the application's lockfile the managed crate was last
+    /// seeded from, kept beside the crate's own `Cargo.lock`.
+    pub const LOCKFILE_SEED: &str = "Cargo.lock.seed";
+
+    /// Seed the managed crate's `Cargo.lock` from the application's lockfile.
+    ///
+    /// The managed crate is its own Cargo workspace, so left alone it resolves
+    /// its dependency graph fresh from the registry the first time it is built,
+    /// and the application ships with versions nothing in the project pins or
+    /// tests (#312). Copying the project's lockfile in before Cargo resolves
+    /// keeps every version the project already pins; Cargo then only adds the
+    /// entries the managed crate needs on top (`waterui-ffi` and its own
+    /// dependencies) and prunes the ones it does not use.
+    ///
+    /// Cargo rewrites `Cargo.lock` on every resolution, so the seed cannot be
+    /// compared against it. A copy of the seed is kept as [`LOCKFILE_SEED`]
+    /// instead, and the crate is re-seeded only when the project's lockfile
+    /// differs from that copy, or when the crate has no `Cargo.lock` at all.
+    /// A project without a lockfile has nothing to pin yet and is left to
+    /// resolve on its own.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when the lockfiles cannot be read or written.
+    pub async fn seed_lockfile(base_dir: &Path, project_lockfile: &Path) -> io::Result<()> {
+        let seed = match fs::read(project_lockfile).await {
+            Ok(seed) => seed,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => {
+                tracing::debug!(
+                    lockfile = %project_lockfile.display(),
+                    "project has no lockfile; the managed FFI crate resolves on its own"
+                );
+                return Ok(());
+            }
+            Err(error) => return Err(error),
+        };
+
+        let seed_copy = base_dir.join(LOCKFILE_SEED);
+        let managed_lockfile = base_dir.join("Cargo.lock");
+        let seeded_from = match fs::read(&seed_copy).await {
+            Ok(previous) => previous == seed,
+            Err(error) if error.kind() == io::ErrorKind::NotFound => false,
+            Err(error) => return Err(error),
+        };
+        if seeded_from && managed_lockfile.exists() {
+            return Ok(());
+        }
+
+        tracing::debug!(
+            lockfile = %project_lockfile.display(),
+            "seeding the managed FFI crate's Cargo.lock from the project lockfile"
+        );
+        fs::write(&managed_lockfile, &seed).await?;
+        fs::write(&seed_copy, &seed).await
     }
 
     async fn generate_cargo_toml(


### PR DESCRIPTION
The managed FFI crate under `~/.water/build_cache/…/managed_backends/ffi` is its own Cargo workspace and resolved its graph fresh from the registry, so `water run` built the app with versions nothing in the project pins or tests; `examples/map` picked up `tinyvec 1.13.0` that way and failed to compile while every workspace check was green (#312).

- `Project` resolves the workspace root alongside the target directory from the single `cargo metadata --no-deps` run it already makes (`CargoLayout`), and exposes `lockfile_path()`: the workspace `Cargo.lock` for a member, the project's own otherwise.
- `templates::ffi::seed_lockfile` copies that lockfile into the managed crate before Cargo resolves. Cargo keeps every pinned version and only adds the FFI-only entries on top. A copy of the seed (`Cargo.lock.seed`) sits beside the managed lockfile so re-seeding happens only when the project's pins change or the managed lockfile is missing — never on every scaffold, which would re-resolve the FFI-only entries (and hit the index) each run. A project with no lockfile yet is left to resolve on its own.
- Unit test covers first seed, Cargo's rewrite being left alone, re-seed on changed pins, and re-seed after deletion.

Verified end to end on `examples/map` with the managed `Cargo.lock` deleted: the CLI wrote the 353 KB workspace lockfile in as the seed, Cargo pruned it to the 211 KB the FFI graph needs, and the managed lockfile carries `tinyvec 1.12.0` (the workspace pin) instead of a fresh resolution.

Fixes #312