### PR TITLE
fix(apple): reveal the clicked element from Inspect Element

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -25,7 +25,7 @@ waterui-preview-version = "0.1.0"
 waterui-preview-protocol-version = "0.1.0"
 android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
-apple-backend-commit = "5f8604c3a0b5eab193fd84aa50921ee094d401d4"
+apple-backend-commit = "180dfaa559eea9ef6434c1c23d7d7c4b8c07cc7e"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
 android-backend-commit = "91ef771aadea21de11cc53ce5f42f3a63f53638f"
 


### PR DESCRIPTION
Fixes #326

Apple submodule bump (`water-rs/apple-backend` 18a49927) plus the CLI scaffold pin.

**Root cause.** `WuiInspectorMenuTarget.inspect` opened the inspector and published the tree, but never told the runtime which node the user pointed at: it dropped the event location and called `waterui_inspector_open`. The runtime's `InspectorRuntime::inspect_node` (`src/runtime/inspector/mod.rs`) is the entry point for this gesture: it records the selection and reveals it as soon as an inspector attaches, so calling it before the tree is read is fine, but nothing on Apple ever called it. On iOS the two-finger long press did the same and published no tree at all.

**Fix** (`backends/apple/Sources/WaterUI/WuiInspector.swift` only). The menu target carries the click's `locationInWindow`, hit-tests the window's content view with it the way AppKit routes the event, publishes the tree and calls `waterui_inspector_inspect_node` with the hit view's identifier. The identifier is one shared `WuiInspector.identifier(_:)` used by both `publishTree` and the reveal, so the two cannot drift. The iOS long press hit-tests the host view under the touch and does the same.

Verified with `swift build` on the patched package (warm: 6 s, clean cache: 29 s, no diagnostics).
