### PR TITLE
fix(testing): install a complete theme under ui() by default

### DIFF
--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -13,6 +13,7 @@ categories.workspace = true
 
 [dependencies]
 hydrolysis = { workspace = true, features = ["accessibility", "testing"] }
+hydrolysis-m3.workspace = true
 waterui-core.workspace = true
 waterui.workspace = true
 wgpu.workspace = true
@@ -27,7 +28,6 @@ serde_json.workspace = true
 
 [dev-dependencies]
 bitflags.workspace = true
-hydrolysis-m3 = { path = "../backends/hydrolysis_m3" }
 waterui-canvas.workspace = true
 
 [lints]

--- a/testing/README.md
+++ b/testing/README.md
@@ -36,7 +36,8 @@ fn stepper_updates(ui: UiBuilder) {
 ## Design
 
 - **Theme and render mode are orthogonal.** `.theme(installer)` swaps the theme package
-  (plain Hydrolysis test theme by default); `mount()` is the fast semantic runtime,
+  (Material 3 by default, the theme a generated project installs); `mount()` is the fast
+  semantic runtime,
   `mount_offscreen()` the GPU-backed one. Any theme works in either mode.
 - **Interactions are assertions.** `tap`, `set_text`, `increment`, `focus`, drags and key
   presses return `()` and panic when the runtime reports the accessibility action

--- a/testing/src/app.rs
+++ b/testing/src/app.rs
@@ -39,10 +39,26 @@ pub fn ui() -> UiBuilder {
     UiBuilder::new()
 }
 
+/// Installs the theme a test runs under when it names none.
+///
+/// This is the complete Hydrolysis theme: the backend's own test installer
+/// supplies the component bridges it realizes natively (the map), and
+/// Material 3 supplies everything a view can draw with — colour and font
+/// tokens, typography, and the widget theme that every Hydrolysis control
+/// reads its chrome from. Material 3 is what a generated project installs, so
+/// a test sees what the application's window shows, and a scroll view, a
+/// button or a toggle mounts under `ui()` without the test binary opting into
+/// a theme package first. Its tokens replace the backend installer's, which
+/// exist for renderer tests that run without a theme package.
+pub fn install_default_theme(env: &mut Environment) {
+    hydrolysis::testing::install_theme(env);
+    hydrolysis_m3::install_defaults(env);
+}
+
 /// Runtime test host and configuration.
 ///
 /// Theme and render mode are orthogonal: [`Self::theme`] swaps the installed
-/// theme package (defaulting to the plain Hydrolysis test theme), while
+/// theme package (defaulting to [`install_default_theme`]), while
 /// [`Self::mount`] / [`Self::mount_offscreen`] pick between the fast semantic
 /// runtime and the GPU-backed offscreen runtime. Any theme works in either
 /// mode.
@@ -79,7 +95,7 @@ impl UiBuilder {
             env: Environment::new(),
             width: 390,
             height: 844,
-            theme: Rc::new(hydrolysis::testing::install_theme),
+            theme: Rc::new(install_default_theme),
             perf_config: PerfConfig::default(),
         }
     }
@@ -101,7 +117,8 @@ impl UiBuilder {
         self
     }
 
-    /// Replaces the default Hydrolysis test theme with a theme package.
+    /// Replaces the default theme ([`install_default_theme`]) with a theme
+    /// package.
     #[must_use]
     pub fn theme<U: ThemeInstaller>(mut self, theme: U) -> Self {
         self.theme = Rc::new(move |env| theme.install(env));

--- a/testing/src/lib.rs
+++ b/testing/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! `waterui-testing` runs inside ordinary `cargo test` targets. [`ui`] builds a
 //! test session; theme and render mode are orthogonal: [`UiBuilder::theme`]
-//! swaps the theme package (the plain Hydrolysis test theme by default) and
+//! swaps the theme package (Material 3, the theme a generated project installs,
+//! by default) and
 //! [`UiBuilder::mount`] / [`UiBuilder::mount_offscreen`] pick between the fast
 //! semantic runtime and the GPU-backed offscreen runtime.
 //!
@@ -96,7 +97,9 @@ mod snapshot;
 pub(crate) mod wait;
 
 pub use accesskit::Role as AccessKitRole;
-pub use app::{DragOptions, OffscreenApp, SemanticApp, ThemeInstaller, UiBuilder, ui};
+pub use app::{
+    DragOptions, OffscreenApp, SemanticApp, ThemeInstaller, UiBuilder, install_default_theme, ui,
+};
 pub use artifacts::{CapturedSnapshot, TestArtifacts, artifact_root};
 pub use driver::FrameTiming;
 pub use executor::drain_parked_local_work;

--- a/testing/src/tests.rs
+++ b/testing/src/tests.rs
@@ -263,6 +263,22 @@ fn smoke_theme_foreground_slot_snapshot_preserves_semantic_labels() {
     assert_eq!(snapshot.rgba8.len(), 240 * 120 * 4);
 }
 
+/// A view that draws widget chrome mounts under the default theme: the scroll
+/// view's scrollbar and the button both read a widget theme from the
+/// environment, and `ui()` used to install none (#290).
+#[test]
+fn default_theme_renders_hydrolysis_widgets() {
+    let mut app = ui().viewport(240, 160).mount_offscreen(|| {
+        ScrollView::vertical(vstack((
+            waterui::component::button("Submit"),
+            text("Scrolled content").body(),
+        )))
+    });
+    assert_eq!(app.query().role(Role::BUTTON).all().len(), 1);
+    let snapshot = app.snapshot();
+    assert_eq!(snapshot.rgba8.len(), 240 * 160 * 4);
+}
+
 #[test]
 fn semantic_builder_does_not_require_theme_package() {
     let mut app = ui()


### PR DESCRIPTION
Fixes #290.

`ui()` installed `hydrolysis::testing::install_theme` and nothing else: colour and font tokens and the map bridge, but no `Box<dyn WidgetTheme>`, which every Hydrolysis control expects. Mounting a scroll view, a button or a toggle under the default theme panicked with `hydrolysis widget theme is not installed in the environment`. The monorepo's tests all opt into Material 3 explicitly, which is why it only surfaced from a standalone crate's test.

The default becomes `waterui_testing::install_default_theme`: the backend installer for the bridges it realizes natively, then `hydrolysis_m3::install_defaults` for tokens, typography and the widget theme. Material 3 is the only widget theme this workspace ships and the one a generated project installs, so a test now sees what the application's window shows. `hydrolysis-m3` moves from a dev-dependency to a dependency of `waterui-testing` (it is on crates.io at 0.1.0, so the published harness can carry it).

`default_theme_renders_hydrolysis_widgets` mounts a scroll view around a button offscreen under `ui()` with no theme named and snapshots it; before this change that panicked. `cargo clippy -p waterui-testing --all-targets -D warnings` is clean.
