### PR TITLE
fix(cli): enable `water run --platform windows` for the gallery example

### DIFF
--- a/cli/src/hydrolysis/platform.rs
+++ b/cli/src/hydrolysis/platform.rs
@@ -129,6 +129,10 @@ pub async fn build_hydrolysis_with_envs_and_features(
         );
     }
 
+    // Stage assets and the Windows icon resource before the backend is built.
+    // The generated `build.rs` expects `app-icon.ico` to exist when targeting Windows.
+    copy_assets_and_fonts(project, &backend_path).await?;
+
     let llvm_envs = WindowsArm64LlvmToolchain
         .cargo_envs()
         .await

--- a/cli/src/terminal/project_path.rs
+++ b/cli/src/terminal/project_path.rs
@@ -3,6 +3,6 @@ use std::path::{Path, PathBuf};
 use color_eyre::eyre::{Result, WrapErr};
 
 pub fn canonicalize(path: &Path) -> Result<PathBuf> {
-    path.canonicalize()
+    dunce::canonicalize(path)
         .wrap_err_with(|| format!("Failed to canonicalize path: {}", path.display()))
 }


### PR DESCRIPTION
## Summary

This PR fixes two Windows-specific issues that prevented `water run --platform windows` from completing for `examples/gallery`:

1. **Path canonicalization mismatch** — `terminal/project_path.rs` used `std::fs::canonicalize`, which on Windows returns verbatim `\\?\` paths. Passing those to `cargo_metadata::MetadataCommand` made `manifest_path` comparisons in `project_model/project.rs` fail, because the rest of the codebase normalizes with `dunce`. Switched to `dunce::canonicalize` so paths stay comparable.

2. **Missing `app-icon.ico` before the hydrolysis build** — The generated hydrolysis `build.rs` panics when `app-icon.ico` is not present, expecting the CLI to stage it first. `package_hydrolysis` staged assets *after* building, so `build_hydrolysis` hit the missing-icon assertion. `build_hydrolysis_with_envs_and_features` now calls `copy_assets_and_fonts` before `RustBuild`, which writes the Windows icon (and project assets/fonts) into the backend directory before `build.rs` runs.

With these changes, the gallery example builds and launches on Windows. (In the test VM, which only exposes the Microsoft Basic Render Driver, the app also needed `WATER_HYDROLYSIS_FORCE_FALLBACK_ADAPTER=1` to render; this is an environment/runtime toggle, not a code change.)
