### PR TITLE
perf(hydrolysis): capture filtered subtrees through a shared atlas

### DIFF
--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -269,6 +269,8 @@ pub struct HydrolysisRenderer {
     /// [`HydrolysisRenderer::refresh_active_applied_filters`] on redraw-only
     /// frames; dead entries are pruned by strong count.
     node_applied_filters: Vec<Rc<RefCell<AppliedFilterRuntime>>>,
+    /// The per-frame atlas every filtered subtree is captured through.
+    subtree_captures: SubtreeCaptures,
     pub(crate) lazy: LazyState,
     pub(crate) navigation: NavigationState,
     navigation_captures: Vec<NavigationSceneCapture>,
@@ -386,6 +388,7 @@ impl HydrolysisRenderer {
             node_gpu_surfaces: Vec::new(),
             node_view_effects: Vec::new(),
             node_applied_filters: Vec::new(),
+            subtree_captures: SubtreeCaptures::default(),
             lazy: LazyState::default(),
             navigation: NavigationState::default(),
             navigation_captures: Vec::new(),

--- a/backends/hydrolysis/src/renderer/effects.rs
+++ b/backends/hydrolysis/src/renderer/effects.rs
@@ -133,9 +133,38 @@ impl AppliedFilterRuntime {
             "hydrolysis_applied_filter_input",
             width,
             height,
+            // `COPY_DST`: the tree flush captures the child into an atlas page
+            // and copies the slot into this texture.
             wgpu::TextureUsages::RENDER_ATTACHMENT
                 | wgpu::TextureUsages::TEXTURE_BINDING
-                | wgpu::TextureUsages::STORAGE_BINDING,
+                | wgpu::TextureUsages::STORAGE_BINDING
+                | wgpu::TextureUsages::COPY_DST,
+        )
+    }
+
+    /// Allocate the output texture for a `width` × `height` input and return
+    /// the image handle that will show its contents, before the filter has run.
+    /// The atlas capture draws the image into the parent scene at flush time and
+    /// runs the filter when the capture level is flushed; the handle is stable
+    /// across both because the texture is.
+    pub(super) fn prepare_output(
+        &mut self,
+        device: &wgpu::Device,
+        vello_renderer: &mut vello::Renderer,
+        width: u32,
+        height: u32,
+    ) -> vello::peniko::ImageData {
+        let (output_width, output_height) = self.filter().output_size(width, height);
+        let output_texture = self
+            .output_texture(device, output_width, output_height)
+            .0
+            .clone();
+        register_or_override_output_image(
+            &mut self.output_image,
+            vello_renderer,
+            output_texture,
+            output_width,
+            output_height,
         )
     }
 
@@ -173,22 +202,6 @@ impl AppliedFilterRuntime {
         self.input_texture
             .as_ref()
             .map(|texture| (texture.width, texture.height))
-    }
-
-    pub(super) fn render_output(
-        &mut self,
-        device: &wgpu::Device,
-        queue: &wgpu::Queue,
-        vello_renderer: &mut vello::Renderer,
-        width: u32,
-        height: u32,
-    ) -> (vello::peniko::ImageData, bool) {
-        let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("hydrolysis applied filter encoder"),
-        });
-        let output = self.encode_output(device, queue, vello_renderer, width, height, &mut encoder);
-        queue.submit([encoder.finish()]);
-        output
     }
 
     pub(super) fn encode_output(
@@ -648,6 +661,13 @@ impl HydrolysisRenderer {
         runtime: Rc<RefCell<AppliedFilterRuntime>>,
     ) {
         self.node_applied_filters.push(runtime);
+    }
+
+    /// Atlas pages rendered this frame; every filter of a nesting level shares
+    /// one page until it fills.
+    #[cfg(test)]
+    pub(crate) fn applied_filter_capture_pages(&self) -> u32 {
+        self.subtree_captures.frame_pages()
     }
 
     pub(crate) fn applied_filter_stats(&self) -> (u32, u64, u64) {

--- a/backends/hydrolysis/src/renderer/frame.rs
+++ b/backends/hydrolysis/src/renderer/frame.rs
@@ -101,6 +101,7 @@ impl HydrolysisRenderer {
         self.frame_applied_filter_count = 0;
         self.frame_applied_filter_capture = Duration::ZERO;
         self.frame_applied_filter_effect = Duration::ZERO;
+        self.subtree_captures.begin_frame();
         #[cfg(feature = "accessibility")]
         self.accessibility.reset_scene();
     }
@@ -115,6 +116,7 @@ impl HydrolysisRenderer {
         self.frame_applied_filter_count = 0;
         self.frame_applied_filter_capture = Duration::ZERO;
         self.frame_applied_filter_effect = Duration::ZERO;
+        self.subtree_captures.begin_frame();
         self.lifecycle.begin_rebuild_frame();
         self.hit_test.begin_rebuild_frame();
         self.gesture_group_ids.clear();

--- a/backends/hydrolysis/src/renderer/render/mod.rs
+++ b/backends/hydrolysis/src/renderer/render/mod.rs
@@ -5,6 +5,7 @@ mod measurement;
 mod measurement_cache;
 mod render_context;
 mod state;
+mod subtree_capture;
 mod subview;
 mod text_service;
 mod view_helpers;
@@ -24,6 +25,7 @@ pub use render_context::RenderContext;
 pub(crate) use render_context::WidgetRenderContext;
 pub(crate) use render_context::{HydrolysisTextContextMenuMode, HydrolysisWindowOrigin};
 pub use state::HydroState;
+pub(crate) use subtree_capture::SubtreeCaptures;
 pub(crate) use subview::HydroSubview;
 pub(crate) use text_service::{
     ResolvedTextLayoutInput, TextMeasureService, resolve_text_layout_input,

--- a/backends/hydrolysis/src/renderer/render/subtree_capture.rs
+++ b/backends/hydrolysis/src/renderer/render/subtree_capture.rs
@@ -1,0 +1,436 @@
+//! Batched capture of filtered subtrees.
+//!
+//! An `AppliedFilter` needs its child's pixels as a texture before it can run.
+//! Rendering each filtered subtree through its own compositor pass costs a fixed
+//! few milliseconds per filter on every backend (39 ms on DX12 / WARP), so a
+//! screen of a hundred filters paid a hundred passes per frame. Every filtered
+//! subtree in a frame is instead flushed into a slot of a shelf-packed atlas
+//! page, each page is rendered with one compositor pass, and the slots are
+//! copied into the filters' input textures and filtered under a single command
+//! encoder and queue submit.
+//!
+//! Filters nest: a filter inside a filtered subtree is captured one level
+//! deeper. Deeper levels are rendered first, so a filter's output image exists
+//! by the time the page holding its parent is rendered.
+
+use super::*;
+use core::mem;
+use std::time::Instant;
+
+/// Pages are padded up to this granularity so that a layout that jitters by a
+/// few pixels between frames keeps hitting the same pooled page texture.
+const PAGE_EXTENT_GRANULARITY: u32 = 64;
+
+/// The per-frame atlas state: one level per capture nesting depth plus the
+/// page textures kept across frames.
+#[derive(Default)]
+pub(crate) struct SubtreeCaptures {
+    levels: Vec<CaptureLevel>,
+    /// Nesting depth of the subtree currently being flushed: `0` for the
+    /// window, `n + 1` inside the `n`th nested capture.
+    pub(crate) depth: usize,
+    /// Page textures released by earlier frames, reused by exact extent.
+    texture_pool: Vec<CapturePageTexture>,
+    frame_pages: u32,
+}
+
+#[derive(Default)]
+struct CaptureLevel {
+    pages: Vec<CapturePage>,
+    pending: Vec<PendingFilter>,
+}
+
+/// One atlas page: the scene every slot of this page was flushed into and the
+/// shelf-packing cursor that placed them.
+#[derive(Default)]
+struct CapturePage {
+    content: CapturePageContent,
+    slots: Vec<CaptureSlot>,
+    cursor_x: u32,
+    cursor_y: u32,
+    shelf_height: u32,
+    used_width: u32,
+}
+
+/// The renderer scene state a page's slots are flushed into, swapped in and
+/// out of the renderer around each slot flush and the page render.
+#[derive(Default)]
+struct CapturePageContent {
+    scene: vello::Scene,
+    render_layers: Vec<RenderLayer>,
+    transient_scene: Option<vello::Scene>,
+}
+
+struct CaptureSlot {
+    origin: (u32, u32),
+    width: u32,
+    height: u32,
+    /// The filter's input texture the slot is copied into once the page is rendered.
+    input: wgpu::Texture,
+}
+
+struct PendingFilter {
+    runtime: Rc<RefCell<AppliedFilterRuntime>>,
+    width: u32,
+    height: u32,
+}
+
+struct CapturePageTexture {
+    width: u32,
+    height: u32,
+    texture: wgpu::Texture,
+    view: wgpu::TextureView,
+}
+
+impl CapturePage {
+    /// Place a `width` × `height` slot on this page, or `None` when the page is
+    /// full at `limit` pixels per side.
+    fn place(&mut self, width: u32, height: u32, limit: u32) -> Option<(u32, u32)> {
+        if self.cursor_x + width > limit {
+            let next_y = self.cursor_y + self.shelf_height;
+            if next_y + height > limit {
+                return None;
+            }
+            self.cursor_x = 0;
+            self.cursor_y = next_y;
+            self.shelf_height = 0;
+        }
+        if self.cursor_y + height > limit {
+            return None;
+        }
+        let origin = (self.cursor_x, self.cursor_y);
+        self.cursor_x += width;
+        self.shelf_height = self.shelf_height.max(height);
+        self.used_width = self.used_width.max(self.cursor_x);
+        Some(origin)
+    }
+
+    /// The page texture extent, padded to [`PAGE_EXTENT_GRANULARITY`] and
+    /// clamped to `limit`.
+    fn extent(&self, limit: u32) -> (u32, u32) {
+        let pad = |value: u32| value.div_ceil(PAGE_EXTENT_GRANULARITY) * PAGE_EXTENT_GRANULARITY;
+        (
+            pad(self.used_width).min(limit),
+            pad(self.cursor_y + self.shelf_height).min(limit),
+        )
+    }
+}
+
+impl SubtreeCaptures {
+    pub(crate) fn begin_frame(&mut self) {
+        assert!(
+            self.levels.is_empty(),
+            "hydrolysis filter atlas: a previous frame left {} capture level(s) unflushed",
+            self.levels.len()
+        );
+        assert_eq!(
+            self.depth, 0,
+            "hydrolysis filter atlas: a previous frame left the capture depth unbalanced"
+        );
+        self.frame_pages = 0;
+    }
+
+    /// Pages rendered so far this frame.
+    #[cfg(test)]
+    pub(crate) fn frame_pages(&self) -> u32 {
+        self.frame_pages
+    }
+
+    fn allocate(
+        &mut self,
+        depth: usize,
+        width: u32,
+        height: u32,
+        limit: u32,
+        input: wgpu::Texture,
+    ) -> (usize, (u32, u32)) {
+        assert!(
+            width <= limit && height <= limit,
+            "hydrolysis filter atlas: a {width}x{height} filtered subtree exceeds the \
+             device's {limit}px texture limit"
+        );
+        if self.levels.len() <= depth {
+            self.levels.resize_with(depth + 1, CaptureLevel::default);
+        }
+        let pages = &mut self.levels[depth].pages;
+        let placed = pages
+            .last_mut()
+            .and_then(|page| page.place(width, height, limit));
+        let (index, origin) = match placed {
+            Some(origin) => (pages.len() - 1, origin),
+            None => {
+                let mut page = CapturePage::default();
+                let origin = page
+                    .place(width, height, limit)
+                    .expect("hydrolysis filter atlas: a fresh page must fit one slot");
+                pages.push(page);
+                (pages.len() - 1, origin)
+            }
+        };
+        pages[index].slots.push(CaptureSlot {
+            origin,
+            width,
+            height,
+            input,
+        });
+        (index, origin)
+    }
+
+    fn acquire_page_texture(
+        &mut self,
+        device: &wgpu::Device,
+        width: u32,
+        height: u32,
+    ) -> CapturePageTexture {
+        if let Some(index) = self
+            .texture_pool
+            .iter()
+            .position(|page| page.width == width && page.height == height)
+        {
+            return self.texture_pool.swap_remove(index);
+        }
+        let texture = device.create_texture(&wgpu::TextureDescriptor {
+            label: Some("hydrolysis_filter_atlas_page"),
+            size: wgpu::Extent3d {
+                width,
+                height,
+                depth_or_array_layers: 1,
+            },
+            mip_level_count: 1,
+            sample_count: 1,
+            dimension: wgpu::TextureDimension::D2,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                | wgpu::TextureUsages::TEXTURE_BINDING
+                | wgpu::TextureUsages::STORAGE_BINDING
+                | wgpu::TextureUsages::COPY_SRC,
+            view_formats: &[],
+        });
+        let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+        CapturePageTexture {
+            width,
+            height,
+            texture,
+            view,
+        }
+    }
+}
+
+impl HydrolysisRenderer {
+    /// Flush `child` into an atlas slot at the current capture depth and queue
+    /// `runtime` to be filtered from that slot when the level is flushed.
+    ///
+    /// The child is flushed in slot-local coordinates: its viewport is the slot
+    /// and its root transform places the slot on the page. Hit testing keeps the
+    /// parent's transform so controls inside a filtered subtree stay clickable
+    /// where they are drawn.
+    pub(crate) fn capture_child_into_atlas(
+        &mut self,
+        child: &RenderNode,
+        ctx: RenderContext,
+        env: &Environment,
+        runtime: &Rc<RefCell<AppliedFilterRuntime>>,
+        width: u32,
+        height: u32,
+    ) {
+        let device = self.state().frame_resources().0.clone();
+        let limit = device.limits().max_texture_dimension_2d;
+        let input = runtime
+            .borrow_mut()
+            .input_texture(&device, width, height)
+            .0
+            .clone();
+        let depth = self.subtree_captures.depth;
+        let (page_index, origin) = self
+            .subtree_captures
+            .allocate(depth, width, height, limit, input);
+
+        let page_content =
+            mem::take(&mut self.subtree_captures.levels[depth].pages[page_index].content);
+        let parent_content = self.swap_capture_page_content(page_content);
+        let parent_active_layers = mem::take(&mut self.compositor.active_scene_layers);
+        let parent_window_bounds = self.window_bounds;
+        let parent_window_root_transform = self.window_root_transform;
+
+        let local_bounds = vello::kurbo::Rect::new(0.0, 0.0, f64::from(width), f64::from(height));
+        let slot_transform =
+            vello::kurbo::Affine::translate((f64::from(origin.0), f64::from(origin.1)));
+        self.set_window_viewport(local_bounds, slot_transform);
+        let local_ctx = RenderContext::with_transforms(
+            local_bounds,
+            slot_transform,
+            ctx.hit_transform * vello::kurbo::Affine::translate((ctx.bounds.x0, ctx.bounds.y0)),
+        );
+
+        self.subtree_captures.depth = depth + 1;
+        // The slot clip keeps a child that paints outside its bounds (a shadow,
+        // an overflowing transform) from bleeding into its neighbours' slots.
+        self.push_layer_rect(1.0, slot_transform, local_bounds);
+        child.flush(self, local_ctx, env);
+        self.pop_layer();
+        self.subtree_captures.depth = depth;
+        assert!(
+            self.compositor.active_scene_layers.is_empty(),
+            "hydrolysis filter atlas capture left an unclosed scene layer"
+        );
+
+        self.subtree_captures.levels[depth].pages[page_index].content =
+            self.swap_capture_page_content(parent_content);
+        self.compositor.active_scene_layers = parent_active_layers;
+        self.set_window_viewport(parent_window_bounds, parent_window_root_transform);
+        self.subtree_captures.levels[depth]
+            .pending
+            .push(PendingFilter {
+                runtime: Rc::clone(runtime),
+                width,
+                height,
+            });
+    }
+
+    /// Render every atlas page at capture depth `from_depth` and deeper, copy
+    /// the slots into their filters' input textures, and run the filters.
+    /// Deeper levels go first so their outputs exist when the level above is
+    /// rendered.
+    ///
+    /// Called once the subtree that owns those levels has been flushed: the
+    /// window flush calls it with depth `0`, and a nested texture capture with
+    /// the depth of its own child.
+    pub(crate) fn flush_subtree_captures(&mut self, from_depth: usize) {
+        if self.subtree_captures.levels.len() <= from_depth {
+            return;
+        }
+        let levels = self.subtree_captures.levels.split_off(from_depth);
+        let adapter = self.state().frame_adapter().clone();
+        let (device, queue) = {
+            let (device, queue) = self.state().frame_resources();
+            (device.clone(), queue.clone())
+        };
+        let limit = device.limits().max_texture_dimension_2d;
+        for level in levels.into_iter().rev() {
+            let capture_started_at = Instant::now();
+            let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+                label: Some("hydrolysis filter atlas encoder"),
+            });
+            // Page textures are handed back to the pool only after the submit
+            // that copies out of them: releasing one earlier would let the next
+            // page of this frame render over slots not yet copied.
+            let mut used_textures = Vec::with_capacity(level.pages.len());
+            for page in level.pages {
+                let (page_width, page_height) = page.extent(limit);
+                let texture =
+                    self.subtree_captures
+                        .acquire_page_texture(&device, page_width, page_height);
+                self.render_capture_page(page.content, &adapter, &device, &queue, &texture);
+                for slot in &page.slots {
+                    encoder.copy_texture_to_texture(
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &texture.texture,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d {
+                                x: slot.origin.0,
+                                y: slot.origin.1,
+                                z: 0,
+                            },
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::TexelCopyTextureInfo {
+                            texture: &slot.input,
+                            mip_level: 0,
+                            origin: wgpu::Origin3d::ZERO,
+                            aspect: wgpu::TextureAspect::All,
+                        },
+                        wgpu::Extent3d {
+                            width: slot.width,
+                            height: slot.height,
+                            depth_or_array_layers: 1,
+                        },
+                    );
+                }
+                used_textures.push(texture);
+                self.subtree_captures.frame_pages = self
+                    .subtree_captures
+                    .frame_pages
+                    .checked_add(1)
+                    .expect("hydrolysis filter atlas page counter overflow");
+            }
+            self.frame_applied_filter_capture += capture_started_at.elapsed();
+
+            let effect_started_at = Instant::now();
+            for pending in level.pending {
+                let (_image, needs_redraw) = pending.runtime.borrow_mut().encode_output(
+                    &device,
+                    &queue,
+                    &mut self.vello_renderer,
+                    pending.width,
+                    pending.height,
+                    &mut encoder,
+                );
+                self.frame_applied_filter_count = self
+                    .frame_applied_filter_count
+                    .checked_add(1)
+                    .expect("hydrolysis applied filter counter overflow");
+                if needs_redraw {
+                    self.request_redraw();
+                }
+            }
+            queue.submit([encoder.finish()]);
+            self.frame_applied_filter_effect += effect_started_at.elapsed();
+            self.subtree_captures.texture_pool.extend(used_textures);
+        }
+    }
+
+    /// Composite one page's scene into its page texture with the renderer's
+    /// scene state swapped out for the duration.
+    fn render_capture_page(
+        &mut self,
+        content: CapturePageContent,
+        adapter: &wgpu::Adapter,
+        device: &wgpu::Device,
+        queue: &wgpu::Queue,
+        texture: &CapturePageTexture,
+    ) {
+        let parent_content = self.swap_capture_page_content(content);
+        let parent_active_layers = mem::take(&mut self.compositor.active_scene_layers);
+        let parent_window_bounds = self.window_bounds;
+        let parent_window_root_transform = self.window_root_transform;
+        self.set_window_viewport(
+            vello::kurbo::Rect::new(
+                0.0,
+                0.0,
+                f64::from(texture.width),
+                f64::from(texture.height),
+            ),
+            vello::kurbo::Affine::IDENTITY,
+        );
+        self.render_scene_to_texture(HydrolysisRenderTarget {
+            adapter,
+            device,
+            queue,
+            texture: Some(&texture.texture),
+            view: &texture.view,
+            format: wgpu::TextureFormat::Rgba8Unorm,
+            width: texture.width,
+            height: texture.height,
+            base_color: vello::peniko::Color::TRANSPARENT,
+        });
+        assert!(
+            self.compositor.active_scene_layers.is_empty(),
+            "hydrolysis filter atlas compositor restored an active scene layer"
+        );
+        // The compositor consumed the page content; what it leaves behind is
+        // empty and dropped.
+        let _ = self.swap_capture_page_content(parent_content);
+        self.compositor.active_scene_layers = parent_active_layers;
+        self.set_window_viewport(parent_window_bounds, parent_window_root_transform);
+    }
+
+    /// Install `content` as the renderer's current scene state and return the
+    /// state it replaced.
+    fn swap_capture_page_content(&mut self, content: CapturePageContent) -> CapturePageContent {
+        CapturePageContent {
+            scene: mem::replace(&mut self.scene, content.scene),
+            render_layers: mem::replace(&mut self.compositor.render_layers, content.render_layers),
+            transient_scene: mem::replace(&mut self.transient_scene, content.transient_scene),
+        }
+    }
+}

--- a/backends/hydrolysis/src/renderer/tests/retained_scene.rs
+++ b/backends/hydrolysis/src/renderer/tests/retained_scene.rs
@@ -37,7 +37,7 @@ use waterui_layout::container::LazyContainer;
 use waterui_layout::frame::Frame;
 use waterui_layout::stack::ZStackLayout;
 
-use super::test_environment;
+use super::{pumped_test_environment, test_environment};
 use crate::HeadlessRuntime;
 
 /// Aggregated frame-economy metrics over a run of parametric (post-trigger) frames.
@@ -782,4 +782,109 @@ fn collection_membership_enter_animates_then_settles() {
         "after the enter animation completes the collection must render \
          pixel-identical to a fresh build of the grown membership"
     );
+}
+
+/// Pump frames until every filter of `content` has been set up and run once,
+/// then return the frame that rendered them all. Filter setup is asynchronous
+/// (`AppliedFilterRuntime::ensure_setup` spawns it), so the first frames draw
+/// nothing for the filter.
+fn pump_until_filters_render(
+    runtime: &mut HeadlessRuntime,
+    expected_filters: u32,
+) -> crate::runner::HeadlessSnapshot {
+    let start = Instant::now();
+    for frame in 0..8_u32 {
+        let result = runtime.pump_at(true, start + Duration::from_millis(16 * u64::from(frame)));
+        if runtime.renderer().applied_filter_stats().0 == expected_filters {
+            return result
+                .snapshot
+                .expect("a frame that ran the filters must produce a snapshot");
+        }
+    }
+    panic!("{expected_filters} applied filter(s) never ran within eight frames");
+}
+
+fn pixel(snapshot: &crate::runner::HeadlessSnapshot, x: u32, y: u32) -> [u8; 4] {
+    let index = ((y * snapshot.width + x) * 4) as usize;
+    snapshot.rgba8[index..index + 4]
+        .try_into()
+        .expect("four channels per pixel")
+}
+
+fn assert_red(snapshot: &crate::runner::HeadlessSnapshot, x: u32, y: u32) {
+    let [r, g, b, _] = pixel(snapshot, x, y);
+    assert!(
+        r > 160 && g < 90 && b < 90,
+        "pixel ({x}, {y}) must be the red box, got rgb({r}, {g}, {b})"
+    );
+}
+
+fn assert_blue(snapshot: &crate::runner::HeadlessSnapshot, x: u32, y: u32) {
+    let [r, g, b, _] = pixel(snapshot, x, y);
+    assert!(
+        b > 160 && r < 90,
+        "pixel ({x}, {y}) must be the blue box, got rgb({r}, {g}, {b})"
+    );
+}
+
+/// Sibling filtered subtrees are captured through one shared atlas page — one
+/// compositor pass and one submit for the whole level — instead of a compositor
+/// pass per filter, and each filter still receives its own subtree's pixels: the
+/// slots must not overlap or swap.
+#[test]
+fn sibling_applied_filters_share_one_atlas_page() {
+    fn filtered_boxes() -> AnyView {
+        use waterui::prelude::*;
+        AnyView::new(hstack((
+            ().size(48.0, 48.0)
+                .background(Color::srgb_hex("#DC2626"))
+                .blur(2.0f32),
+            ().size(48.0, 48.0)
+                .background(Color::srgb_hex("#2563EB"))
+                .blur(2.0f32),
+        )))
+    }
+
+    let env = pumped_test_environment();
+    let builder = AnyViewBuilder::<AnyView>::new(filtered_boxes);
+    let mut runtime = HeadlessRuntime::new_for_tests(env, builder, 96, 48);
+    let snapshot = pump_until_filters_render(&mut runtime, 2);
+    assert_eq!(
+        runtime.renderer().applied_filter_capture_pages(),
+        1,
+        "two sibling filters must be captured through one atlas page"
+    );
+    assert_red(&snapshot, 24, 24);
+    assert_blue(&snapshot, 72, 24);
+}
+
+/// A filter inside a filtered subtree is captured one level deeper, and that
+/// level is rendered first, so the outer filter sees the inner filter's output
+/// rather than an empty slot.
+#[test]
+fn nested_applied_filters_capture_inner_before_outer() {
+    fn nested_boxes() -> AnyView {
+        use waterui::prelude::*;
+        AnyView::new(
+            ().size(32.0, 32.0)
+                .background(Color::srgb_hex("#DC2626"))
+                .blur(2.0f32)
+                .padding_with(EdgeInsets::all(32.0))
+                .background(Color::srgb_hex("#2563EB"))
+                .blur(2.0f32),
+        )
+    }
+
+    let env = pumped_test_environment();
+    let builder = AnyViewBuilder::<AnyView>::new(nested_boxes);
+    let mut runtime = HeadlessRuntime::new_for_tests(env, builder, 96, 96);
+    let snapshot = pump_until_filters_render(&mut runtime, 2);
+    assert_eq!(
+        runtime.renderer().applied_filter_capture_pages(),
+        2,
+        "a nested filter is captured on its own level's page"
+    );
+    assert_red(&snapshot, 48, 48);
+    assert_blue(&snapshot, 48, 12);
+    assert_blue(&snapshot, 12, 48);
 }

--- a/backends/hydrolysis/src/renderer/tree/flush.rs
+++ b/backends/hydrolysis/src/renderer/tree/flush.rs
@@ -466,11 +466,17 @@ impl HydrolysisRenderer {
             f64::from(target.width),
             f64::from(target.height),
         ));
