### PR TITLE
fix(release): run release-plz from the water-rs fork that rewinds submodules

### DIFF
--- a/.github/actions/release-plz/action.yml
+++ b/.github/actions/release-plz/action.yml
@@ -1,0 +1,34 @@
+name: release-plz
+description: >-
+  Runs one release-plz command with the water-rs/release-plz build. The fork
+  rewinds submodules when it checks historical commits out to compare packages
+  with the registry (#313), which upstream release-plz-v0.3.161 does not;
+  everything else mirrors what MarcoIeni/release-plz-action@v0.5 does around
+  the binary.
+inputs:
+  command:
+    description: "`release-pr` or `release`."
+    required: true
+runs:
+  using: composite
+  steps:
+    - uses: taiki-e/install-action@v2
+      with:
+        tool: cargo-semver-checks@0.50
+    # Built from the fork at a pinned commit and cached by that commit, so
+    # the compile is paid once per rev. Bump `rev` after rebasing the fork's
+    # `waterui/commit-too-old-before-packaging` branch onto a newer upstream tag.
+    - uses: taiki-e/cache-cargo-install-action@v3
+      with:
+        tool: release-plz
+        git: https://github.com/water-rs/release-plz
+        rev: cc554a52e97e0ee359e45c7801d770895247cf27
+        locked: true
+    - uses: release-plz/git-config@v0.1.2
+    - name: Run release-plz ${{ inputs.command }}
+      shell: bash
+      run: >-
+        release-plz ${{ inputs.command }}
+        --git-token "${GITHUB_TOKEN}"
+        --repo-url "https://github.com/${GITHUB_REPOSITORY}"
+        --forge github

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
       # `cros-libva` build script, reached through `waterkit-codec`, fails the
       # `waterui-image` verify build on the missing `libva-dev`.
       - uses: ./.github/actions/setup-linux-deps
-      - uses: MarcoIeni/release-plz-action@v0.5
+      - uses: ./.github/actions/release-plz
         with:
           command: release
         env:
@@ -69,7 +69,7 @@ jobs:
       # The same native libraries as above: computing the next versions also
       # builds the workspace's metadata against every crate's dependencies.
       - uses: ./.github/actions/setup-linux-deps
-      - uses: MarcoIeni/release-plz-action@v0.5
+      - uses: ./.github/actions/release-plz
         with:
           command: release-pr
         env:


### PR DESCRIPTION
Fixes #313.

release-plz's `release-pr` dies on `main`: `get_package_diff` checks historical commits out in a copy of the repository and runs `cargo package` there to compare each package with the registry. A plain `git checkout` leaves every submodule at the working tree's commit, so an old superproject commit gets packaged with the current `kit/` contents, `waterkit-codec` (wanting `shaderloom ^0.1.2`) cannot resolve against that commit's `Cargo.lock` (`shaderloom 0.1.0`), and the update aborts for every package. No release PR has been opened since.

Per the decision on #313 this is fixed locally, not upstream. [water-rs/release-plz](https://github.com/water-rs/release-plz), branch `waterui/commit-too-old-before-packaging`, carries one commit on top of `release-plz-v0.3.161` (the version `release-plz-action@v0.5` pins):

- `Repo::checkout` runs `git submodule update --init --recursive` after the checkout, which also fetches recorded commits the local clone lacks. Best effort: some of our pins point at submodule history that was rewritten afterwards (kit `e164b19e`, recorded by 9ca31664), so such a submodule stays put with a warning.
- The walk asks `is_commit_too_old` before packaging a commit it would stop at anyway.
- A commit whose package cannot be built for comparison counts as "changed", with a warning, instead of aborting the whole update.

Verified against a clone of `main` (a19d500d) with full submodule history: the released 0.3.161 binary dies on the first package; the patched `release-plz update` walks all 44 packages, computes 43 bumps, and never needed the comparison fallback.

`.github/actions/release-plz` is a local composite action that installs that build at a pinned commit through `taiki-e/cache-cargo-install-action` (compiled once per rev, cached after) and runs the same `release-pr` / `release` invocation the upstream action ran, with `release-plz/git-config` and `cargo-semver-checks@0.50` beside it. Both release jobs use it. To take a newer upstream release: rebase the fork branch onto the new tag, push, bump `rev`.
