### PR TITLE
fix(android): fill a colour view's own bounds instead of the whole clip

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
 apple-backend-commit = "dd07ae94d6617eca73879f195b322a44bc06f5ba"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
-android-backend-commit = "f4649a3641f0442bcbbfd1de2994af111d234c2f"
+android-backend-commit = "fc64afed40624f301d2a22593a7a1262f3fd2d7f"
 
 [[bin]]
 name = "water"


### PR DESCRIPTION
Fixes #373

Android submodule bump only (`water-rs/android-backend` fc64afed).

`ColorFillView`, the view behind `Color`, `ResolvedColor` and therefore `Divider`, and the colour picker's `HdrColorPreviewView` painted with `Canvas.drawColor`. That call floods the canvas's *current clip*, not the view's bounds, and every WaterUI container (`RustLayoutViewGroup`, `PassThroughFrameLayout`) sets `clipChildren = false`, so the clip in effect is the nearest clipping ancestor: the `ScrollView` viewport or the window. Each divider therefore painted a viewport-sized grey rectangle over everything drawn before it. In the icons example on the Pixel 9 Pro only the last section was visible; the view hierarchy was correct (`ColorFillView` bounds `0,0-888,2`), only the paint was wrong.

Pre-existing. It was masked because SVG icons rendered through `GpuSurface` `SurfaceView`s above the window; the in-tree bitmap path of #372 exposed it.

Fix: both views fill `0,0,width,height` with a `Paint` carrying the packed colour; the flooding `Canvas.drawPackedColor` helper is deleted. Verified on the Pixel 9 Pro: the icons example shows the title, three hairline dividers and every section.
