### PR TITLE
fix(apple): show a filtered Photo and survive a filter laid out empty

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ waterui-preview-version = "0.1.0"
 waterui-preview-protocol-version = "0.1.0"
 android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
-apple-backend-commit = "a676865ba7315170aa964c89773e1f6543108aab"
+apple-backend-commit = "aa55c057cb92dd020361e7a0ac705d9f2781e395"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
 android-backend-commit = "f4649a3641f0442bcbbfd1de2994af111d234c2f"
 

--- a/ffi/src/components/visual/applied_filter.rs
+++ b/ffi/src/components/visual/applied_filter.rs
@@ -218,6 +218,7 @@ fn ensure_dimensions(state: &mut WuiAppliedFilterState, width: u32, height: u32)
     if input_resized || state.capture_texture.is_none() {
         state.capture_texture = Some(create_capture_texture(
             &state.runtime.context().device,
+            &state.runtime.context().queue,
             capture_format,
             width,
             height,
@@ -225,13 +226,24 @@ fn ensure_dimensions(state: &mut WuiAppliedFilterState, width: u32, height: u32)
     }
 }
 
+/// Creates the texture the native backend captures the filtered subtree into.
+///
+/// The host writes this texture from outside wgpu — Metal's `CARenderer` and
+/// the capture compositor on Apple — and wgpu only ever samples it. wgpu tracks
+/// memory initialisation per texture, and a texture it has never written is
+/// zero-cleared the first time it is bound for sampling, which would wipe the
+/// host's first capture and hand the filter a transparent input. Clearing it
+/// here, through wgpu, marks it initialised once and for all, so every later
+/// external write is read back as written. The clear is an empty render pass
+/// rather than `clear_texture`, which needs the `CLEAR_TEXTURE` device feature.
 fn create_capture_texture(
     device: &wgpu::Device,
+    queue: &wgpu::Queue,
     format: wgpu::TextureFormat,
     width: u32,
     height: u32,
 ) -> wgpu::Texture {
-    device.create_texture(&wgpu::TextureDescriptor {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
         label: Some("AppliedFilter Capture Texture"),
         size: wgpu::Extent3d {
             width,
@@ -246,7 +258,29 @@ fn create_capture_texture(
             | wgpu::TextureUsages::RENDER_ATTACHMENT
             | wgpu::TextureUsages::COPY_DST,
         view_formats: &[],
-    })
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("AppliedFilter Capture Texture Init"),
+    });
+    drop(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("AppliedFilter Capture Texture Init"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: &view,
+            depth_slice: None,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                store: wgpu::StoreOp::Store,
+            },
+        })],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    }));
+    queue.submit([encoder.finish()]);
+    texture
 }
 
 fn resolve_output_size(
@@ -435,6 +469,7 @@ pub unsafe extern "C" fn waterui_applied_filter_attach(
     }
     let capture_texture = create_capture_texture(
         &state.runtime.context().device,
+        &state.runtime.context().queue,
         capture_format,
         input_width,
         input_height,


### PR DESCRIPTION
Fixes #310. Fixes #342.

Two commits:

- **ffi**: the applied-filter capture texture is written from outside wgpu (Metal's `CARenderer` and the capture compositor) and only sampled by wgpu. wgpu tracks memory initialisation per texture and zero-clears a never-written texture the first time it is bound for sampling, which wiped the host's first capture and handed the filter a transparent input. One clear through wgpu (an empty render pass; `clear_texture` needs a feature we do not enable) marks it initialised.
- **apple submodule → aa55c057 (apple-backend dev after #13 and #14) with the CLI pin moved together** (#342). #14 carries the Apple half: `CARenderer` never clears its destination, so uninitialised memory composited as opaque content; a `GpuSurface` whose content changed size after setup never relaid out its host; an applied filter attached at a `Dynamic` host's first offered size and then laid out to zero kept asking for frames and trapped (#352).

Verified on macOS with `examples/image`: the "Photo from URL" section shows the blurred photo with its slider and the Custom URL Loader below it; Load no longer crashes; the loaded photo appears at its decoded size and its blur slider updates the filter live.
