### PR TITLE
ci(test): run every crate's optional-feature tests, not just the root's

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,12 @@ jobs:
         with:
           components: llvm-tools-preview
       - uses: ./.github/actions/setup-linux-deps
+        # The instrumented run executes the same GPU-backed snapshot tests as
+        # Test / ubuntu-latest, so it needs the same software Vulkan ICD. Without
+        # it wgpu picks the EGL/llvmpipe GL adapter instead, which is not the
+        # backend those tests are baselined against.
+        with:
+          gpu: "true"
       # Its own key: an instrumented build shares no artifacts with the
       # ordinary ones, so storing it under the shared key would just overwrite
       # a useful tarball with one nothing else can restore. The target dir is

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -201,6 +201,13 @@ jobs:
   # `--all-features` asks those crates for feature sets that are mutually
   # exclusive by construction. Each is run below in the shapes it actually
   # has, sharing this job's target dir.
+  #
+  # `waterui-browser-wpe` is a fifth exclusion here that the clippy sweep does
+  # not need: its `real-engine` feature adds a test target that drives a
+  # staged WPE WebKit runtime (`WATERUI_WPE_RUNTIME`), which only
+  # `browser-wpe.yml` builds, so under `--all-features` that target runs here
+  # and fails at once for want of the runtime. Its `webview` shape is the
+  # default one, covered by the workspace pass in `test`.
   all-features:
     name: ubuntu-latest (all features)
     runs-on: ubuntu-latest
@@ -232,7 +239,8 @@ jobs:
             --exclude waterui-core \
             --exclude waterui-ffi \
             --exclude hydrolysis \
-            --exclude waterui-browser-cef
+            --exclude waterui-browser-cef \
+            --exclude waterui-browser-wpe
       # `nightly` is `feature(never_type)`, a hard E0554 on stable.
       - name: Test (waterui-core, every stable feature)
         run: cargo nextest run -p waterui-core --features std,serde --profile ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -126,10 +126,11 @@ jobs:
       - name: Skill snippet compile gate
         run: cargo check -p skill_snippets --all-targets --features compile-gate-tests
 
-  # The workspace test run, per platform. On Linux it also carries the two
-  # short passes that share its build (all-features and doctests); on macOS
-  # those go to `macos-suites`, so that this job is the workspace run alone —
-  # the single longest step in CI — and everything else overlaps it.
+  # The workspace test run, per platform. On Linux it also carries the
+  # doctests, which share its build; on macOS those go to `macos-suites`, so
+  # that this job is the workspace run alone — the single longest step in CI —
+  # and everything else overlaps it. The all-features pass is `all-features`
+  # below on Linux and part of `macos-suites` on macOS.
   test:
     name: ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
