### PR TITLE
fix(graphics): poll the device after every presented frame

### DIFF
--- a/backends/hydrolysis/src/platform.rs
+++ b/backends/hydrolysis/src/platform.rs
@@ -4,6 +4,7 @@ use waterui_graphics::RedrawHandle;
 
 #[cfg(any(feature = "winit", all(target_arch = "wasm32", feature = "web")))]
 use waterui_graphics::gpu_surface::preferred_surface_format;
+use waterui_graphics::shared_context::reclaim_device;
 
 /// Input button mapped from a platform pointer event.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -434,9 +435,7 @@ impl OffscreenGpuContext {
     /// in sequence otherwise keeps every one of their allocations outstanding
     /// until the device itself is torn down.
     pub fn reclaim(&self) {
-        if let Err(error) = self.inner.device.poll(wgpu::PollType::Poll) {
-            tracing::warn!("GPU device did not reclaim dropped resources: {error}");
-        }
+        reclaim_device(&self.inner.device);
     }
 
     /// Requests a context on the adapter WaterUI would render an application on.
@@ -1131,7 +1130,7 @@ mod winit_impl {
     use super::{
         CursorStyle, InputEvent, KeyCode, KeyState, Modifiers, PlatformWindow, PointerButton,
         PointerKind, RedrawHandle, SurfaceError, SurfaceFrame, SurfaceProvider, TextInputPurpose,
-        TextInputState, TouchPhase,
+        TextInputState, TouchPhase, reclaim_device,
     };
 
     #[derive(Clone)]
@@ -1306,7 +1305,10 @@ mod winit_impl {
 
         fn present(&mut self, frame: SurfaceFrame) {
             match frame {
-                SurfaceFrame::Window { output, .. } => output.present(),
+                SurfaceFrame::Window { output, .. } => {
+                    output.present();
+                    reclaim_device(&self.gpu.device);
+                }
                 SurfaceFrame::Offscreen { .. } => {
                     panic!("hydrolysis winit surface received an offscreen frame")
                 }

--- a/components/visual/graphics/src/gpu/shared_context.rs
+++ b/components/visual/graphics/src/gpu/shared_context.rs
@@ -474,6 +474,26 @@ pub fn drain_device_before_teardown(device: &wgpu::Device) {
     }
 }
 
+/// Releases the resources whose destruction the device deferred.
+///
+/// `wgpu` retires finished submissions from inside `Queue::submit`, but the
+/// bookkeeping of the objects those submissions dropped — the bind groups and
+/// texture views a scene renderer creates per frame — is released only from
+/// `Device::poll`. A frame loop that only ever submits and presents therefore
+/// keeps every frame's share of it forever: on a Pixel 9 Pro, 56 animated
+/// `GpuSurface`s grew the native heap by 87 MB per 150 s, and were flat with
+/// this call after each presented frame.
+///
+/// Non-blocking: `PollType::Poll` processes what has already completed and
+/// returns. Every frame owner that presents without registering the submission
+/// with the completion driver (which polls for it) calls this once per frame,
+/// after the present.
+pub fn reclaim_device(device: &wgpu::Device) {
+    if let Err(error) = device.poll(wgpu::PollType::Poll) {
+        tracing::warn!("GPU device did not reclaim deferred resources: {error}");
+    }
+}
+
 impl Drop for SharedGpuContext {
     fn drop(&mut self) {
         // Draining first leaves the completion thread nothing left to wait for,

--- a/ffi/src/components/visual/applied_filter.rs
+++ b/ffi/src/components/visual/applied_filter.rs
@@ -30,7 +30,7 @@ use waterui_graphics::RedrawHandle;
 use waterui_graphics::filter_view::{
     AppliedFilter, EffectContext, EffectFrameClock, EffectInput, EffectOutput, WgslModuleCache,
 };
-use waterui_graphics::shared_context::GpuRuntime;
+use waterui_graphics::shared_context::{GpuRuntime, reclaim_device};
 
 use crate::{IntoFFI, WuiAnyView};
 
@@ -700,6 +700,7 @@ pub unsafe extern "C" fn waterui_applied_filter_render(
 
     // Present
     output.present();
+    reclaim_device(&state.runtime.context().device);
 
     needs_redraw
 }

--- a/ffi/src/components/visual/gpu_surface.rs
+++ b/ffi/src/components/visual/gpu_surface.rs
@@ -40,7 +40,7 @@ use {
 use waterui_graphics::gpu_surface::{
     GestureState, GpuContext, GpuFrame, GpuSurface, PointerState, RedrawHandle,
 };
-use waterui_graphics::shared_context::{GpuRuntime, GpuSubmissionCompletionDriver};
+use waterui_graphics::shared_context::{GpuRuntime, GpuSubmissionCompletionDriver, reclaim_device};
 
 use crate::components::layouting::layout::{WuiProposalSize, WuiViewDimensions};
 use crate::{IntoFFI, IntoRust};
@@ -813,6 +813,7 @@ pub unsafe extern "C" fn waterui_gpu_surface_render(
     let needs_redraw = frame.was_redraw_requested() || state.redraw_handle.take_dirty();
 
     output.present();
+    reclaim_device(&state.runtime.context().device);
 
     needs_redraw
 }

--- a/ffi/src/components/visual/view_effect.rs
+++ b/ffi/src/components/visual/view_effect.rs
@@ -32,7 +32,7 @@ use {
 };
 
 use waterui_graphics::RedrawHandle;
-use waterui_graphics::shared_context::GpuRuntime;
+use waterui_graphics::shared_context::{GpuRuntime, reclaim_device};
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 use waterui_graphics::view_effect::ViewEffectContext;
 use waterui_graphics::view_effect::{
@@ -615,6 +615,7 @@ pub unsafe extern "C" fn waterui_view_effect_render(state: *mut WuiViewEffectSta
 
     // Present
     output.present();
+    reclaim_device(&state.runtime.context().device);
 
     needs_redraw
 }


### PR DESCRIPTION
Fixes #370

Pre-existing defect. wgpu retires finished submissions from inside `Queue::submit`, but the bookkeeping of the objects those submissions dropped (the bind groups and texture views vello creates per frame) is released only from `Device::poll`. The Metal `GpuSurface` path registers each frame with the completion driver, which polls for it, so macOS was flat. The Vulkan/Android `GpuSurface` path, the view-effect and applied-filter surfaces, and the Hydrolysis window pump only ever submitted and presented, so every frame's share stayed allocated for the life of the process.

**Measured on the Pixel 9 Pro**, 56 animated `GpuSurface`s, screen kept awake for the run:

| build | native heap t=30 s | t=180 s | renders in window |
|---|---|---|---|
| dev | 466 MB | 553 MB | 160k |
| this PR | 437 MB | 437 MB | 160k |

heapprofd attributes the growth to `Device::create_bind_group` and `Device::create_texture_view` boxes under `vello::Renderer::render_to_texture`, with every wgpu-hal object count flat (the GPU objects are freed, the wgpu-core shells are not).

**Change**: `reclaim_device` in `waterui_graphics::shared_context` is the one non-blocking `PollType::Poll`. Every frame owner that presents without a completion registration calls it after the present (`waterui_gpu_surface_render`, view effect, applied filter, Hydrolysis winit window), and Hydrolysis's offscreen `reclaim` reuses it.

Checked locally: `cargo clippy -p waterui-graphics -p waterui-ffi -p hydrolysis --all-targets --features waterui-ffi/gpu -D warnings`, rustfmt on the touched files, and the device run above.
