### PR TITLE
feat(graphics): share invalidate_on_change for scene content that follows a signal

### DIFF
--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -28,7 +28,7 @@ use waterui_core::AnyView;
 use waterui_core::layout::{Point, Rect as LayoutRect, Size};
 use waterui_dew::{ClipRegion, DewRuntime, DisplayList, DrawCommand, HostBoard, render_view_png};
 use waterui_graphics::color::Srgb;
-use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
+use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, invalidate_on_change};
 use waterui_layout::scroll::ScrollView;
 use waterui_svg::Svg;
 
@@ -219,7 +219,7 @@ impl SceneContent for CountingContent {
     }
 
     fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
-        self.guard = invalidator.map(|invalidator| self.fill.watch(move |_| invalidator()));
+        self.guard = invalidator.map(|invalidator| invalidate_on_change(&invalidator, &self.fill));
     }
 }
 

--- a/components/visual/graphics/src/lib.rs
+++ b/components/visual/graphics/src/lib.rs
@@ -125,8 +125,8 @@ pub use image_generator::{
 };
 
 pub use scene_view::{
-    SceneContent, SceneInvalidator, SceneView, SceneViewMergeToParent, resolve_scene_proposal,
-    scene_stretch_axis,
+    SceneContent, SceneInvalidator, SceneView, SceneViewMergeToParent, invalidate_on_change,
+    resolve_scene_proposal, scene_stretch_axis,
 };
 pub use scene2d::{Glyph, GlyphRun, Scene2D, SceneRecording};
 #[cfg(feature = "vello-scene")]

--- a/components/visual/graphics/src/scene/scene_view.rs
+++ b/components/visual/graphics/src/scene/scene_view.rs
@@ -2,6 +2,9 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::fmt;
 
+use nami::Signal;
+use nami::watcher::BoxWatcherGuard;
+
 use waterui_core::layout::{ProposalSize, Size, StretchAxis};
 use waterui_core::{AnyView, Environment, Native, NativeView, View};
 
@@ -17,6 +20,23 @@ pub struct SceneViewMergeToParent;
 
 /// Callback used by scene content to request another frame.
 pub type SceneInvalidator = Rc<dyn Fn()>;
+
+/// Asks for a frame whenever `signal` changes, for as long as the returned
+/// guard lives.
+///
+/// The one way scene content follows a signal it draws from. This is scene
+/// invalidation, not a subtree rebuild: the content instance and whatever it
+/// caches survive the change, and the next `build_scene` reads the new value.
+/// Keep the guard beside the invalidator and drop both when the invalidator
+/// is cleared, which is what stopping the frames means.
+#[must_use]
+pub fn invalidate_on_change<S: Signal>(
+    invalidator: &SceneInvalidator,
+    signal: &S,
+) -> BoxWatcherGuard {
+    let invalidator = Rc::clone(invalidator);
+    Box::new(signal.watch(move |_| invalidator()))
+}
 
 /// Object-safe scene producer for `SceneView`.
 pub trait SceneContent: 'static {

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -10,7 +10,7 @@ use peniko::{Brush, Color as PenikoColor, FontData};
 use waterui_core::layout::Size;
 use waterui_core::{Computed, Environment, Signal, View};
 use waterui_graphics::color::{Color, ForegroundColor, ResolvedColor};
-use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
+use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, invalidate_on_change};
 use waterui_layout::frame::Frame;
 use waterui_str::Str;
 
@@ -368,10 +368,9 @@ impl SceneContent for MathContent {
         // box it typeset last. Watching the signal schedules the frame that
         // re-typesets it; this is scene invalidation, not a subtree rebuild,
         // so the content instance and its resolved font survive the change.
-        self.source_guard = invalidator.as_ref().map(|invalidator| {
-            let invalidator = SceneInvalidator::clone(invalidator);
-            self.source.watch(move |_| invalidator())
-        });
+        self.source_guard = invalidator
+            .as_ref()
+            .map(|invalidator| invalidate_on_change(invalidator, &self.source));
         self.invalidator = invalidator;
     }
 }


### PR DESCRIPTION
Fixes #274

The "watch a signal, ask the `SceneInvalidator` for a frame on change, keep the `BoxWatcherGuard` beside the invalidator, drop both when it is cleared" pattern is now one helper in `waterui-graphics`, `invalidate_on_change(&invalidator, &signal) -> BoxWatcherGuard`, exported next to `SceneInvalidator`. The math content and dew's scene render test use it.

`SceneInvalidator` stays the `Rc<dyn Fn()>` alias rather than becoming a type with a `watch` method: `waterui-canvas` 0.1.0 from the registry is compiled against this crate through the workspace `[patch]` and calls the invalidator as a function, so that shape change is bound to the next `waterui-graphics` release. The `waterui-visualizer` and `waterui-map-gpu` sites named in the issue live in their own repositories on the published 0.3.0 and pick the helper up with that release.

Verified: clippy clean on every touched crate; `waterui-math` unit tests and `waterui-dew` `scene_render` tests pass.
