### PR TITLE
ci: only the integration branches write the bench and Windows caches

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -172,6 +172,13 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: bench-${{ matrix.os }}
+          # Only the integration branches write cache generations, as in
+          # ci.yml and test.yml. Bench runs on dev only from the schedule and
+          # by hand, so that is where the three bench generations get written;
+          # a pull request reads them and saves nothing. PR runs used to write
+          # them on every fingerprint, and their 5 GB share of the 10 GB
+          # repository cap evicted the Test tarballs (#328).
+          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Build water CLI

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -52,6 +52,12 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: test-windows-latest
+          # Only the integration branches write cache generations, as in
+          # ci.yml and test.yml: a pull request reads them and saves nothing.
+          # Every PR fingerprint used to mint its own 5 GB generation here,
+          # and with the 10 GB repository cap that evicted the Test tarballs
+          # a dev run had just written (#328).
+          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       # Four crates cannot be tested here, for reasons that are not bugs:


### PR DESCRIPTION
Part of #328.

`ci.yml` and `test.yml` already restrict rust-cache saves to `dev` and `main` so pull-request fingerprints do not mint cache generations that nothing reclaims. `bench.yml` and `windows.yml` never got that rule, and the repository's Actions cache right now holds exactly their PR-written generations:

| cache | size | written by |
|---|---|---|
| `bench-ubuntu-latest` | 1.5 GB | a PR bench run |
| `bench-windows-latest` | 1.8 GB | a PR bench run |
| `bench-macos-latest` | 1.6 GB | a PR bench run |
| `test-windows-latest` | 5.1 GB | a PR Windows run |

That is the whole 10 GB cap, and every Test tarball the last `dev` run wrote has been evicted, so each `dev` run compiles cold.

This PR gives both workflows the same `save-if` as the others. Bench runs on `dev` from the schedule and by hand, so that is where its three generations get written. The remaining work on #328 is sizing the Test tarballs themselves so all of the `dev`-written generations fit under the cap; that needs the sizes from the next `dev` run, which is queued.
