### PR TITLE
ci: fit the Actions cache into the 10 GB quota

### DIFF
--- a/.github/workflows/bench.yml
+++ b/.github/workflows/bench.yml
@@ -173,16 +173,14 @@ jobs:
       - name: Verify DirectX Shader Compiler
         if: runner.os == 'Windows'
         run: dxc --version
+      # No target tarball: the bench legs are off every gating path and their
+      # three generations did not fit the cache budget (see ci.yml). They read
+      # the per-OS `~/.cargo` tarball and compile from there.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: bench-${{ matrix.os }}
-          # Only the integration branches write cache generations, as in
-          # ci.yml and test.yml. Bench runs on dev only from the schedule and
-          # by hand, so that is where the three bench generations get written;
-          # a pull request reads them and saves nothing. PR runs used to write
-          # them on every fingerprint, and their 5 GB share of the 10 GB
-          # repository cap evicted the Test tarballs (#328).
-          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: false
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Build water CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,15 @@ env:
   # repository's 10GB Actions cache quota, so its main effect was evicting the
   # rust-cache tarballs that do work and putting every job back on a cold
   # build. Local development still uses sccache; this is CI-only.
+  #
+  # The 10 GB quota is the budget every rust-cache block in this repository is
+  # written against (#328). Only two jobs store a target directory: the macOS
+  # and Windows Test legs (`test-macos-latest`, `test-windows-latest`), the
+  # slowest cold builds on the scarcest runners. Every other job stores just
+  # `~/.cargo` under one per-OS key (`cargo-home-<OS>`), written by a single
+  # job per OS on the integration branches and read by the rest. The full set
+  # of per-job target tarballs measured ~27 GB against the cap, so each dev
+  # run evicted what the previous one wrote and every job restored nothing.
   # Incremental artifacts are per-machine rebuild state, useless to a fresh
   # runner, and they bloat the cache that is restored.
   CARGO_INCREMENTAL: 0
@@ -61,14 +70,9 @@ jobs:
       # only stores the ~0.2GB dependency caches, so the Test legs stay warm.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-coverage
-          # Only the integration branches write cache generations. A pull
-          # request reads them and saves nothing: every distinct fingerprint
-          # would otherwise mint a generation that is never reclaimed, and the
-          # stale ones evict the Test tarballs that decide whether a leg is
-          # warm (16 min) or cold (66 min).
-          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
+          shared-key: cargo-home-${{ runner.os }}
           cache-targets: false
+          save-if: false
           cache-on-failure: true
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest
@@ -121,9 +125,10 @@ jobs:
       # the larger graph.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-ubuntu
-          cache-on-failure: true
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
           save-if: false
+          cache-on-failure: true
       # The audit and deny checks run against the COMMITTED Cargo.lock — the
       # dependency set the workspace actually builds. A `cargo generate-lockfile`
       # step used to precede them; it silently re-resolved everything to the
@@ -167,13 +172,9 @@ jobs:
       # The single writer of `ci-ubuntu` (see Hygiene above).
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-ubuntu
-          # Only the integration branches write cache generations. A pull
-          # request reads them and saves nothing: every distinct fingerprint
-          # would otherwise mint a generation that is never reclaimed, and the
-          # stale ones evict the Test tarballs that decide whether a leg is
-          # warm (16 min) or cold (66 min).
-          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: false
           cache-on-failure: true
       - uses: taiki-e/install-action@cargo-hack
       # `--feature-powerset` is deliberately absent. The workspace has ~33_800
@@ -206,8 +207,9 @@ jobs:
       # dependency caches keeps the quota pressure off the caches that do hit.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ffi-header-macos
+          shared-key: cargo-home-${{ runner.os }}
           cache-targets: false
+          save-if: false
           cache-on-failure: true
       # `+nightly` is named rather than inherited: `rust-toolchain.toml` pins the
       # repository to stable and overrides what the action above sets, so an
@@ -270,10 +272,9 @@ jobs:
       # storing it under theirs would evict a tarball nothing else can use.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ci-android-ffi
-          # Only the integration branches write cache generations (see Features
-          # above for why).
-          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: false
           cache-on-failure: true
       # `ring` compiles C for the target, so the NDK's clang wrapper is
       # required even though clippy itself never links. The wrapper is named

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,14 +34,15 @@ jobs:
           components: clippy, rustfmt
       - name: Install native dependencies
         uses: ./.github/actions/setup-linux-deps
