### PR TITLE
fix(dew): install dew's type scale for unset font slots

### DIFF
--- a/backends/dew/src/lib.rs
+++ b/backends/dew/src/lib.rs
@@ -27,8 +27,9 @@
 //! - [`display`]: the flush boundary — where rasterized regions leave the
 //!   renderer toward a concrete screen (in-memory buffer on desktop,
 //!   RGB565 LCD stream on embedded targets)
-//! - [`theme`]: the built-in widget palette — named colors every handler
-//!   draws with until environment-driven theming lands
+//! - [`theme`]: the built-in appearance — named colors every handler draws
+//!   with, and the type scale [`DewRuntime`] installs for the font slots an
+//!   application's theme leaves unset
 //!
 //! # Deliberately unsupported: the GPU stack
 //!
@@ -50,7 +51,7 @@
 //! # Interaction beyond controls: the `gestures` feature
 //!
 //! Controls (buttons, toggles, sliders, tabs) hit-test through
-//! [`pointer::PointerRouter`] and are always available. The richer pointer
+//! dew's internal pointer router and are always available. The richer pointer
 //! semantics a view asks for with `.gesture(...)` / `.on_hover_*` —
 //! `Metadata<GestureObserver>` and `Metadata<OnEvent>`, which is what makes an
 //! interactive chart interactive — recognize through `waterui-backend-core`'s

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -68,12 +68,17 @@ impl<B: Board> DewRuntime<B> {
     /// into bands at most `band_height` rows tall.
     ///
     /// `build_root` is invoked exactly once, on the first pump.
+    ///
+    /// Dew's built-in type scale is installed into `env` for every font slot it
+    /// does not already carry, so an app that installs no theme still renders
+    /// text; see [`crate::theme::install_default_fonts`].
     pub fn new(
         mut board: B,
-        env: Environment,
+        mut env: Environment,
         band_height: u32,
         build_root: impl Fn() -> AnyView + 'static,
     ) -> Self {
+        crate::theme::install_default_fonts(&mut env);
         let render_settings = board.render_settings();
         let fonts = board.fonts();
         let signals = waterui_backend_core::frame_signals::FrameSignals::new(board.now());
@@ -250,6 +255,7 @@ mod tests {
     use std::rc::Rc;
     use waterui_backend_core::input::TouchPhase;
     use waterui_controls::toggle::Toggle;
+    use waterui_text::text;
 
     struct CountingToggle {
         body_calls: Rc<Cell<usize>>,
@@ -289,6 +295,19 @@ mod tests {
 
         assert!(!frame.dirty.is_empty());
         assert_eq!(body_calls.get(), 1, "refresh must not evaluate body again");
+    }
+
+    /// Dew supplies its own type scale, so an application that installs no
+    /// theme still renders text: the body font slot is resolved inside
+    /// `waterui-text`, which panics when the environment carries no token.
+    #[test]
+    fn text_renders_without_an_installed_theme() {
+        let mut runtime = DewRuntime::new(HostBoard::new(200, 40), Environment::new(), 16, || {
+            AnyView::new(text("Dew"))
+        });
+
+        let frame = runtime.pump().expect("initial frame must render");
+        assert!(!frame.dirty.is_empty(), "text must paint something");
     }
 
     #[test]

--- a/backends/dew/src/theme.rs
+++ b/backends/dew/src/theme.rs
@@ -3,10 +3,13 @@
 use nami::{Computed, Signal};
 use peniko::Color;
 use waterui_backend_core::frame_signals::FrameSignals;
-use waterui_core::Environment;
+use waterui_core::{Environment, env::Store};
 use waterui_graphics::color::{
     AccentColor, AccentForegroundColor, BackgroundColor, BorderColor, ForegroundColor,
     MutedForegroundColor, ResolvedColor, Srgb, SurfaceColor, SurfaceVariantColor,
+};
+use waterui_text::font::{
+    Body, Caption, FontWeight, Footnote, Headline, ResolvedFont, Subheadline, Title,
 };
 
 use crate::dispatch::WatchedSignal;
@@ -38,6 +41,57 @@ pub const TRACK: Color = Color::from_rgb8(229, 229, 234);
 
 /// Movable control knobs: toggle and slider thumbs.
 pub const THUMB: Color = Color::WHITE;
+
+/// Body text: the size and weight `text("…")` shapes at.
+pub const BODY_FONT: ResolvedFont = ResolvedFont::new(16.0, FontWeight::Normal);
+
+/// Screen and section titles.
+pub const TITLE_FONT: ResolvedFont = ResolvedFont::new(22.0, FontWeight::Normal);
+
+/// The most prominent line on a screen.
+pub const HEADLINE_FONT: ResolvedFont = ResolvedFont::new(24.0, FontWeight::Normal);
+
+/// Body-sized text carrying a heading's emphasis.
+pub const SUBHEADLINE_FONT: ResolvedFont = ResolvedFont::new(16.0, FontWeight::Medium);
+
+/// Secondary annotations beside content.
+pub const CAPTION_FONT: ResolvedFont = ResolvedFont::new(12.0, FontWeight::Normal);
+
+/// The smallest supporting text.
+pub const FOOTNOTE_FONT: ResolvedFont = ResolvedFont::new(11.0, FontWeight::Medium);
+
+/// Installs dew's built-in type scale for every font slot the application's
+/// theme left unset.
+///
+/// Font slots are the one part of the palette dew cannot resolve at draw time:
+/// a colour an application never chose falls back to this module's constants
+/// where it is drawn, while a font is resolved inside `waterui-text`, which
+/// requires the token to be in the environment and panics when it is not. Supplying a default appearance is
+/// the backend's job rather than the view code's, so [`crate::DewRuntime`]
+/// applies this to the environment it renders under — a device app that
+/// installs no theme still renders `text("…")`, exactly as it renders a
+/// foreground colour it never chose.
+///
+/// The scale matches the one every other `WaterUI` backend defaults to, so the
+/// same view has the same proportions on a panel and on a desktop window. No
+/// family is named: firmware shapes with the faces its board bundles, and a
+/// desktop simulator with the system collection.
+pub fn install_default_fonts(env: &mut Environment) {
+    install_default::<Body>(env, BODY_FONT);
+    install_default::<Title>(env, TITLE_FONT);
+    install_default::<Headline>(env, HEADLINE_FONT);
+    install_default::<Subheadline>(env, SUBHEADLINE_FONT);
+    install_default::<Caption>(env, CAPTION_FONT);
+    install_default::<Footnote>(env, FOOTNOTE_FONT);
+}
+
+fn install_default<T: 'static>(env: &mut Environment, font: ResolvedFont) {
+    if env.query::<T, Computed<ResolvedFont>>().is_none() {
+        env.insert(Store::<T, Computed<ResolvedFont>>::new(Computed::constant(
+            font,
+        )));
+    }
+}
 
 /// Theme signals retained for the renderer lifetime. Every slot requests a
 /// frame when it changes, so controls repaint without rebuilding the tree.


### PR DESCRIPTION
## Root cause

`cargo run -p waterui-dew --example watch_sim --features embedded-simulator` panicked at `components/foundation/text/src/font.rs:245` — "Body font token is not installed in the environment".

The example is not what is broken. Every dew host hands `DewRuntime` an environment the application built, and nothing in dew ever put a font token into one: the generated ESP32 firmware harness passes `Environment::new()` straight through `espidf::run` (`cli/src/templates/esp32/src/main.rs.tpl`), and so does the simulator (`backends/dew/examples/watch_sim.rs`). A colour an application never chose falls back to `backends/dew/src/theme.rs`'s built-in constants where it is drawn (`theme::slot`, `theme::foreground`); a font is instead resolved inside `waterui-text`, whose slot `Resolvable` requires the token to be in the environment and panics when it is not. So any dew app that installs no theme died at its first text layout, not only this example. Pre-existing, and in dew's shared host setup rather than in the example.

Principle 6 puts default appearance on the framework: dew already ships a built-in palette for colours, and its typography half was missing.

## The fix

- `backends/dew/src/theme.rs`: dew's built-in type scale (`BODY_FONT` … `FOOTNOTE_FONT`) plus `install_default_fonts`, which installs each slot the environment does not already carry — a theme the application installs still wins. The sizes and weights match what every other backend defaults to, so the same view keeps its proportions on a panel and on a desktop window. No family is named: firmware shapes with the faces its board bundles, the simulator with the system collection.
- `backends/dew/src/runtime.rs`: `DewRuntime::new` applies it to the environment it renders under, which is the single choke point every dew host goes through (`espidf::run`, `embedded_simulator::run`, `render_view_png`, and firmware driving the runtime directly).
- Regression test `runtime::tests::text_renders_without_an_installed_theme`: a runtime built with a bare `Environment::new()` renders `text("Dew")`. Verified it fails with the same panic when the install line is removed.
- Two pre-existing rustdoc warnings in the touched files (public docs linking private items) fixed alongside.

## Verification

- `cargo run -p waterui-dew --example watch_sim --features embedded-simulator` — runs; window captured and read: "Dew on watch" at body size, the cyan block, and the reactive "uptime: 6 s" counter at the bottom.
- `cargo clippy -p waterui-dew --all-targets --features embedded-simulator -- -D warnings` — clean.
- `cargo nextest run -p waterui-dew` — 104 tests run: 104 passed.
- `cargo doc -p waterui-dew --no-deps --features embedded-simulator` — no warnings.

Fixes #377