@@ -168,22 +169,10 @@ jobs:
           save-if: ${{ runner.os == 'macOS' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      # One full-workspace pass under default features. A workspace-wide
-      # `--all-features` pass would need the same four `--exclude` flags the
-      # clippy passes above carry — `waterui-ffi` enforces "exactly one ABI"
-      # with a `compile_error!` (ffi/src/lib.rs), so enabling `c-api` and
-      # `android-jni` together can never build. The all-features pass below
-      # only *looks* workspace-wide: the root manifest has both `[workspace]`
-      # and `[package]`, so without `--workspace` cargo narrows it to the root
-      # `waterui` crate. Running the excluded crates' tests in their own
-      # feature shapes is a separate question from linting them and is not
-      # what this pass is for.
+      # One full-workspace pass under default features. Every crate's own
+      # optional features are the `all-features` job below (Linux) and the
+      # `macos-suites` all-features pass (macOS).
       - run: cargo nextest run --workspace --exclude '*-example' --profile ci
-      # The root crate's feature-gated re-export surface, with every feature
-      # on. Root-crate-only scope is intentional (see above); most of the
-      # build is shared with the workspace pass, so this increment is cheap.
-      - if: runner.os == 'Linux'
-        run: cargo nextest run --all-features --profile ci
       # nextest cannot run doctests, and this workspace has plenty of them.
       - if: runner.os == 'Linux'
         run: cargo test --doc --workspace --exclude '*-example'
@@ -196,10 +185,88 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-  # Everything macOS runs besides the workspace test pass: the root crate's
-  # all-features tests, the doctests, and the suites that exist only on this
-  # platform. Together they are a fraction of the workspace run, so they
-  # overlap it here instead of queueing behind it.
+  # Every crate's own optional features, run. This pass used to be
+  # `cargo nextest run --all-features` inside the `test` job, with neither
+  # `-p` nor `--workspace`: the root manifest carries both `[workspace]` and
+  # `[package]`, so cargo narrowed it to the root `waterui` crate, and a
+  # backend crate's tests behind its own optional features — dew's
+  # `embedded-simulator`, hydrolysis' `inspector-signals` / `web`, the
+  # browsers' engine features — ran nowhere (#276, the test-side twin of
+  # #261). It is its own job for the same reason the clippy sweep is a
+  # separate step: a second feature variant of the dependency graph is a
+  # second codegen of most of the workspace, and it overlaps the workspace
+  # pass here instead of queueing behind it.
+  #
+  # Same four exclusions as the clippy sweep in `lint`, for the same reason:
+  # `--all-features` asks those crates for feature sets that are mutually
+  # exclusive by construction. Each is run below in the shapes it actually
+  # has, sharing this job's target dir.
+  all-features:
+    name: ubuntu-latest (all features)
+    runs-on: ubuntu-latest
+    timeout-minutes: 120
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+      # GPU snapshot tests run under these features too, so this leg needs
+      # the Vulkan ICD loader the way `test` does.
+      - name: Install native dependencies
+        uses: ./.github/actions/setup-linux-deps
+        with:
+          gpu: "true"
+      # Restore-only reader of the shared Linux `~/.cargo` tarball (see the
+      # cache budget note in ci.yml).
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: false
+          cache-on-failure: true
+      - uses: taiki-e/install-action@nextest
+      - name: Test (all features, workspace)
+        run: |
+          cargo nextest run --workspace --all-features --profile ci \
+            --exclude '*-example' \
+            --exclude waterui-core \
+            --exclude waterui-ffi \
+            --exclude hydrolysis \
+            --exclude waterui-browser-cef
+      # `nightly` is `feature(never_type)`, a hard E0554 on stable.
+      - name: Test (waterui-core, every stable feature)
+        run: cargo nextest run -p waterui-core --features std,serde --profile ci
+      # The `c-api` half with every optional C surface a runtime build can
+      # carry; `android-jni` is the `Android FFI` job in ci.yml.
+      - name: Test (waterui-ffi, C ABI surfaces)
+        run: cargo nextest run -p waterui-ffi --features map,chromium,webview-cef --profile ci
+      # Every hydrolysis feature but `webview-system`, which only builds on
+      # macOS (`macos-suites` runs its `real_engine_macos` target).
+      - name: Test (hydrolysis, every portable feature)
+        run: |
+          cargo nextest run -p hydrolysis --profile ci \
+            --features accessibility,inspector-signals,testing,web,winit
+      # The CEF runtime shape; `compile-only` and `real-engine` exclude it.
+      - name: Test (waterui-browser-cef, CEF runtime)
+        run: cargo nextest run -p waterui-browser-cef --features chromium,webview --profile ci
+      # Dew's firmware shape, a first-class configuration whose test targets
+      # had stopped compiling entirely before the clippy pass covered them
+      # (#259); this is the run that goes with that lint.
+      - name: Test (dew firmware shape)
+        run: cargo nextest run -p waterui-dew --no-default-features --profile ci
+      - name: Upload Test Snapshots
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-snapshots-ubuntu-latest-all-features
+          path: test-artifacts/
+          if-no-files-found: ignore
+          retention-days: 14
+
+  # Everything macOS runs besides the workspace test pass: the all-features
+  # pass, the doctests, and the suites that exist only on this platform.
+  # Together they are a fraction of the workspace run, so they overlap it
+  # here instead of queueing behind it.
   macos-suites:
     name: macos-suites
     runs-on: macos-latest
@@ -224,9 +291,25 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      # The root crate's feature-gated re-export surface, with every feature
-      # on (see the `test` job for why the scope is the root crate).
-      - run: cargo nextest run --all-features --profile ci
+      # Every crate's own optional features, with the same four exclusions as
+      # the Linux `all-features` job (see there). Of the excluded crates, the
+      # two whose feature shapes carry macOS-specific code run below; the FFI
+      # C surfaces, the CEF runtime shape and dew's firmware shape are
+      # host-independent and the Linux job covers them.
+      - name: Test (all features, workspace)
+        run: |
+          cargo nextest run --workspace --all-features --profile ci \
+            --exclude '*-example' \
+            --exclude waterui-core \
+            --exclude waterui-ffi \
+            --exclude hydrolysis \
+            --exclude waterui-browser-cef
+      - name: Test (waterui-core, every stable feature)
+        run: cargo nextest run -p waterui-core --features std,serde --profile ci
+      - name: Test (hydrolysis, every portable feature)
+        run: |
+          cargo nextest run -p hydrolysis --profile ci \
+            --features accessibility,inspector-signals,testing,web,winit
       # The macOS real-engine suite drives a genuine WKWebView through the
       # shared bridge contract — the macOS sibling of the WPE real-engine
       # workflow. It is `harness = false` (WKWebView is MainThreadOnly, and

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -208,6 +208,12 @@ jobs:
   # `browser-wpe.yml` builds, so under `--all-features` that target runs here
   # and fails at once for want of the runtime. Its `webview` shape is the
   # default one, covered by the workspace pass in `test`.
+  #
+  # `skill_snippets` is a sixth, on every platform: its `compile-gate-tests`
+  # feature registers the skill's `#[waterui::test]` transcriptions as test
+  # targets that address elements which do not exist by design and must never
+  # run, and its `dev` feature turns on `waterui/dynamic_linking`. The lint
+  # job compiles that crate in the shape it is meant to be compiled in.
   all-features:
     name: ubuntu-latest (all features)
     runs-on: ubuntu-latest
@@ -240,7 +246,8 @@ jobs:
             --exclude waterui-ffi \
             --exclude hydrolysis \
             --exclude waterui-browser-cef \
-            --exclude waterui-browser-wpe
+            --exclude waterui-browser-wpe \
+            --exclude skill_snippets
       # `nightly` is `feature(never_type)`, a hard E0554 on stable.
       - name: Test (waterui-core, every stable feature)
         run: cargo nextest run -p waterui-core --features std,serde --profile ci
@@ -299,10 +306,11 @@ jobs:
           save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      # Every crate's own optional features, with the same four exclusions as
-      # the Linux `all-features` job (see there). Of the excluded crates, the
-      # two whose feature shapes carry macOS-specific code run below; the FFI
-      # C surfaces, the CEF runtime shape and dew's firmware shape are
+      # Every crate's own optional features, with the same exclusions as the
+      # Linux `all-features` job (see there; `waterui-browser-wpe` is
+      # Linux-only, so it needs no exclusion here). Of the excluded crates,
+      # the two whose feature shapes carry macOS-specific code run below; the
+      # FFI C surfaces, the CEF runtime shape and dew's firmware shape are
       # host-independent and the Linux job covers them.
       - name: Test (all features, workspace)
         run: |
@@ -311,7 +319,8 @@ jobs:
             --exclude waterui-core \
             --exclude waterui-ffi \
             --exclude hydrolysis \
-            --exclude waterui-browser-cef
+            --exclude waterui-browser-cef \
+            --exclude skill_snippets
       - name: Test (waterui-core, every stable feature)
         run: cargo nextest run -p waterui-core --features std,serde --profile ci
       - name: Test (hydrolysis, every portable feature)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -117,8 +117,11 @@ jobs:
   # of the workspace runs under `--all-features` with the root and the dylib
   # excluded, plus the same four exclusions the Linux `all-features` job in
   # test.yml carries for crates whose feature sets are mutually exclusive by
-  # construction (#276). The two excluded crates with platform-specific code
-  # in their feature shapes run afterwards in the shapes they have.
+  # construction (#276), and `skill_snippets`, whose `dev` feature would turn
+  # `dynamic_linking` back on and whose `compile-gate-tests` transcriptions
+  # must never run (see the Linux job). The two excluded crates with
+  # platform-specific code in their feature shapes run afterwards in the
+  # shapes they have.
   all-features:
     name: windows-latest (all features)
     runs-on: windows-latest
@@ -150,7 +153,8 @@ jobs:
             --exclude waterui-core `
             --exclude waterui-ffi `
             --exclude hydrolysis `
-            --exclude waterui-browser-cef
+            --exclude waterui-browser-cef `
+            --exclude skill_snippets
       - name: Test (waterui-core, every stable feature)
         run: cargo nextest run -p waterui-core --features std,serde --profile ci
       - name: Test (hydrolysis, every portable feature)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -104,16 +104,21 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
-  # The root crate's feature-gated re-export surface, in its own job so the
-  # test tarball above holds one feature variant of the dependency graph
-  # instead of two (#362): this job stores only `~/.cargo`, like macos-suites.
-  # `--features all` rather than `--all-features`: the latter turns on
-  # `dynamic_linking`, which pulls in `waterui-dylib`, and that crate exports
-  # 77k symbols against a PE export table limit of 65535 — it cannot link
-  # here, which is why the workspace pass excludes it. Root-crate-only scope
-  # is what cargo's default package selection does without `--workspace`, and
-  # here that narrowing is exactly right: the root `waterui` crate is the one
-  # crate whose features are all mutually compatible.
+  # Every crate's own optional features, in its own job so the test tarball
+  # above holds one feature variant of the dependency graph instead of two
+  # (#362): this job stores only `~/.cargo`, like macos-suites.
+  #
+  # Two passes, because the root crate cannot join a workspace-wide
+  # `--all-features` here: that turns on `dynamic_linking`, which pulls in
+  # `waterui-dylib`, and that crate exports 77k symbols against a PE export
+  # table limit of 65535 — it cannot link on Windows, which is why the
+  # workspace pass in `test` excludes it. So the root `waterui` crate runs on
+  # its own under `--features all` (every feature but that one), and the rest
+  # of the workspace runs under `--all-features` with the root and the dylib
+  # excluded, plus the same four exclusions the Linux `all-features` job in
+  # test.yml carries for crates whose feature sets are mutually exclusive by
+  # construction (#276). The two excluded crates with platform-specific code
+  # in their feature shapes run afterwards in the shapes they have.
   all-features:
     name: windows-latest (all features)
     runs-on: windows-latest
@@ -134,7 +139,24 @@ jobs:
           save-if: false
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-      - run: cargo nextest run --features all --profile ci
+      - name: Test (root crate, every feature but dynamic_linking)
+        run: cargo nextest run --features all --profile ci
+      - name: Test (all features, workspace)
+        run: |
+          cargo nextest run --workspace --all-features --profile ci `
+            --exclude waterui `
+            --exclude waterui-dylib `
+            --exclude '*-example' `
+            --exclude waterui-core `
+            --exclude waterui-ffi `
+            --exclude hydrolysis `
+            --exclude waterui-browser-cef
+      - name: Test (waterui-core, every stable feature)
+        run: cargo nextest run -p waterui-core --features std,serde --profile ci
+      - name: Test (hydrolysis, every portable feature)
+        run: |
+          cargo nextest run -p hydrolysis --profile ci `
+            --features accessibility,inspector-signals,testing,web,winit
       - name: Upload Test Snapshots
         if: always()
         uses: actions/upload-artifact@v4

--- a/backends/dew/tests/dispatch_views.rs
+++ b/backends/dew/tests/dispatch_views.rs
@@ -242,6 +242,6 @@ fn export_composed_ui_for_visual_review() {
         320,
         160,
     );
-    std::fs::write(support::export_path("waterui_dew_views.png"), png)
+    std::fs::write(support::export_path("dispatch_views", "composed"), png)
         .expect("export visual review PNG");
 }

--- a/backends/dew/tests/dispatch_views.rs
+++ b/backends/dew/tests/dispatch_views.rs
@@ -242,5 +242,6 @@ fn export_composed_ui_for_visual_review() {
         320,
         160,
     );
-    std::fs::write("/tmp/waterui_dew_views.png", png).expect("export visual review PNG");
+    std::fs::write(support::export_path("waterui_dew_views.png"), png)
+        .expect("export visual review PNG");
 }