+      # The Linux `~/.cargo` tarball is written here and read by every other
+      # Linux job (see the cache budget note in ci.yml). Only the integration
+      # branches write it: a pull request reads and saves nothing, since every
+      # distinct fingerprint would otherwise mint a generation that is never
+      # reclaimed.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: test-lint
-          # Only the integration branches write cache generations. A pull
-          # request reads them and saves nothing: every distinct fingerprint
-          # would otherwise mint a generation that is never reclaimed, and the
-          # stale ones evict the Test tarballs that decide whether a leg is
-          # warm (16 min) or cold (66 min).
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       - name: Format
@@ -156,10 +157,15 @@ jobs:
         uses: ./.github/actions/setup-linux-deps
         with:
           gpu: "true"
+      # macOS keeps its target directory (one of the two target tarballs the
+      # cache budget in ci.yml affords); the Linux leg reads the shared Linux
+      # `~/.cargo` tarball and compiles from there. Linux runners are the
+      # plentiful ones, and its cold build is shorter than the Windows one.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: test-${{ matrix.os }}
-          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
+          shared-key: ${{ runner.os == 'macOS' && 'test-macos-latest' || format('cargo-home-{0}', runner.os) }}
+          cache-targets: ${{ runner.os == 'macOS' }}
+          save-if: ${{ runner.os == 'macOS' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       # One full-workspace pass under default features. A workspace-wide
@@ -209,9 +215,12 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           components: clippy
+      # Writes the macOS `~/.cargo` tarball for the macOS jobs that store no
+      # target directory (see the cache budget note in ci.yml).
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: test-macos-suites
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
           save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
@@ -294,8 +303,9 @@ jobs:
           gpu: "true"
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: test-examples-${{ matrix.os }}
-          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: false
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Clippy (examples)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -131,9 +131,15 @@ jobs:
         uses: tracel-ai/github-actions/install-dxc@295f2fdbae5271f4f8ad56d634e4ff6a95daafc8
       - name: Verify DirectX Shader Compiler
         run: dxc --version
+      # Writes the Windows `~/.cargo` tarball (see the cache budget note in
+      # ci.yml); the target directory belongs to the test job above. This
+      # block used to save a 2.2 GB target tarball on every pull request
+      # fingerprint, ungated.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: lint-windows-latest
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       # Compile the CEF backend without its binary distribution (see the test
       # job for why it cannot be linked here).


### PR DESCRIPTION
Fixes #328

## Measured

Last fully-run dev CI (run 33988033906, `9a9d58c4e`): every job restored nothing (`No cache found` in Test/ubuntu, Test/macos, Test/lint, Test/examples, Android FFI, FFI Header, Coverage). Cold durations: Windows 59 min, Test/ubuntu 47, Test/macos 44, Coverage 39, Test/lint 31, FFI Header 30, Features 29, examples 22+22, macos-suites 20, Android 12.

Cache demand per dev run: test-ubuntu 4.9 GB, test-macos 3.7, test-lint 3.9, macos-suites 3.2, examples-macos 1.7 (+ubuntu), android 1.0, ffi-header 0.5, windows test 4.6, windows lint 2.2, bench ×3 — about 27 GB against the 10 GB cap, so each save evicts the previous run's tarballs. Two blocks also saved on every pull-request fingerprint (Windows lint 2.2 GB, FFI Header 0.5 GB), visible in `gh cache list` as `refs/pull/359/merge` entries.

## Change (pure cache layout; nothing checked changes)

- Only `test-macos-latest` and `test-windows-latest` keep a target tarball (8.3 GB): the slowest cold builds on the scarcest runners.
- Every other rust-cache block stores only `~/.cargo` under `cargo-home-<OS>`, saved by one job per OS on dev/main (Test/lint, Test/macos-suites, Windows/lint) and read by the rest with `save-if: false`.
- The Windows lint and FFI Header saves are gated to dev/main like the others.
- The budget and its reasoning are written once at the top of `ci.yml`.

## Verification after merge

`gh cache list` on the next dev run must total under 10 GB and the macOS / Windows Test legs must log a cache hit on the run after that. If the two target tarballs grow past the budget, the next step is splitting their `--all-features` passes into no-target jobs.
