### PR TITLE
chore(apple): take apple-backend dev at dd07ae94 (#353 fix)

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ waterui-preview-version = "0.1.0"
 waterui-preview-protocol-version = "0.1.0"
 android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
-apple-backend-commit = "aa55c057cb92dd020361e7a0ac705d9f2781e395"
+apple-backend-commit = "dd07ae94d6617eca73879f195b322a44bc06f5ba"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
 android-backend-commit = "f4649a3641f0442bcbbfd1de2994af111d234c2f"
 


### PR DESCRIPTION
Moves the `backends/apple` submodule and the CLI's `apple-backend-commit` pin to apple-backend `dd07ae94`, which merged water-rs/apple-backend#15: `WuiAppliedFilter` and `WuiViewEffect` no longer re-arm their display link while the window is occluded, and re-arm on `NSWindow.didChangeOcclusionStateNotification` (#353, verified on `examples/image`: silent while hidden or covered, exactly one capture on reveal, including for a filter created while hidden).

`cargo check -p waterui-cli` and the CLI's pin tests pass.