--- a/backends/dew/tests/form_render.rs
+++ b/backends/dew/tests/form_render.rs
@@ -90,7 +90,8 @@ fn build_screen() -> impl View {
 #[test]
 fn form_ui_renders_to_png() {
     let png = render_view_png(build_screen, support::test_environment(), WIDTH, HEIGHT);
-    std::fs::write("/tmp/dew_form_render.png", &png).expect("export form render PNG");
+    std::fs::write(support::export_path("dew_form_render.png"), &png)
+        .expect("export form render PNG");
 
     let pixmap = vello_cpu::Pixmap::from_png(std::io::Cursor::new(png.as_slice()))
         .expect("png decodes back");

--- a/backends/dew/tests/form_render.rs
+++ b/backends/dew/tests/form_render.rs
@@ -90,8 +90,7 @@ fn build_screen() -> impl View {
 #[test]
 fn form_ui_renders_to_png() {
     let png = render_view_png(build_screen, support::test_environment(), WIDTH, HEIGHT);
-    std::fs::write(support::export_path("dew_form_render.png"), &png)
-        .expect("export form render PNG");
+    std::fs::write(support::export_path("form", "render"), &png).expect("export form render PNG");
 
     let pixmap = vello_cpu::Pixmap::from_png(std::io::Cursor::new(png.as_slice()))
         .expect("png decodes back");

--- a/backends/dew/tests/navigation_render.rs
+++ b/backends/dew/tests/navigation_render.rs
@@ -485,13 +485,13 @@ fn export_navigation_for_visual_review() {
         ))
     });
     std::fs::write(
-        "/tmp/waterui_dew_navigation_root.png",
+        support::export_path("waterui_dew_navigation_root.png"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export the root screen");
     tap_labeled(&mut runtime, "Schedule").expect("following the link renders a frame");
     std::fs::write(
-        "/tmp/waterui_dew_navigation_pushed.png",
+        support::export_path("waterui_dew_navigation_pushed.png"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export the pushed screen");
@@ -608,7 +608,7 @@ fn a_three_column_split_retains_both_destination_levels() {
     );
     runtime.pump().expect("all three columns render");
     std::fs::write(
-        "/tmp/waterui_dew_navigation_split.png",
+        support::export_path("waterui_dew_navigation_split.png"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export split visual review PNG");

--- a/backends/dew/tests/navigation_render.rs
+++ b/backends/dew/tests/navigation_render.rs
@@ -485,13 +485,13 @@ fn export_navigation_for_visual_review() {
         ))
     });
     std::fs::write(
-        support::export_path("waterui_dew_navigation_root.png"),
+        support::export_path("navigation", "root"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export the root screen");
     tap_labeled(&mut runtime, "Schedule").expect("following the link renders a frame");
     std::fs::write(
-        support::export_path("waterui_dew_navigation_pushed.png"),
+        support::export_path("navigation", "pushed"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export the pushed screen");
@@ -608,7 +608,7 @@ fn a_three_column_split_retains_both_destination_levels() {
     );
     runtime.pump().expect("all three columns render");
     std::fs::write(
-        support::export_path("waterui_dew_navigation_split.png"),
+        support::export_path("navigation", "split"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export split visual review PNG");

--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -67,8 +67,7 @@ fn only_scene(list: &DisplayList) -> (&DrawCommand, Rect) {
 }
 
 fn export(name: &str, png: &[u8]) {
-    std::fs::write(support::export_path(&format!("{name}.png")), png)
-        .expect("write the review PNG");
+    std::fs::write(support::export_path("scene2d", name), png).expect("write the review PNG");
 }
 
 /// A box covering the canvas' own coordinate space.

--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -34,8 +34,6 @@ use waterui_svg::Svg;
 
 mod support;
 
-const EXPORT_DIR: &str = "/tmp/waterui_dew_scene2d";
-
 /// A small document exercising fills, strokes and a group opacity — the three
 /// things an SVG asks of a scene, and the third of which needs a real
 /// compositing layer rather than a per-shape alpha.
@@ -69,8 +67,8 @@ fn only_scene(list: &DisplayList) -> (&DrawCommand, Rect) {
 }
 
 fn export(name: &str, png: &[u8]) {
-    std::fs::create_dir_all(EXPORT_DIR).expect("create the scene export directory");
-    std::fs::write(format!("{EXPORT_DIR}/{name}.png"), png).expect("write the review PNG");
+    std::fs::write(support::export_path(&format!("{name}.png")), png)
+        .expect("write the review PNG");
 }
 
 /// A box covering the canvas' own coordinate space.

--- a/backends/dew/tests/shape_render.rs
+++ b/backends/dew/tests/shape_render.rs
@@ -178,5 +178,6 @@ fn export_shapes_for_visual_review() {
         320,
         180,
     );
-    std::fs::write("/tmp/waterui_dew_shapes.png", png).expect("export visual review PNG");
+    std::fs::write(support::export_path("waterui_dew_shapes.png"), png)
+        .expect("export visual review PNG");
 }

--- a/backends/dew/tests/shape_render.rs
+++ b/backends/dew/tests/shape_render.rs
@@ -178,6 +178,6 @@ fn export_shapes_for_visual_review() {
         320,
         180,
     );
-    std::fs::write(support::export_path("waterui_dew_shapes.png"), png)
+    std::fs::write(support::export_path("shapes", "review"), png)
         .expect("export visual review PNG");
 }

--- a/backends/dew/tests/smoke_frame.rs
+++ b/backends/dew/tests/smoke_frame.rs
@@ -9,6 +9,8 @@ use kurbo::{Affine, Circle, Rect, RoundedRect, Stroke};
 use peniko::Color;
 use waterui_dew::{BandScheduler, BufferDisplay, DisplayList, FrameWork, Painter, render_frame};
 
+mod support;
+
 fn demo_scene() -> DisplayList {
     let mut list = DisplayList::new();
     // Background.
@@ -73,8 +75,11 @@ fn full_frame_renders_through_bands() {
     assert_eq!(display.pixel(100, 99), [70, 130, 240, 255]);
     assert_eq!(display.pixel(250, 180), [240, 180, 60, 255]);
 
-    std::fs::write("/tmp/waterui_dew_smoke.png", display.to_png())
-        .expect("failed to export smoke-frame PNG");
+    std::fs::write(
+        support::export_path("waterui_dew_smoke.png"),
+        display.to_png(),
+    )
+    .expect("failed to export smoke-frame PNG");
 }
 
 /// A partial update must only repaint the dirty region: pixels outside it

--- a/backends/dew/tests/smoke_frame.rs
+++ b/backends/dew/tests/smoke_frame.rs
@@ -76,7 +76,7 @@ fn full_frame_renders_through_bands() {
     assert_eq!(display.pixel(250, 180), [240, 180, 60, 255]);
 
     std::fs::write(
-        support::export_path("waterui_dew_smoke.png"),
+        support::export_path("smoke_frame", "frame"),
         display.to_png(),
     )
     .expect("failed to export smoke-frame PNG");

--- a/backends/dew/tests/support/mod.rs
+++ b/backends/dew/tests/support/mod.rs
@@ -8,6 +8,8 @@ use waterui_text::font::{FontWeight, ResolvedFont};
 
 use std::path::PathBuf;
 
+use waterui_testing::TestArtifacts;
+
 #[allow(dead_code, reason = "each integration test binary uses its own subset")]
 pub fn test_environment() -> Environment {
     let _ = executor_core::try_init_global_executor(native_executor::NativeExecutor::new());
@@ -53,16 +55,26 @@ pub fn test_renderer() -> DewRenderer {
 #[allow(dead_code, reason = "each integration test binary uses its own subset")]
 pub mod simulation;
 
-/// Where a test writes the PNG (or report) it exports for visual review.
+/// Where a test writes the PNG it exports for visual review.
 ///
-/// Everything lands under the artifact root `waterui-testing` shares with CI
-/// (`WATERUI_TEST_ARTIFACTS_DIR`, uploaded with every run), in a `dew`
-/// subdirectory, and under the platform temp directory when that variable is
-/// unset — so the exports work on every host rather than only where `/tmp`
-/// exists.
+/// Everything lands in `waterui-testing`'s canonical artifact layout
+/// (`<root>/dew/<case>/<stage>.png`, with the root taken from
+/// `WATERUI_TEST_ARTIFACTS_DIR` when CI sets it and the platform temp directory
+/// otherwise), so the images ride along with the uploaded CI artifacts and the
+/// test report can list them — on every host, not only where `/tmp` exists.
 #[allow(dead_code, reason = "each integration test binary uses its own subset")]
-pub fn export_path(file_name: &str) -> PathBuf {
-    let directory = waterui_testing::artifact_root().join("dew");
-    std::fs::create_dir_all(&directory).expect("the dew export directory must be creatable");
+pub fn export_path(case: &str, stage: &str) -> PathBuf {
+    let path = TestArtifacts::new("dew").snapshot_path(case, stage);
+    std::fs::create_dir_all(path.parent().expect("a snapshot path has a case directory"))
+        .expect("the dew export directory must be creatable");
+    path
+}
+
+/// Where a test writes a non-image report, beside its images in the same case
+/// directory.
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn report_path(case: &str, file_name: &str) -> PathBuf {
+    let directory = TestArtifacts::new("dew").case_dir(case);
+    std::fs::create_dir_all(&directory).expect("the dew report directory must be creatable");
     directory.join(file_name)
 }

--- a/backends/dew/tests/support/mod.rs
+++ b/backends/dew/tests/support/mod.rs
@@ -6,6 +6,9 @@ use waterui_core::Environment;
 use waterui_dew::{DewRenderer, FontSources};
 use waterui_text::font::{FontWeight, ResolvedFont};
 
+use std::path::PathBuf;
+
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
 pub fn test_environment() -> Environment {
     let _ = executor_core::try_init_global_executor(native_executor::NativeExecutor::new());
     waterui_testing::install_test_executor();
@@ -49,3 +52,17 @@ pub fn test_renderer() -> DewRenderer {
 // `support` for `test_environment` alone.
 #[allow(dead_code, reason = "each integration test binary uses its own subset")]
 pub mod simulation;
+
+/// Where a test writes the PNG (or report) it exports for visual review.
+///
+/// Everything lands under the artifact root `waterui-testing` shares with CI
+/// (`WATERUI_TEST_ARTIFACTS_DIR`, uploaded with every run), in a `dew`
+/// subdirectory, and under the platform temp directory when that variable is
+/// unset — so the exports work on every host rather than only where `/tmp`
+/// exists.
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn export_path(file_name: &str) -> PathBuf {
+    let directory = waterui_testing::artifact_root().join("dew");
+    std::fs::create_dir_all(&directory).expect("the dew export directory must be creatable");
+    directory.join(file_name)
+}

--- a/backends/dew/tests/tabs_render.rs
+++ b/backends/dew/tests/tabs_render.rs
@@ -157,7 +157,7 @@ fn export_tabs_for_visual_review() {
     );
     runtime.pump().expect("the first frame renders");
     std::fs::write(
-        support::export_path("waterui_dew_tabs.png"),
+        support::export_path("tabs", "tabs"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export visual review PNG");
@@ -192,7 +192,7 @@ fn sidebar_tabs_select_and_retain_pages() {
     );
     runtime.pump().expect("the sidebar's first frame renders");
     std::fs::write(
-        support::export_path("waterui_dew_tabs_sidebar.png"),
+        support::export_path("tabs", "sidebar"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export sidebar visual review PNG");

--- a/backends/dew/tests/tabs_render.rs
+++ b/backends/dew/tests/tabs_render.rs
@@ -157,7 +157,7 @@ fn export_tabs_for_visual_review() {
     );
     runtime.pump().expect("the first frame renders");
     std::fs::write(
-        "/tmp/waterui_dew_tabs.png",
+        support::export_path("waterui_dew_tabs.png"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export visual review PNG");
@@ -192,7 +192,7 @@ fn sidebar_tabs_select_and_retain_pages() {
     );
     runtime.pump().expect("the sidebar's first frame renders");
     std::fs::write(
-        "/tmp/waterui_dew_tabs_sidebar.png",
+        support::export_path("waterui_dew_tabs_sidebar.png"),
         runtime.board().framebuffer().to_png(),
     )
     .expect("export sidebar visual review PNG");

--- a/backends/dew/tests/vending_performance.rs
+++ b/backends/dew/tests/vending_performance.rs
@@ -872,7 +872,7 @@ fn run_budgeted_simulation() {
     let report = build_report(&sample, frames, band_height);
     let rendered = toml::to_string_pretty(&report).expect("the report must serialize");
     std::fs::write(
-        support::export_path("waterui_dew_vending_performance.toml"),
+        support::report_path("vending_performance", "report.toml"),
         &rendered,
     )
     .expect("the performance report must be writable");

--- a/backends/dew/tests/vending_performance.rs
+++ b/backends/dew/tests/vending_performance.rs
@@ -871,8 +871,11 @@ fn run_budgeted_simulation() {
 
     let report = build_report(&sample, frames, band_height);
     let rendered = toml::to_string_pretty(&report).expect("the report must serialize");
-    std::fs::write("/tmp/waterui_dew_vending_performance.toml", &rendered)
-        .expect("the performance report must be writable");
+    std::fs::write(
+        support::export_path("waterui_dew_vending_performance.toml"),
+        &rendered,
+    )
+    .expect("the performance report must be writable");
 
     let max_rgba_band = WIDTH as usize * band_height as usize * 4;
     assert!(

--- a/backends/hydrolysis/src/renderer/tests/gpu_surface_direct.rs
+++ b/backends/hydrolysis/src/renderer/tests/gpu_surface_direct.rs
@@ -20,7 +20,7 @@ use core::cell::RefCell;
 use core::time::Duration;
 use std::rc::Rc;
 use std::time::Instant;
-use waterui_testing::artifact_root;
+use waterui_testing::TestArtifacts;
 
 use waterui::Binding;
 use waterui_core::AnyView;
@@ -44,11 +44,12 @@ const FILL: wgpu::Color = wgpu::Color {
     a: 1.0,
 };
 
-/// Where this module's visual evidence is written: the artifact root shared
-/// with CI (`WATERUI_TEST_ARTIFACTS_DIR`, uploaded with every run), or the
-/// platform temp directory when it is unset.
+/// Where this module's visual evidence is written: `waterui-testing`'s
+/// canonical `<root>/hydrolysis/direct_to_target/<stage>.png` layout, with the
+/// root from `WATERUI_TEST_ARTIFACTS_DIR` when CI sets it and the platform temp
+/// directory otherwise.
 fn image_dir() -> std::path::PathBuf {
-    artifact_root().join("waterui_direct_to_target")
+    TestArtifacts::new("hydrolysis").case_dir("direct_to_target")
 }
 
 /// What a probe recorded about its own lifetime: how often it was set up, how

--- a/backends/hydrolysis/src/renderer/tests/gpu_surface_direct.rs
+++ b/backends/hydrolysis/src/renderer/tests/gpu_surface_direct.rs
@@ -20,6 +20,7 @@ use core::cell::RefCell;
 use core::time::Duration;
 use std::rc::Rc;
 use std::time::Instant;
+use waterui_testing::artifact_root;
 
 use waterui::Binding;
 use waterui_core::AnyView;
@@ -43,8 +44,12 @@ const FILL: wgpu::Color = wgpu::Color {
     a: 1.0,
 };
 
-/// Where this module's visual evidence is written.
-const IMAGE_DIR: &str = "/tmp/waterui_direct_to_target";
+/// Where this module's visual evidence is written: the artifact root shared
+/// with CI (`WATERUI_TEST_ARTIFACTS_DIR`, uploaded with every run), or the
+/// platform temp directory when it is unset.
+fn image_dir() -> std::path::PathBuf {
+    artifact_root().join("waterui_direct_to_target")
+}
 
 /// What a probe recorded about its own lifetime: how often it was set up, how
 /// often it drew, and which format it was handed each time.
@@ -242,8 +247,9 @@ fn full_window_bindings() -> (Binding<f32>, Binding<f32>) {
 }
 
 fn write_png(name: &str, snapshot: &crate::runner::HeadlessSnapshot) -> std::path::PathBuf {
-    std::fs::create_dir_all(IMAGE_DIR).expect("the image directory must be creatable");
-    let path = std::path::Path::new(IMAGE_DIR).join(name);
+    let directory = image_dir();
+    std::fs::create_dir_all(&directory).expect("the image directory must be creatable");
+    let path = directory.join(name);
     let image = image::RgbaImage::from_raw(snapshot.width, snapshot.height, snapshot.rgba8.clone())
         .expect("snapshot dimensions must match the rgba buffer");
     image.save(&path).expect("snapshot png must be writable");

--- a/backends/hydrolysis/src/renderer/tests/tree.rs
+++ b/backends/hydrolysis/src/renderer/tests/tree.rs
@@ -10,6 +10,16 @@ use waterui::ViewExt as _;
 use waterui_controls::button::button;
 use waterui_core::layout::{HorizontalAlignment, Size};
 use waterui_core::{AnyView, SignalExt as _};
+use waterui_testing::artifact_root;
+
+/// Where this module's visual evidence is written: the artifact root shared
+/// with CI (`WATERUI_TEST_ARTIFACTS_DIR`, uploaded with every run), or the
+/// platform temp directory when it is unset.
+fn export_path(name: &str) -> std::path::PathBuf {
+    let directory = artifact_root().join("hydrolysis");
+    std::fs::create_dir_all(&directory).expect("the export directory must be creatable");
+    directory.join(name)
+}
 use waterui_layout::stack::{VStackLayout, vstack};
 use waterui_text::styled::StyledStr;
 
@@ -509,7 +519,7 @@ fn render_tree_chart_switch_snapshot() {
     use waterui_core::dynamic::watch;
     use waterui_core::handler::AnyViewBuilder;
 
-    fn write_png(path: &str, width: u32, height: u32, rgba: Vec<u8>) {
+    fn write_png(path: &std::path::Path, width: u32, height: u32, rgba: Vec<u8>) {
         let image = image::RgbaImage::from_raw(width, height, rgba)
             .expect("snapshot dimensions must match the rgba buffer");
         image.save(path).expect("snapshot png must be writable");
@@ -539,7 +549,7 @@ fn render_tree_chart_switch_snapshot() {
         .snapshot
         .expect("first frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_switch_before.png",
+        &export_path("waterui_tree_switch_before.png"),
         before.width,
         before.height,
         before.rgba8,
@@ -551,7 +561,7 @@ fn render_tree_chart_switch_snapshot() {
         .snapshot
         .expect("switched frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_switch_after.png",
+        &export_path("waterui_tree_switch_after.png"),
         after.width,
         after.height,
         after.rgba8,
@@ -576,7 +586,7 @@ fn render_tree_scene_view_switch_snapshot() {
     use waterui_core::layout::{Point, Rect, Size as LayoutSize};
     use waterui_graphics::color::Srgb;
 
-    fn write_png(path: &str, width: u32, height: u32, rgba: Vec<u8>) {
+    fn write_png(path: &std::path::Path, width: u32, height: u32, rgba: Vec<u8>) {
         let image = image::RgbaImage::from_raw(width, height, rgba)
             .expect("snapshot dimensions must match the rgba buffer");
         image.save(path).expect("snapshot png must be writable");
@@ -615,7 +625,7 @@ fn render_tree_scene_view_switch_snapshot() {
         .snapshot
         .expect("first frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_sceneview_before.png",
+        &export_path("waterui_tree_sceneview_before.png"),
         before.width,
         before.height,
         before.rgba8,
@@ -627,7 +637,7 @@ fn render_tree_scene_view_switch_snapshot() {
         .snapshot
         .expect("switched frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_sceneview_after.png",
+        &export_path("waterui_tree_sceneview_after.png"),
         after.width,
         after.height,
         after.rgba8,
@@ -648,7 +658,7 @@ fn render_tree_scroll_snapshot() {
     use std::time::Instant;
     use waterui_core::handler::AnyViewBuilder;
 
-    fn write_png(path: &str, width: u32, height: u32, rgba: Vec<u8>) {
+    fn write_png(path: &std::path::Path, width: u32, height: u32, rgba: Vec<u8>) {
         let image = image::RgbaImage::from_raw(width, height, rgba)
             .expect("snapshot dimensions must match the rgba buffer");
         image.save(path).expect("snapshot png must be writable");
@@ -679,7 +689,7 @@ fn render_tree_scroll_snapshot() {
         .snapshot
         .expect("first frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_scroll_before.png",
+        &export_path("waterui_tree_scroll_before.png"),
         before.width,
         before.height,
         before.rgba8,
@@ -697,7 +707,7 @@ fn render_tree_scroll_snapshot() {
         .snapshot
         .expect("scrolled frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_scroll_after.png",
+        &export_path("waterui_tree_scroll_after.png"),
         after.width,
         after.height,
         after.rgba8,
@@ -773,7 +783,7 @@ fn render_tree_collection_snapshot() {
     use waterui_core::handler::AnyViewBuilder;
     use waterui_core::id::SelfId;
 
-    fn write_png(path: &str, width: u32, height: u32, rgba: Vec<u8>) {
+    fn write_png(path: &std::path::Path, width: u32, height: u32, rgba: Vec<u8>) {
         let image = image::RgbaImage::from_raw(width, height, rgba)
             .expect("snapshot dimensions must match the rgba buffer");
         image.save(path).expect("snapshot png must be writable");
@@ -799,7 +809,7 @@ fn render_tree_collection_snapshot() {
         .snapshot
         .expect("collection frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_collection.png",
+        &export_path("waterui_tree_collection.png"),
         snapshot.width,
         snapshot.height,
         snapshot.rgba8,
@@ -942,7 +952,7 @@ fn gesture_wrapper_keeps_reactive_descendant_live() {
 fn render_tree_grid_snapshot() {
     use waterui_core::handler::AnyViewBuilder;
 
-    fn write_png(path: &str, width: u32, height: u32, rgba: Vec<u8>) {
+    fn write_png(path: &std::path::Path, width: u32, height: u32, rgba: Vec<u8>) {
         let image = image::RgbaImage::from_raw(width, height, rgba)
             .expect("snapshot dimensions must match the rgba buffer");
         image.save(path).expect("snapshot png must be writable");
@@ -980,7 +990,7 @@ fn render_tree_grid_snapshot() {
         .snapshot
         .expect("grid frame must capture a snapshot");
     write_png(
-        "/tmp/waterui_tree_grid.png",
+        &export_path("waterui_tree_grid.png"),
         snapshot.width,
         snapshot.height,
         snapshot.rgba8,

--- a/backends/hydrolysis/src/renderer/tests/tree.rs
+++ b/backends/hydrolysis/src/renderer/tests/tree.rs
@@ -10,15 +10,17 @@ use waterui::ViewExt as _;
 use waterui_controls::button::button;
 use waterui_core::layout::{HorizontalAlignment, Size};
 use waterui_core::{AnyView, SignalExt as _};
-use waterui_testing::artifact_root;
+use waterui_testing::TestArtifacts;
 
-/// Where this module's visual evidence is written: the artifact root shared
-/// with CI (`WATERUI_TEST_ARTIFACTS_DIR`, uploaded with every run), or the
-/// platform temp directory when it is unset.
-fn export_path(name: &str) -> std::path::PathBuf {
-    let directory = artifact_root().join("hydrolysis");
-    std::fs::create_dir_all(&directory).expect("the export directory must be creatable");
-    directory.join(name)
+/// Where this module's visual evidence is written: `waterui-testing`'s
+/// canonical `<root>/hydrolysis/<case>/<stage>.png` layout, with the root from
+/// `WATERUI_TEST_ARTIFACTS_DIR` when CI sets it (uploaded with every run) and
+/// the platform temp directory otherwise.
+fn export_path(case: &str, stage: &str) -> std::path::PathBuf {
+    let path = TestArtifacts::new("hydrolysis").snapshot_path(case, stage);
+    std::fs::create_dir_all(path.parent().expect("a snapshot path has a case directory"))
+        .expect("the export directory must be creatable");
+    path
 }
 use waterui_layout::stack::{VStackLayout, vstack};
 use waterui_text::styled::StyledStr;
@@ -549,7 +551,7 @@ fn render_tree_chart_switch_snapshot() {
         .snapshot
         .expect("first frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_switch_before.png"),
+        &export_path("switch", "before"),
         before.width,
         before.height,
         before.rgba8,
@@ -561,7 +563,7 @@ fn render_tree_chart_switch_snapshot() {
         .snapshot
         .expect("switched frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_switch_after.png"),
+        &export_path("switch", "after"),
         after.width,
         after.height,
         after.rgba8,
@@ -625,7 +627,7 @@ fn render_tree_scene_view_switch_snapshot() {
         .snapshot
         .expect("first frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_sceneview_before.png"),
+        &export_path("sceneview", "before"),
         before.width,
         before.height,
         before.rgba8,
@@ -637,7 +639,7 @@ fn render_tree_scene_view_switch_snapshot() {
         .snapshot
         .expect("switched frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_sceneview_after.png"),
+        &export_path("sceneview", "after"),
         after.width,
         after.height,
         after.rgba8,
@@ -689,7 +691,7 @@ fn render_tree_scroll_snapshot() {
         .snapshot
         .expect("first frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_scroll_before.png"),
+        &export_path("scroll", "before"),
         before.width,
         before.height,
         before.rgba8,
@@ -707,7 +709,7 @@ fn render_tree_scroll_snapshot() {
         .snapshot
         .expect("scrolled frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_scroll_after.png"),
+        &export_path("scroll", "after"),
         after.width,
         after.height,
         after.rgba8,
@@ -809,7 +811,7 @@ fn render_tree_collection_snapshot() {
         .snapshot
         .expect("collection frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_collection.png"),
+        &export_path("collection", "review"),
         snapshot.width,
         snapshot.height,
         snapshot.rgba8,
@@ -990,7 +992,7 @@ fn render_tree_grid_snapshot() {
         .snapshot
         .expect("grid frame must capture a snapshot");
     write_png(
-        &export_path("waterui_tree_grid.png"),
+        &export_path("grid", "review"),
         snapshot.width,
         snapshot.height,
         snapshot.rgba8,

--- a/components/visual/math/tests/gallery.rs
+++ b/components/visual/math/tests/gallery.rs
@@ -86,7 +86,7 @@ const GALLERY: &[(&str, &str)] = &[
 
 fn output_directory() -> PathBuf {
     std::env::var("WATERUI_MATH_GALLERY_DIR").map_or_else(
-        |_| PathBuf::from("/tmp/waterui_math_gallery"),
+        |_| std::env::temp_dir().join("waterui_math_gallery"),
         PathBuf::from,
     )
 }

--- a/components/visual/svg/tests/scene_engines.rs
+++ b/components/visual/svg/tests/scene_engines.rs
@@ -8,19 +8,18 @@
 //! The PNGs are written out to be looked at. The engines rasterize
 //! differently, so nothing about them is asserted pixel-wise.
 
-use std::path::Path;
-
 use waterui_graphics::shared_context::SceneEngine;
 use waterui_graphics::{GpuRuntime, OffscreenRenderConfig, OffscreenSize, SceneView};
 use waterui_svg::SvgSceneContent;
+use waterui_testing::artifact_root;
 
 const STROKED_ICON: &str = include_str!("data/stroked_icon.svg");
 const PAINTED_ICON: &str = include_str!("data/painted_icon.svg");
 
 #[test]
 fn both_scene_engines_render_an_svg() {
-    let directory = Path::new("/tmp/waterui_scene_engines");
-    std::fs::create_dir_all(directory).expect("output directory must be creatable");
+    let directory = artifact_root().join("waterui_scene_engines");
+    std::fs::create_dir_all(&directory).expect("output directory must be creatable");
     let runtime = pollster::block_on(GpuRuntime::new())
         .expect("scene engine comparison requires a working GPU runtime");
     let size = OffscreenSize::try_from_pixels(192, 192).expect("test size must be valid");

--- a/components/visual/svg/tests/scene_engines.rs
+++ b/components/visual/svg/tests/scene_engines.rs
@@ -11,15 +11,16 @@
 use waterui_graphics::shared_context::SceneEngine;
 use waterui_graphics::{GpuRuntime, OffscreenRenderConfig, OffscreenSize, SceneView};
 use waterui_svg::SvgSceneContent;
-use waterui_testing::artifact_root;
+use waterui_testing::TestArtifacts;
 
 const STROKED_ICON: &str = include_str!("data/stroked_icon.svg");
 const PAINTED_ICON: &str = include_str!("data/painted_icon.svg");
 
 #[test]
 fn both_scene_engines_render_an_svg() {
-    let directory = artifact_root().join("waterui_scene_engines");
-    std::fs::create_dir_all(&directory).expect("output directory must be creatable");
+    let artifacts = TestArtifacts::new("svg");
+    std::fs::create_dir_all(artifacts.case_dir("scene_engines"))
+        .expect("output directory must be creatable");
     let runtime = pollster::block_on(GpuRuntime::new())
         .expect("scene engine comparison requires a working GPU runtime");
     let size = OffscreenSize::try_from_pixels(192, 192).expect("test size must be valid");
@@ -37,7 +38,9 @@ fn both_scene_engines_render_an_svg() {
             let output = pollster::block_on(surface.render_offscreen(&runtime, config, &mut env))
                 .expect("offscreen render should succeed");
             output
-                .save_png(directory.join(format!("svg_{icon_name}_{engine_name}.png")))
+                .save_png(
+                    artifacts.snapshot_path("scene_engines", format!("{icon_name}_{engine_name}")),
+                )
                 .expect("png should be written");
         }
     }


### PR DESCRIPTION
Fixes #276

The all-features nextest passes in test.yml and windows.yml had neither `-p` nor `--workspace`, so cargo narrowed them to the root `waterui` crate: a backend crate's tests behind its own optional features (dew's `embedded-simulator`, hydrolysis' `inspector-signals` / `web`, the browsers' engine features) ran nowhere. This applies #275's clippy shape to the test side: `--workspace --all-features` with the same four exclusions (`waterui-core` nightly, `waterui-ffi` ABI `compile_error!`, `hydrolysis` `webview-system`, `waterui-browser-cef` compile-only vs runtime), plus per-crate runs in the shapes those crates actually have.

- Linux: the pass leaves the `test` job for its own `ubuntu-latest (all features)` job, so the second codegen of the graph overlaps the workspace run instead of lengthening it. Per-crate runs there: `waterui-core --features std,serde`, `waterui-ffi --features map,chromium,webview-cef`, `hydrolysis --features accessibility,inspector-signals,testing,web,winit`, `waterui-browser-cef --features chromium,webview`, `waterui-dew --no-default-features`.
- macOS: `macos-suites` runs the workspace pass plus the `waterui-core` and `hydrolysis` shapes (the other three shapes are host-independent and covered on Linux).
- Windows: the `all features` job keeps the root `--features all` run (`waterui-dylib` cannot link there) and adds the workspace pass with the root and the dylib excluded, plus the `waterui-core` and `hydrolysis` shapes.

Runtime of the new legs is measured on this PR's run.


The first Windows run of the dew tests under `--all-features` exposed a pre-existing defect: every visual-review export wrote to a hard-coded `/tmp/...` path, which does not exist on Windows. The last commit routes the dew, svg, hydrolysis and math exports through `waterui_testing::artifact_root()`, so they land in the uploaded CI artifacts on every platform.

Fixes #369
