### PR TITLE
fix(graphics): keep the hybrid image atlas two layers deep on GL adapters

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,8 +4360,7 @@ dependencies = [
 [[package]]
 name = "glifo"
 version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282a26c1e23de04bdab3e34a21b6f877a479b96737792516b9b8b8f69b6661be"
+source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
 dependencies = [
  "bytemuck",
  "foldhash 0.2.0",
@@ -11690,8 +11689,7 @@ dependencies = [
 [[package]]
 name = "vello_common"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb2141a2bca6e6d598e471fd4d1d7eed8e020aad6a28187edda07f091a325dd"
+source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -11730,8 +11728,7 @@ dependencies = [
 [[package]]
 name = "vello_hybrid"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dccbb4221070e7ef92486abef0002a651702f00a52d6be532249a0fa0eb3e9ba"
+source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
 dependencies = [
  "bytemuck",
  "glifo 0.3.0",
@@ -11758,8 +11755,7 @@ dependencies = [
 [[package]]
 name = "vello_sparse_shaders"
 version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86e5fd6b8d73d641ffe8522f05e2d5a7f23620005dfc1a7f49488790b9970267"
+source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
 dependencies = [
  "wesl",
  "wesl-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -420,6 +420,21 @@ block = { git = "https://github.com/Dicklesworthstone/rust-block", rev = "b39ae8
 # linebender/vello#1817; drop this patch when a release containing it ships.
 vello = { git = "https://github.com/lexoliu/vello", rev = "5e5f538556be16527f67379b105af82f408b747d" }
 
+# vello_hybrid 0.2.0 keeps only one physical layer in its image atlas off wasm,
+# and wgpu's GL backend then makes that texture `TEXTURE_2D` while the shader
+# samples a `texture_2d_array`, so every image brush renders black on a GL
+# adapter (#366). This rev is the 0.2.0 release plus a two-layer floor decided
+# by the adapter backend. The other two sparse-strip crates come from the same
+# rev because `vello_hybrid` names them by path there, and a second copy of
+# `vello_common` would make its paint types different types. Drop when a
+# release with linebender/vello#1859 (one 2D texture per atlas) ships.
+vello_hybrid = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
+vello_common = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
+vello_sparse_shaders = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
+# `vello_hybrid`'s text API takes glyphs from `glifo`, which that repo also
+# carries by path; the same rev keeps one `Glyph` type in the graph.
+glifo = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
+
 # Arm's proprietary Vulkan driver (r54p2 on Pixel 9 Pro / Android 16)
 # rasterizes as if viewport heights were positive, ignoring the negative-height
 # viewport wgpu uses to flip Y, so every render pass comes out upside down.

--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -28,7 +28,7 @@ use waterui_core::AnyView;
 use waterui_core::layout::{Point, Rect as LayoutRect, Size};
 use waterui_dew::{ClipRegion, DewRuntime, DisplayList, DrawCommand, HostBoard, render_view_png};
 use waterui_graphics::color::Srgb;
-use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
+use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, invalidate_on_change};
 use waterui_layout::scroll::ScrollView;
 use waterui_svg::Svg;
 
@@ -219,7 +219,7 @@ impl SceneContent for CountingContent {
     }
 
     fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
-        self.guard = invalidator.map(|invalidator| self.fill.watch(move |_| invalidator()));
+        self.guard = invalidator.map(|invalidator| invalidate_on_change(&invalidator, &self.fill));
     }
 }
 

--- a/components/visual/graphics/src/lib.rs
+++ b/components/visual/graphics/src/lib.rs
@@ -125,8 +125,8 @@ pub use image_generator::{
 };
 
 pub use scene_view::{
-    SceneContent, SceneInvalidator, SceneView, SceneViewMergeToParent, resolve_scene_proposal,
-    scene_stretch_axis,
+    SceneContent, SceneInvalidator, SceneView, SceneViewMergeToParent, invalidate_on_change,
+    resolve_scene_proposal, scene_stretch_axis,
 };
 pub use scene2d::{Glyph, GlyphRun, Scene2D, SceneRecording};
 #[cfg(feature = "vello-scene")]

--- a/components/visual/graphics/src/scene/scene_view.rs
+++ b/components/visual/graphics/src/scene/scene_view.rs
@@ -2,6 +2,9 @@ use alloc::boxed::Box;
 use alloc::rc::Rc;
 use core::fmt;
 
+use nami::Signal;
+use nami::watcher::BoxWatcherGuard;
+
 use waterui_core::layout::{ProposalSize, Size, StretchAxis};
 use waterui_core::{AnyView, Environment, Native, NativeView, View};
 
@@ -17,6 +20,23 @@ pub struct SceneViewMergeToParent;
 
 /// Callback used by scene content to request another frame.
 pub type SceneInvalidator = Rc<dyn Fn()>;
+
+/// Asks for a frame whenever `signal` changes, for as long as the returned
+/// guard lives.
+///
+/// The one way scene content follows a signal it draws from. This is scene
+/// invalidation, not a subtree rebuild: the content instance and whatever it
+/// caches survive the change, and the next `build_scene` reads the new value.
+/// Keep the guard beside the invalidator and drop both when the invalidator
+/// is cleared, which is what stopping the frames means.
+#[must_use]
+pub fn invalidate_on_change<S: Signal>(
+    invalidator: &SceneInvalidator,
+    signal: &S,
+) -> BoxWatcherGuard {
+    let invalidator = Rc::clone(invalidator);
+    Box::new(signal.watch(move |_| invalidator()))
+}
 
 /// Object-safe scene producer for `SceneView`.
 pub trait SceneContent: 'static {

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -10,7 +10,7 @@ use peniko::{Brush, Color as PenikoColor, FontData};
 use waterui_core::layout::Size;
 use waterui_core::{Computed, Environment, Signal, View};
 use waterui_graphics::color::{Color, ForegroundColor, ResolvedColor};
-use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView};
+use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, invalidate_on_change};
 use waterui_layout::frame::Frame;
 use waterui_str::Str;
 
@@ -368,10 +368,9 @@ impl SceneContent for MathContent {
         // box it typeset last. Watching the signal schedules the frame that
         // re-typesets it; this is scene invalidation, not a subtree rebuild,
         // so the content instance and its resolved font survive the change.
-        self.source_guard = invalidator.as_ref().map(|invalidator| {
-            let invalidator = SceneInvalidator::clone(invalidator);
-            self.source.watch(move |_| invalidator())
-        });
+        self.source_guard = invalidator
+            .as_ref()
+            .map(|invalidator| invalidate_on_change(invalidator, &self.source));
         self.invalidator = invalidator;
     }
 }


### PR DESCRIPTION
Fixes #366

`vello_hybrid` 0.2.0 allocates its image atlas with one physical layer off wasm. wgpu's GL backend picks a texture's GL target from its layer count (`get_info_from_desc` in wgpu-hal's gles backend), so that one-layer `D2` texture becomes `TEXTURE_2D` while the strip shader samples a `texture_2d_array`, and every image brush renders black. vello_hybrid already carried a two-layer floor for exactly this heuristic, gated on `target_arch = "wasm32"`; the same backend is what wgpu selects on native Linux without a Vulkan ICD, which is how the Coverage job hit it (#319) and how any Linux machine on EGL/GL would.

The fix lives in our vello fork on top of the `sparse-strips-v0.2.0` tag (lexoliu/vello@30322fbc): the floor is decided by `device.adapter_info().backend == Backend::Gl` instead of the compile target. This PR patches `vello_hybrid`, `vello_common`, `vello_sparse_shaders` and `glifo` to that rev together, because `vello_hybrid` names the other three by path inside that repo and a second copy of `vello_common` or `glifo` would make `ImageId`/`Glyph` two different types. Upstream main has since replaced the texture array with one 2D texture per atlas (linebender/vello#1859); the patch goes away with the release that carries it.

Verified:
- `hybrid_scene_engine_draws_an_image_brush` fails on an `ubuntu:24.04` container with no Vulkan ICD (llvmpipe over EGL, `backend: Gl`) at the crates.io 0.2.0 and passes at this rev; the rendered snapshot shows the full colour field instead of a black corner.
- The same test passes on Metal here, and clippy is clean on `waterui-graphics`, `hydrolysis`, `hydrolysis-m3`, `waterui-svg` and `waterui-math` against the patched stack.
