### PR TITLE
fix(release): let dist build without owning release.yml

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -17,3 +17,8 @@ formula = "water"
 publish-jobs = ["homebrew"]
 # Target platforms to build apps for (Rust target-triple syntax)
 targets = ["aarch64-apple-darwin", "aarch64-unknown-linux-gnu", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-pc-windows-msvc", "x86_64-pc-windows-msvc"]
+# release-plz owns `release.yml`, and `build-cli.yml` calls `dist build` per
+# target, so the CI file is ours rather than dist-generated. Without this,
+# `dist build` refuses to run until release.yml matches dist's own template
+# (#349).
+allow-dirty = ["ci"]


### PR DESCRIPTION
Release run 33927540889 was the first to reach `Build waterui-cli binaries` (waterui-cli 0.1.4 published), and every target failed in `dist build` with "release.yml has out of date contents": `ci = "github"` makes dist verify the release workflow against its own template, and ours is release-plz's with `build-cli.yml` as the per-target `dist build` hand-off (#349).

`allow-dirty = ["ci"]` in `dist-workspace.toml` is dist's documented setting for a customized CI file. `dist plan --tag waterui-cli-v0.1.4` passes locally with cargo-dist 0.30.2 (the version CI pins); the real verification is re-running the failed jobs of the Release run once this is on `main`.

Fixes #349