+        // Filters inside this subtree are captured one level deeper and flushed
+        // here, so their outputs exist before the subtree itself is rendered.
+        let depth = self.subtree_captures.depth;
+        self.subtree_captures.depth = depth + 1;
         child.flush(self, local_ctx, env);
+        self.subtree_captures.depth = depth;
         assert!(
             self.compositor.active_scene_layers.is_empty(),
             "hydrolysis GPU subtree capture left an unclosed scene layer"
         );
+        self.flush_subtree_captures(depth + 1);
         self.render_scene_to_texture(HydrolysisRenderTarget {
             adapter: &adapter,
             device: &device,

--- a/backends/hydrolysis/src/renderer/tree/nodes.rs
+++ b/backends/hydrolysis/src/renderer/tree/nodes.rs
@@ -738,11 +738,16 @@ impl ViewEffectNode {
 }
 
 impl AppliedFilterNode {
-    /// Render the wrapped child node into the runtime's input texture, run the
-    /// filter into the output texture, and draw the resulting image — the node
+    /// Flush the wrapped child into the frame's capture atlas, queue the filter
+    /// to run from that slot, and draw the filter's output image — the node
     /// analogue of the dispatch path's
     /// [`HydrolysisRenderer::render_applied_filter_metadata`], reusing the
     /// runtime's texture-reuse logic verbatim, with no cursor-bound effect slot.
+    ///
+    /// The filter itself runs when the atlas level is flushed
+    /// ([`HydrolysisRenderer::flush_subtree_captures`]), which happens before
+    /// the scene that draws the output image is rendered, so one compositor
+    /// pass and one submit serve every filter of the level.
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     pub(crate) fn flush(&self, renderer: &mut HydrolysisRenderer, ctx: RenderContext) {
         let (device, queue) = {
@@ -764,42 +769,23 @@ impl AppliedFilterNode {
         // filtered subtree freezes at stale pixels. The redraw-only refresh
         // path (which never re-flushes the tree) is the one place the cached
         // input is legitimately reused.
-        let (input_texture, input_view) = {
-            let mut runtime = self.runtime.borrow_mut();
-            let (texture, view) = runtime.input_texture(&device, width, height);
-            (texture.clone(), view.clone())
-        };
         let capture_started_at = Instant::now();
-        renderer.render_child_node_to_texture(
+        renderer.capture_child_into_atlas(
             &self.child,
             ctx,
             &self.env,
-            ChildTextureTarget {
-                texture: &input_texture,
-                view: &input_view,
-                format: wgpu::TextureFormat::Rgba8Unorm,
-                width,
-                height,
-            },
+            &self.runtime,
+            width,
+            height,
         );
         renderer.frame_applied_filter_capture += capture_started_at.elapsed();
 
-        let effect_started_at = Instant::now();
-        let (image, needs_redraw) = self.runtime.borrow_mut().render_output(
+        let image = self.runtime.borrow_mut().prepare_output(
             &device,
-            &queue,
             &mut renderer.vello_renderer,
             width,
             height,
         );
-        renderer.frame_applied_filter_effect += effect_started_at.elapsed();
-        renderer.frame_applied_filter_count = renderer
-            .frame_applied_filter_count
-            .checked_add(1)
-            .expect("hydrolysis applied filter counter overflow");
-        if needs_redraw {
-            renderer.request_redraw();
-        }
 
         let image_transform = vello::kurbo::Affine::translate((ctx.bounds.x0, ctx.bounds.y0))
             * vello::kurbo::Affine::scale_non_uniform(

--- a/backends/hydrolysis/src/renderer/tree/window.rs
+++ b/backends/hydrolysis/src/renderer/tree/window.rs
@@ -176,6 +176,7 @@ impl HydrolysisRenderer {
             tree.patch(self);
             tree.layout(self, env, size);
             tree.flush(self, ctx, env);
+            self.flush_subtree_captures(0);
             self.render_tree = Some(tree);
             return;
         }
@@ -183,6 +184,7 @@ impl HydrolysisRenderer {
         let mut node = RenderNode::build(content, env, self);
         node.layout(self, env, size);
         node.flush(self, ctx, env);
+        self.flush_subtree_captures(0);
         self.render_tree = Some(node);
     }
 
@@ -226,6 +228,9 @@ impl HydrolysisRenderer {
         tree.layout(self, env, size);
         let ctx = RenderContext::with_transforms(bounds, transform, hit_transform);
         tree.flush(self, ctx, env);
+        // Every filtered subtree captured during the flush is rendered and
+        // filtered now, before the scene that draws their outputs is.
+        self.flush_subtree_captures(0);
         // The overlay-mode text context menu re-encodes with the frame it floats
         // over; drawing it only on the one-time build path would leave it visible
         // for a single frame.

--- a/backends/hydrolysis/src/runner/headless.rs
+++ b/backends/hydrolysis/src/runner/headless.rs
@@ -678,6 +678,12 @@ impl HeadlessRuntime {
         }
     }
 
+    /// The main window's renderer, for tests that assert on frame internals.
+    #[cfg(test)]
+    pub(crate) fn renderer(&self) -> &HydrolysisRenderer {
+        &self.runtime.renderer
+    }
+
     pub fn pump_at(&mut self, capture_snapshot: bool, at: Instant) -> HeadlessPumpResult {
         let frame_started_at = Instant::now();
         self.runtime.renderer.set_frame_instant(at);

--- a/examples/stress/src/lib.rs
+++ b/examples/stress/src/lib.rs
@@ -318,10 +318,11 @@ mod bench {
     }
 
     // Counter budgets derived from a full local run (observed: rebuilt 0/840,
-    // compositor layers 1, gpu-surface layers 0, clip pushes 1) with generous
-    // headroom; they guard structural regressions, which are hardware
-    // independent. Frame-time ceilings are left to CI via `water bench
-    // --max-p95-us`, which knows its own hardware.
+    // compositor layers 1, gpu-surface layers 0, clip pushes 145: the window's
+    // one plus one filter-atlas slot clip for each of the 144 filtered tiles)
+    // with generous headroom; they guard structural regressions,
+    // which are hardware independent. Frame-time ceilings are left to CI via
+    // `water bench --max-p95-us`, which knows its own hardware.
     #[waterui::bench(
         stress_scene,
         theme = hydrolysis_m3::install,
@@ -329,7 +330,7 @@ mod bench {
         max_rebuild_ratio = 0.05,
         max_scene_layers = 4,
         max_gpu_surface_layers = 2,
-        max_clip_layers = 8,
+        max_clip_layers = 160,
     )]
     fn stress_steady_redraw(perf: &mut PerfApp) {
         perf.measure("steady-redraw", |run| {


### PR DESCRIPTION
Fixes #320

Every `AppliedFilter` rendered its child with its own compositor pass and its own queue submit: a fixed few milliseconds per filter on every backend (39 ms on DX12/WARP), so a screen of a hundred filters paid a hundred passes per frame.

## Change

- `renderer/render/subtree_capture.rs`: per-frame `SubtreeCaptures`. Filtered subtrees are flushed into slots of a shelf-packed atlas page per nesting level (pages padded to 64 px and pooled across frames by exact extent, capped at the device's `max_texture_dimension_2d`). `flush_subtree_captures(depth)` renders each page with one compositor pass, copies the slots into the filters' input textures (`COPY_DST` added), and runs every filter of the level under one command encoder and one submit. Deeper levels flush first so an outer filter sees the inner one's output.
- `AppliedFilterNode::flush` flushes the child into a slot (clipped to the slot) and draws the output image from a handle registered up front (`AppliedFilterRuntime::prepare_output`); the level is flushed at the end of `capture_window_tree` / `flush_window_tree`, and inside `render_child_node_to_texture` for filters nested in a `ViewEffect`.
- The per-filter `render_output` submit is gone; the redraw-only refresh path already batched under one encoder and is unchanged.
- Hit testing inside a captured subtree keeps the parent's transform instead of the identity, so controls inside a filtered subtree register where they are drawn.

## Verification

- New tests in `renderer/tests/retained_scene.rs`: two sibling blurs share one page and each keeps its own pixels; a nested blur is captured on its own level and the outer filter sees the inner output (pixel assertions through `HeadlessRuntime`).
- Offscreen PNGs read directly: a 36-tile grid of blur → saturation → hue-rotation chains of varying sizes renders every tile with its own colour, label and filter, no slot bleed or swap; 36 filters captured through 1 page in ~5 ms capture + ~20 ms effect on the first (pipeline-warming) frame.
- `cargo clippy -p hydrolysis --all-targets -D warnings` clean; `cargo nextest run -p hydrolysis -p waterui-testing`: 254 passed.

## Bench (CI, `stress_steady_redraw`, 144 filtered tiles, mean frame)

| leg | dev (c7e196ae6) | this PR |
|---|---|---|
| ubuntu (llvmpipe) | 451 ms | 167 ms |
| macOS | 591 ms | 136 ms |
| Windows (WARP) | 6937 ms | 286 ms |

The first bench run failed only on the structural counter `max_clip_layers = 8`: the atlas clips each filtered subtree to its slot, so the stress scene pushes 145 clip layers instead of 1. The budget is raised to 160 with the observed count in its comment.
