### PR TITLE
ci(coverage): install the Vulkan software driver the GPU tests need

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: ./.github/actions/setup-linux-deps
+        # The instrumented run executes the same GPU-backed snapshot tests as
+        # Test / ubuntu-latest, so it needs the same software Vulkan ICD. Without
+        # it wgpu picks the EGL/llvmpipe GL adapter instead, which is not the
+        # backend those tests are baselined against.
+        with:
+          gpu: "true"
       # Its own key: an instrumented build shares no artifacts with the
       # ordinary ones, so storing it under the shared key would just overwrite
       # a useful tarball with one nothing else can restore. The target dir is


### PR DESCRIPTION
Fixes #319

The Coverage job runs the same GPU-backed snapshot tests as `Test / ubuntu-latest`, but its `setup-linux-deps` step did not pass `gpu: "true"`, so the runner had no Vulkan ICD and wgpu fell through to the EGL/llvmpipe GL adapter. The last dev run shows it: 1616 tests passed on that adapter and only `hybrid_scene_engine_draws_an_image_brush` failed, drawing black where the image should be. This gives Coverage the same software Vulkan driver the ordinary test job gets.

Coverage only runs on `push`, so the proof is the dev run after merge.

The hybrid engine drawing a black image brush on the GL adapter is a separate defect; it is being reproduced in a Linux container without a Vulkan ICD and gets its own issue and fix.
