### PR TITLE
fix(gtk): clip shapes from their ShapeKind, not from path commands

### DIFF
--- a/backends/gtk/Cargo.toml
+++ b/backends/gtk/Cargo.toml
@@ -12,6 +12,11 @@ keywords = ["ui", "gtk", "waterui", "gui", "backend"]
 categories = ["gui"]
 
 [dependencies]
+# Shape geometry is plain arithmetic with no GTK in it, so `shape_geometry`
+# compiles and is tested on every host even though the rest of this backend is
+# Linux only. Default features are off here: the GPU morph renderer is Linux-only
+# work, and the Linux entry below turns it back on.
+waterui-shape = { workspace = true, default-features = false }
 
 [target.'cfg(target_os = "linux")'.dependencies]
 waterui.workspace = true

--- a/backends/gtk/src/components/graphics/clip_shape_widget.rs
+++ b/backends/gtk/src/components/graphics/clip_shape_widget.rs
@@ -1,0 +1,126 @@
+//! A GTK widget that clips its child to a `WaterUI` shape.
+//!
+//! Clipping happens in [`WidgetImpl::snapshot`], where the widget's allocated
+//! size is finally known, so a normalized corner radius can be resolved against
+//! the shorter side the way [`crate::shape_geometry`] describes. CSS cannot do
+//! this: `border-radius` in percent resolves horizontally against the width and
+//! vertically against the height, so a percentage that is round on a square
+//! surface is elliptical on every other one.
+
+use gtk4::prelude::*;
+use gtk4::subclass::prelude::*;
+use gtk4::{Widget, glib, graphene, gsk};
+use waterui_shape::ShapeKind;
+
+use crate::shape_geometry::{Corner, ShapeGeometry, resolve};
+
+mod imp {
+    // The glib subclass macros expand against the parent scope, so this module
+    // deliberately re-exports it wholesale rather than tracking each generated use.
+    #[allow(
+        clippy::wildcard_imports,
+        reason = "glib subclass macros expand against the parent scope"
+    )]
+    use super::*;
+    use std::cell::{Cell, RefCell};
+
+    #[derive(Debug, Default)]
+    pub struct WuiClipShape {
+        pub kind: Cell<ShapeKind>,
+        pub child: RefCell<Option<Widget>>,
+    }
+
+    #[glib::object_subclass]
+    impl ObjectSubclass for WuiClipShape {
+        const NAME: &'static str = "WuiClipShape";
+        type Type = super::WuiClipShape;
+        type ParentType = Widget;
+
+        fn class_init(klass: &mut Self::Class) {
+            klass.set_layout_manager_type::<gtk4::BinLayout>();
+        }
+    }
+
+    impl ObjectImpl for WuiClipShape {
+        fn dispose(&self) {
+            if let Some(child) = self.child.borrow_mut().take() {
+                child.unparent();
+            }
+        }
+    }
+
+    impl WidgetImpl for WuiClipShape {
+        #[allow(
+            clippy::cast_possible_truncation,
+            reason = "GSK geometry is f32 while the resolved shape geometry is f64"
+        )]
+        fn snapshot(&self, snapshot: &gtk4::Snapshot) {
+            let widget = self.obj();
+            let width = f64::from(widget.width());
+            let height = f64::from(widget.height());
+
+            let ShapeGeometry::Rounded(rect) = resolve(self.kind.get(), width, height) else {
+                unreachable!("WuiClipShape rejects a custom path in its constructor");
+            };
+
+            let bounds = graphene::Rect::new(
+                rect.x as f32,
+                rect.y as f32,
+                rect.width as f32,
+                rect.height as f32,
+            );
+            if rect.is_rectangular() {
+                snapshot.push_clip(&bounds);
+            } else {
+                let size = |corner: Corner| {
+                    graphene::Size::new(corner.horizontal as f32, corner.vertical as f32)
+                };
+                let [top_left, top_right, bottom_right, bottom_left] = rect.corners;
+                snapshot.push_rounded_clip(&gsk::RoundedRect::new(
+                    bounds,
+                    size(top_left),
+                    size(top_right),
+                    size(bottom_right),
+                    size(bottom_left),
+                ));
+            }
+
+            self.parent_snapshot(snapshot);
+            snapshot.pop();
+        }
+    }
+}
+
+glib::wrapper! {
+    /// A single-child widget that clips its child to a [`ShapeKind`].
+    pub struct WuiClipShape(ObjectSubclass<imp::WuiClipShape>)
+        @extends Widget,
+        @implements gtk4::Accessible, gtk4::Buildable, gtk4::ConstraintTarget;
+}
+
+impl WuiClipShape {
+    /// Wraps `child` in a widget that clips it to `kind`.
+    ///
+    /// # Panics
+    ///
+    /// Panics for [`ShapeKind::CustomPath`]. Clipping to an arbitrary path needs
+    /// `gtk_snapshot_push_fill`, which arrived in GTK 4.14, and this backend
+    /// targets 4.12. Clipping to a custom path has never worked on GTK; it used
+    /// to panic out of the path recogniser instead of here.
+    #[must_use]
+    pub fn new(kind: ShapeKind, child: &Widget) -> Self {
+        assert!(
+            !matches!(kind, ShapeKind::CustomPath),
+            "the GTK backend cannot clip to a custom path: gtk_snapshot_push_fill needs GTK 4.14 \
+             and this backend targets 4.12"
+        );
+
+        let widget: Self = glib::Object::new();
+        widget.set_halign(gtk4::Align::Fill);
+        widget.set_valign(gtk4::Align::Fill);
+        widget.imp().kind.set(kind);
+        child.set_parent(&widget);
+        *widget.imp().child.borrow_mut() = Some(child.clone());
+        widget
+    }
+}

--- a/backends/gtk/src/components/graphics/mod.rs
+++ b/backends/gtk/src/components/graphics/mod.rs
@@ -1,5 +1,6 @@
 //! GTK widget implementations for `WaterUI` graphics components.
 
+pub mod clip_shape_widget;
 pub mod color;
 pub mod gpu_surface;
 pub mod gradient;

--- a/backends/gtk/src/components/graphics/shape.rs
+++ b/backends/gtk/src/components/graphics/shape.rs
@@ -12,6 +12,7 @@ use waterui_graphics::color::ResolvedColor;
 
 use crate::component::GtkComponent;
 use crate::renderer::GtkRenderer;
+use crate::shape_geometry::{Corner, RoundedRect, ShapeGeometry, resolve};
 use crate::util::{resolved_color_to_srgba_f64, store_watcher_guard, subscribe_then_get};
 
 impl GtkComponent for Native<ResolvedShape> {
@@ -61,11 +62,9 @@ impl GtkComponent for Native<ResolvedShape> {
 
 /// Appends the shape's outline, resolved against the size it is drawn at.
 ///
-/// The path commands are in unit space, so a corner traced from them stretches
-/// with the rect: a rounded rectangle far wider than it is tall gets flat
-/// elliptical corners sweeping the whole edge. The kind carries what the
-/// commands cannot — a corner radius as a fraction of the *shorter* side — and
-/// only a custom path has nothing better than the commands to describe it.
+/// The geometry comes from [`crate::shape_geometry`], which is also what the
+/// clip widget resolves through, so a clipped fill and its clip agree. Only a
+/// custom path falls back to the unit-space commands.
 fn append_shape(
     cr: &gtk4::cairo::Context,
     kind: ShapeKind,
@@ -73,39 +72,9 @@ fn append_shape(
     width: f64,
     height: f64,
 ) {
-    let shorter = width.min(height);
-    let limit = shorter / 2.0;
-    let scaled = |radius: f32| (f64::from(radius) * shorter).clamp(0.0, limit);
-    match kind {
-        ShapeKind::Rect => cr.rectangle(0.0, 0.0, width, height),
-        // A circle is inscribed in the bounds: centred, its diameter the
-        // shorter side.
-        ShapeKind::Circle => append_ellipse(cr, width / 2.0, height / 2.0, limit, limit),
-        ShapeKind::Ellipse => {
-            append_ellipse(cr, width / 2.0, height / 2.0, width / 2.0, height / 2.0);
-        }
-        ShapeKind::RoundedRect { corner_radius } => {
-            let radius = scaled(corner_radius);
-            append_rounded_rect(cr, width, height, [radius; 4]);
-        }
-        ShapeKind::UnevenRoundedRect {
-            top_left,
-            top_right,
-            bottom_right,
-            bottom_left,
-        } => append_rounded_rect(
-            cr,
-            width,
-            height,
-            [
-                scaled(top_left),
-                scaled(top_right),
-                scaled(bottom_right),
-                scaled(bottom_left),
-            ],
-        ),
-        ShapeKind::Capsule => append_rounded_rect(cr, width, height, [limit; 4]),
-        ShapeKind::CustomPath => {
+    match resolve(kind, width, height) {
+        ShapeGeometry::Rounded(rect) => append_rounded_rect(cr, &rect),
+        ShapeGeometry::CustomPath => {
             for command in commands {
                 apply_path_command(cr, *command, width, height);
             }
@@ -113,52 +82,85 @@ fn append_shape(
     }
 }
 
-/// Traces an axis-aligned ellipse, which cairo has no primitive for.
-fn append_ellipse(
-    cr: &gtk4::cairo::Context,
-    center_x: f64,
-    center_y: f64,
-    radius_x: f64,
-    radius_y: f64,
-) {
-    cr.save().expect("failed to save the cairo state");
-    cr.translate(center_x, center_y);
-    cr.scale(radius_x.max(f64::EPSILON), radius_y.max(f64::EPSILON));
-    cr.arc(0.0, 0.0, 1.0, 0.0, core::f64::consts::TAU);
-    cr.restore().expect("failed to restore the cairo state");
-}
-
-/// Traces a rounded rectangle from four circular corner radii, clockwise from
-/// the top left.
-fn append_rounded_rect(
-    cr: &gtk4::cairo::Context,
-    width: f64,
-    height: f64,
-    [top_left, top_right, bottom_right, bottom_left]: [f64; 4],
-) {
+/// Traces a rounded rectangle, clockwise from the top left.
+///
+/// A circle or an ellipse arrives here as a rect whose corner radii are half its
+/// own width and height, so the four arcs meet with no straight edge between
+/// them and the same routine draws every non-custom shape.
+fn append_rounded_rect(cr: &gtk4::cairo::Context, rect: &RoundedRect) {
     use core::f64::consts::{FRAC_PI_2, PI};
-    cr.move_to(top_left, 0.0);
-    cr.line_to(width - top_right, 0.0);
-    cr.arc(width - top_right, top_right, top_right, -FRAC_PI_2, 0.0);
-    cr.line_to(width, height - bottom_right);
-    cr.arc(
-        width - bottom_right,
-        height - bottom_right,
+
+    let RoundedRect {
+        x: left,
+        y: top,
+        width,
+        height,
+        corners: [top_left, top_right, bottom_right, bottom_left],
+    } = *rect;
+    let right = left + width;
+    let bottom = top + height;
+
+    cr.move_to(left + top_left.horizontal, top);
+    cr.line_to(right - top_right.horizontal, top);
+    append_corner_arc(
+        cr,
+        right - top_right.horizontal,
+        top + top_right.vertical,
+        top_right,
+        -FRAC_PI_2,
+        0.0,
+    );
+    cr.line_to(right, bottom - bottom_right.vertical);
+    append_corner_arc(
+        cr,
+        right - bottom_right.horizontal,
+        bottom - bottom_right.vertical,
         bottom_right,
         0.0,
         FRAC_PI_2,
     );
-    cr.line_to(bottom_left, height);
-    cr.arc(
-        bottom_left,
-        height - bottom_left,
+    cr.line_to(left + bottom_left.horizontal, bottom);
+    append_corner_arc(
+        cr,
+        left + bottom_left.horizontal,
+        bottom - bottom_left.vertical,
         bottom_left,
         FRAC_PI_2,
         PI,
     );
-    cr.line_to(0.0, top_left);
-    cr.arc(top_left, top_left, top_left, PI, PI + FRAC_PI_2);
+    cr.line_to(left, top + top_left.vertical);
+    append_corner_arc(
+        cr,
+        left + top_left.horizontal,
+        top + top_left.vertical,
+        top_left,
+        PI,
+        PI + FRAC_PI_2,
+    );
     cr.close_path();
+}
+
+/// Traces one corner as an elliptical arc, which cairo can only express by
+/// scaling a unit circle.
+fn append_corner_arc(
+    cr: &gtk4::cairo::Context,
+    center_x: f64,
+    center_y: f64,
+    corner: Corner,
+    start: f64,
+    end: f64,
+) {
+    if corner.horizontal <= 0.0 || corner.vertical <= 0.0 {
+        // A square corner: the two edges already meet at the centre point.
+        cr.line_to(center_x, center_y);
+        return;
+    }
+
+    cr.save().expect("failed to save the cairo state");
+    cr.translate(center_x, center_y);
+    cr.scale(corner.horizontal, corner.vertical);
+    cr.arc(0.0, 0.0, 1.0, start, end);
+    cr.restore().expect("failed to restore the cairo state");
 }
 
 /// Appends one resolved path command to the cairo context.

--- a/backends/gtk/src/lib.rs
+++ b/backends/gtk/src/lib.rs
@@ -33,6 +33,8 @@ pub mod components;
 pub mod layout;
 #[cfg(target_os = "linux")]
 pub mod renderer;
+// Plain geometry with no GTK in it, so it builds and tests on every host.
+pub mod shape_geometry;
 #[cfg(target_os = "linux")]
 mod theme;
 #[cfg(target_os = "linux")]

--- a/backends/gtk/src/renderer.rs
+++ b/backends/gtk/src/renderer.rs
@@ -5,9 +5,9 @@ use std::rc::Rc;
 
 use glib::object::ObjectExt;
 use glib::value::ToValue;
+use gtk4::Align;
 use gtk4::Widget;
 use gtk4::prelude::*;
-use gtk4::{Align, Overflow};
 use nami::Signal;
 use waterui::accessibility::{
     AccessibilityChecked, AccessibilityChildren, AccessibilityHidden, AccessibilityLabel,
@@ -58,12 +58,13 @@ use waterui_navigation::{
     NavigationSplitLayout, NavigationStack, NavigationTransitionDestination,
     NavigationTransitionSource, NavigationView,
 };
-use waterui_shape::{ClipShape, PathCommand, ResolvedShape};
+use waterui_shape::{ClipShape, ResolvedShape};
 use waterui_text::TextConfig;
 #[cfg(feature = "webview-system")]
 use waterui_webview::WebView;
 
 use crate::component::GtkComponent;
+use crate::components::graphics::clip_shape_widget::WuiClipShape;
 use crate::components::menu::rebuild_menu_popover;
 use crate::util::{ScopedCss, store_watcher_guard, subscribe_then_get};
 
@@ -356,19 +357,6 @@ const CSS_CLASS_SHADOW: &str = "waterui-metadata-shadow";
 const CSS_CLASS_SCALE: &str = "waterui-metadata-scale";
 const CSS_CLASS_ROTATION: &str = "waterui-metadata-rotation";
 const CSS_CLASS_OFFSET: &str = "waterui-metadata-offset";
-const CSS_CLASS_CLIP_SHAPE: &str = "waterui-metadata-clip-shape";
-
-#[derive(Debug, Clone, Copy)]
-enum ClipShapeCss {
-    Rectangle,
-    Ellipse,
-    Rounded {
-        top_left: f32,
-        top_right: f32,
-        bottom_right: f32,
-        bottom_left: f32,
-    },
-}
 
 fn wrap_for_metadata(child: &Widget) -> gtk4::Box {
     let wrapper = gtk4::Box::new(gtk4::Orientation::Vertical, 0);
@@ -449,140 +437,6 @@ fn apply_rotation_css(css: &ScopedCss, angle_degrees: f32, anchor: waterui::styl
 
 fn apply_offset_css(css: &ScopedCss, x: f32, y: f32) {
     css.set_declarations(&format!("transform: translate({x:.2}px, {y:.2}px);"));
-}
-
-fn apply_clip_shape_css(css: &ScopedCss, shape: ClipShapeCss) {
-    let body = match shape {
-        ClipShapeCss::Rectangle => "overflow: hidden;",
-        ClipShapeCss::Ellipse => "overflow: hidden; border-radius: 50%;",
-        ClipShapeCss::Rounded {
-            top_left,
-            top_right,
-            bottom_right,
-            bottom_left,
-        } => {
-            let tl = top_left * 100.0;
-            let tr = top_right * 100.0;
-            let br = bottom_right * 100.0;
-            let bl = bottom_left * 100.0;
-            return css.set_declarations(&format!(
-                "overflow: hidden; border-radius: {tl:.3}% {tr:.3}% {br:.3}% {bl:.3}%;"
-            ));
-        }
-    };
-    css.set_declarations(body);
-}
-
-fn approx_eq(a: f32, b: f32) -> bool {
-    (a - b).abs() <= 1e-3
-}
-
-#[allow(
-    clippy::too_many_lines,
-    reason = "one cohesive widget-construction pass; splitting it would scatter GTK setup order"
-)]
-fn clip_shape_css(shape: &ClipShape) -> ClipShapeCss {
-    let commands = shape.commands();
-    match commands {
-        [
-            PathCommand::MoveTo { x: 0.0, y: 0.0 },
-            PathCommand::LineTo { x: 1.0, y: 0.0 },
-            PathCommand::LineTo { x: 1.0, y: 1.0 },
-            PathCommand::LineTo { x: 0.0, y: 1.0 },
-            PathCommand::Close,
-        ] => ClipShapeCss::Rectangle,
-        [
-            PathCommand::Arc {
-                cx,
-                cy,
-                rx,
-                ry,
-                start,
-                sweep,
-            },
-        ] if approx_eq(*cx, 0.5)
-            && approx_eq(*cy, 0.5)
-            && approx_eq(*rx, 0.5)
-            && approx_eq(*ry, 0.5)
-            && approx_eq(*start, 0.0)
-            && approx_eq(*sweep, std::f32::consts::TAU) =>
-        {
-            ClipShapeCss::Ellipse
-        }
-        [
-            PathCommand::MoveTo { x: tl, y: 0.0 },
-            PathCommand::LineTo { x: x2, y: 0.0 },
-            PathCommand::Arc {
-                cx: _,
-                cy: tr,
-                rx: top_right_radius_x,
-                ry: top_right_radius_y,
-                start: _,
-                sweep: _,
-            },
-            PathCommand::LineTo { x: 1.0, y: y4 },
-            PathCommand::Arc {
-                cx: _,
-                cy: _,
-                rx: bottom_right_radius_x,
-                ry: bottom_right_radius_y,
-                start: _,
-                sweep: _,
-            },
-            PathCommand::LineTo { x: bl, y: 1.0 },
-            PathCommand::Arc {
-                cx: _,
-                cy: _,
-                rx: bottom_left_radius_x,
-                ry: bottom_left_radius_y,
-                start: _,
-                sweep: _,
-            },
-            PathCommand::LineTo { x: 0.0, y: y8 },
-            PathCommand::Arc {
-                cx: _,
-                cy: _,
-                rx: top_left_radius_x,
-                ry: top_left_radius_y,
-                start: _,
-                sweep: _,
-            },
-            PathCommand::Close,
-        ] => {
-            let top_left = (*tl + *top_left_radius_x + *top_left_radius_y + *y8) / 4.0;
-            let top_right = ((1.0 - *x2) + *tr + *top_right_radius_x + *top_right_radius_y) / 4.0;
-            let bottom_right =
-                ((1.0 - *y4) + *bottom_right_radius_x + *bottom_right_radius_y) / 3.0;
-            let bottom_left = (*bl + *bottom_left_radius_x + *bottom_left_radius_y) / 3.0;
-            ClipShapeCss::Rounded {
-                top_left,
-                top_right,
-                bottom_right,
-                bottom_left,
-            }
-        }
-        [
-            PathCommand::MoveTo { x: 0.5, y: 0.0 },
-            PathCommand::Arc {
-                cx: 0.5,
-                cy: 0.5,
-                rx: 0.5,
-                ry: 0.5,
-                start: _,
-                sweep: _,
-            },
-            PathCommand::Arc {
-                cx: 0.5,
-                cy: 0.5,
-                rx: 0.5,
-                ry: 0.5,
-                start: _,
-                sweep: _,
-            },
-            PathCommand::Close,
-        ] => ClipShapeCss::Ellipse,
-        _ => panic!("unsupported ClipShape path for GTK backend"),
-    }
 }
 
 fn drag_content_provider(data: &DragData) -> gdk4::ContentProvider {
@@ -1285,12 +1139,11 @@ impl GtkRenderer {
             dispatcher,
             |renderer, metadata, env| {
                 let content = renderer.render_any(metadata.content, env);
-                let wrapper = wrap_for_metadata(&content);
-                wrapper.set_overflow(Overflow::Hidden);
-                let scoped_css = attach_css_provider(&wrapper, CSS_CLASS_CLIP_SHAPE);
-                let css = clip_shape_css(&metadata.value);
-                apply_clip_shape_css(&scoped_css, css);
-                wrapper.upcast()
+                // The clip resolves the shape's `ShapeKind` against the
+                // allocated size at snapshot time. CSS cannot: a percentage
+                // `border-radius` resolves per axis, so it turns every round
+                // corner on a non-square surface into an elliptical one (#157).
+                WuiClipShape::new(metadata.value.kind(), &content).upcast()
             },
         );
 

--- a/backends/gtk/src/shape_geometry.rs
+++ b/backends/gtk/src/shape_geometry.rs
@@ -1,0 +1,286 @@
+//! Resolving a [`ShapeKind`] against the size the shape is drawn at.
+//!
+//! A shape's [`PathCommand`](waterui_shape::PathCommand) list is normalized per
+//! axis, so resolving it against a non-square rect stretches every corner by the
+//! aspect ratio: a 200x50 surface with a rounded-rectangle clip gets flat
+//! elliptical corners sweeping most of its edge instead of round ones. The kind
+//! carries what the commands cannot — a corner radius as a fraction of the
+//! *shorter* side — so this module resolves the kind and the commands are only
+//! consulted for [`ShapeKind::CustomPath`].
+//!
+//! Both the fill ([`crate::components::graphics::shape`]) and the clip
+//! ([`crate::components::graphics::clip_shape_widget`]) resolve through here, so
+//! a clip always matches the fill of the same shape.
+//!
+//! This module is platform independent on purpose: it is plain geometry, and it
+//! compiles and is tested on every host even though the rest of the backend is
+//! Linux only.
+
+use waterui_shape::ShapeKind;
+
+/// One corner's radii in points, which an ellipse makes unequal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct Corner {
+    /// Radius along the x axis.
+    pub horizontal: f64,
+    /// Radius along the y axis.
+    pub vertical: f64,
+}
+
+impl Corner {
+    /// A square corner.
+    pub const SQUARE: Self = Self {
+        horizontal: 0.0,
+        vertical: 0.0,
+    };
+
+    /// A corner whose two radii are equal, which is what every kind but
+    /// [`ShapeKind::Ellipse`] produces.
+    #[must_use]
+    pub const fn circular(radius: f64) -> Self {
+        Self {
+            horizontal: radius,
+            vertical: radius,
+        }
+    }
+}
+
+/// An axis-aligned rounded rectangle in widget-local points.
+///
+/// Every non-custom [`ShapeKind`] is one of these: a plain rect has square
+/// corners, and a circle or an ellipse is a rect whose corners are half its own
+/// width and height, which leaves no straight edge between them.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RoundedRect {
+    /// Left edge.
+    pub x: f64,
+    /// Top edge.
+    pub y: f64,
+    /// Width.
+    pub width: f64,
+    /// Height.
+    pub height: f64,
+    /// Corner radii, clockwise from the top left.
+    pub corners: [Corner; 4],
+}
+
+impl RoundedRect {
+    /// Whether every corner is square, so a plain rect describes this shape.
+    #[must_use]
+    pub fn is_rectangular(&self) -> bool {
+        self.corners
+            .iter()
+            .all(|corner| corner.horizontal <= 0.0 || corner.vertical <= 0.0)
+    }
+}
+
+/// A [`ShapeKind`] resolved against a concrete size.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub enum ShapeGeometry {
+    /// A rounded rectangle, which covers every kind but a custom path.
+    Rounded(RoundedRect),
+    /// Only the unit-space path commands describe this shape.
+    CustomPath,
+}
+
+/// Resolves `kind` against a `width` x `height` box.
+///
+/// Normalized radii are a fraction of the shorter side, so they come out equal
+/// on both axes and a corner stays circular however wide the box is.
+#[must_use]
+pub fn resolve(kind: ShapeKind, width: f64, height: f64) -> ShapeGeometry {
+    let width = width.max(0.0);
+    let height = height.max(0.0);
+    let shorter = width.min(height);
+    let limit = shorter / 2.0;
+    let circular = |radius: f32| Corner::circular((f64::from(radius) * shorter).clamp(0.0, limit));
+    let full = |corners: [Corner; 4]| {
+        ShapeGeometry::Rounded(RoundedRect {
+            x: 0.0,
+            y: 0.0,
+            width,
+            height,
+            corners,
+        })
+    };
+
+    match kind {
+        ShapeKind::Rect => full([Corner::SQUARE; 4]),
+        // A circle is inscribed in the box: centred, its diameter the shorter
+        // side, so it stays a circle rather than becoming an ellipse.
+        ShapeKind::Circle => ShapeGeometry::Rounded(RoundedRect {
+            x: (width - shorter) / 2.0,
+            y: (height - shorter) / 2.0,
+            width: shorter,
+            height: shorter,
+            corners: [Corner::circular(limit); 4],
+        }),
+        ShapeKind::Ellipse => full(
+            [Corner {
+                horizontal: width / 2.0,
+                vertical: height / 2.0,
+            }; 4],
+        ),
+        ShapeKind::RoundedRect { corner_radius } => full([circular(corner_radius); 4]),
+        ShapeKind::UnevenRoundedRect {
+            top_left,
+            top_right,
+            bottom_right,
+            bottom_left,
+        } => full([
+            circular(top_left),
+            circular(top_right),
+            circular(bottom_right),
+            circular(bottom_left),
+        ]),
+        ShapeKind::Capsule => full([Corner::circular(limit); 4]),
+        ShapeKind::CustomPath => ShapeGeometry::CustomPath,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Corner, RoundedRect, ShapeGeometry, resolve};
+    use waterui_shape::ShapeKind;
+
+    fn rounded(kind: ShapeKind, width: f64, height: f64) -> RoundedRect {
+        match resolve(kind, width, height) {
+            ShapeGeometry::Rounded(rect) => rect,
+            ShapeGeometry::CustomPath => panic!("expected a rounded rectangle, got a custom path"),
+        }
+    }
+
+    /// Normalized radii are `f32`, so `12 / 50` comes back as 11.9999997 once
+    /// it has been resolved in `f64`. Compare to the point rather than the bit.
+    #[track_caller]
+    fn assert_corners(actual: [Corner; 4], expected: [Corner; 4]) {
+        let close = |a: f64, b: f64| (a - b).abs() < 1e-4;
+        assert!(
+            actual
+                .iter()
+                .zip(expected.iter())
+                .all(|(a, b)| close(a.horizontal, b.horizontal) && close(a.vertical, b.vertical)),
+            "corners {actual:?} are not approximately {expected:?}"
+        );
+    }
+
+    /// The defect this module exists for: a wide, short surface used to get
+    /// corners stretched by its aspect ratio, so a 200x50 snackbar's 12pt
+    /// corners swept 48pt horizontally. A normalized radius resolves against the
+    /// shorter side and lands on the same number in both axes.
+    #[test]
+    fn rounded_rect_corners_are_circular_on_a_wide_rect() {
+        let rect = rounded(
+            ShapeKind::RoundedRect {
+                corner_radius: 12.0 / 50.0,
+            },
+            200.0,
+            50.0,
+        );
+        assert_corners(rect.corners, [Corner::circular(12.0); 4]);
+        assert!(!rect.is_rectangular());
+    }
+
+    /// The same shape rotated: the radius follows the shorter side, whichever
+    /// axis that is.
+    #[test]
+    fn rounded_rect_corners_are_circular_on_a_tall_rect() {
+        let rect = rounded(
+            ShapeKind::RoundedRect {
+                corner_radius: 12.0 / 50.0,
+            },
+            50.0,
+            200.0,
+        );
+        assert_corners(rect.corners, [Corner::circular(12.0); 4]);
+    }
+
+    #[test]
+    fn rounded_rect_radius_saturates_at_half_the_shorter_side() {
+        let rect = rounded(ShapeKind::RoundedRect { corner_radius: 0.9 }, 200.0, 50.0);
+        assert_corners(rect.corners, [Corner::circular(25.0); 4]);
+    }
+
+    #[test]
+    fn uneven_rounded_rect_keeps_each_corner_circular() {
+        let rect = rounded(
+            ShapeKind::UnevenRoundedRect {
+                top_left: 0.2,
+                top_right: 0.1,
+                bottom_right: 0.0,
+                bottom_left: 0.4,
+            },
+            200.0,
+            50.0,
+        );
+        assert_corners(
+            rect.corners,
+            [
+                Corner::circular(10.0),
+                Corner::circular(5.0),
+                Corner::SQUARE,
+                Corner::circular(20.0),
+            ],
+        );
+    }
+
+    #[test]
+    fn capsule_caps_are_half_the_shorter_side() {
+        let rect = rounded(ShapeKind::Capsule, 200.0, 50.0);
+        assert_corners(rect.corners, [Corner::circular(25.0); 4]);
+        assert_eq!(
+            (rect.x, rect.y, rect.width, rect.height),
+            (0.0, 0.0, 200.0, 50.0)
+        );
+    }
+
+    #[test]
+    fn circle_is_inscribed_and_centred() {
+        let rect = rounded(ShapeKind::Circle, 200.0, 50.0);
+        assert_eq!(
+            (rect.x, rect.y, rect.width, rect.height),
+            (75.0, 0.0, 50.0, 50.0)
+        );
+        assert_corners(rect.corners, [Corner::circular(25.0); 4]);
+    }
+
+    /// An ellipse is the one kind whose corners are deliberately unequal: it
+    /// fills the box, so each "corner" is half the box in that axis.
+    #[test]
+    fn ellipse_fills_the_bounds() {
+        let rect = rounded(ShapeKind::Ellipse, 200.0, 50.0);
+        assert_eq!(
+            (rect.x, rect.y, rect.width, rect.height),
+            (0.0, 0.0, 200.0, 50.0)
+        );
+        assert_corners(
+            rect.corners,
+            [Corner {
+                horizontal: 100.0,
+                vertical: 25.0,
+            }; 4],
+        );
+    }
+
+    #[test]
+    fn rect_has_square_corners() {
+        let rect = rounded(ShapeKind::Rect, 200.0, 50.0);
+        assert_eq!(rect.corners, [Corner::SQUARE; 4]);
+        assert!(rect.is_rectangular());
+    }
+
+    #[test]
+    fn custom_path_has_no_resolved_geometry() {
+        assert_eq!(
+            resolve(ShapeKind::CustomPath, 200.0, 50.0),
+            ShapeGeometry::CustomPath
+        );
+    }
+
+    #[test]
+    fn a_degenerate_box_produces_no_radius() {
+        let rect = rounded(ShapeKind::Capsule, 200.0, 0.0);
+        assert_eq!(rect.corners, [Corner::SQUARE; 4]);
+        assert!(rect.is_rectangular());
+    }
+}


### PR DESCRIPTION
## Root cause

Two pre-existing defects, both in the GTK clip path.

**1. The shape was guessed from its path commands.** `clip_shape_css` at
`backends/gtk/src/renderer.rs:484` pattern-matched the unit-space `PathCommand`
list and *averaged* the components it found to recover a corner radius:

```rust
let top_left = (*tl + *top_left_radius_x + *top_left_radius_y + *y8) / 4.0;
```

Those coordinates are normalized per axis, so the fraction is of the width on
one axis and of the height on the other. On a wide, short surface — a snackbar,
a toolbar, a list row — the corners stretched with the aspect ratio into flat
ellipses sweeping most of the edge. The recogniser also predates `ShapeKind`,
which states outright what the shape is.

**2. A CSS percentage radius is per-axis, so it cannot be circular.**
`apply_clip_shape_css` at `backends/gtk/src/renderer.rs:454` emitted
`border-radius: {tl}% {tr}% {br}% {bl}%`, and a percentage `border-radius`
resolves horizontally against the width and vertically against the height. Even
a correct fraction could not describe a circular corner on a non-square widget.

The same class of bug was already fixed in the GTK fill path
(`backends/gtk/src/components/graphics/shape.rs`) and on the Android backend.

## What changed

- **New `backends/gtk/src/shape_geometry.rs`.** `resolve(kind, width, height)`
  turns a `ShapeKind` and a size into a rounded rectangle with per-corner radii
  in points. A normalized radius resolves against the *shorter* side, so it
  lands on the same number in both axes; a capsule takes half the shorter side;
  a circle is a centred square of the shorter side; an ellipse is the one kind
  whose corner radii are deliberately unequal; a custom path resolves to
  nothing and keeps its commands.
- **New `backends/gtk/src/components/graphics/clip_shape_widget.rs`.**
  `WuiClipShape` is a single-child `GtkWidget` subclass that clips in its
  `snapshot` vfunc, where the allocated size is finally known, with
  `gtk_snapshot_push_rounded_clip` (or a plain rect clip when every corner is
  square). GTK4 exposes no size-allocation signal on a plain widget and CSS
  cannot express a circular corner on a non-square one, so the clip has to
  happen here rather than in a stylesheet.
- **`renderer.rs`:** `ClipShapeCss`, `clip_shape_css`, `apply_clip_shape_css`,
  `approx_eq` and `CSS_CLASS_CLIP_SHAPE` are deleted outright, not kept as a
  fallback. `Metadata<ClipShape>` now builds a `WuiClipShape` from
  `ClipShape::kind()`.
- **`components/graphics/shape.rs`:** the fill resolves through the same
  `shape_geometry`, so a clip and the fill of the same shape agree. Corner arcs
  became elliptical (a scaled unit circle), which lets one routine draw every
  non-custom kind and retires the separate ellipse tracer.

Clipping to a custom path still fails, but now at construction with a message
naming the reason: it needs `gtk_snapshot_push_fill`, which arrived in GTK 4.14,
and this backend targets 4.12. It never worked before either — it panicked out
of the path recogniser with `unsupported ClipShape path for GTK backend`.

`shape_geometry` is plain arithmetic with no GTK in it, so it is declared
outside this backend's `cfg(target_os = "linux")` gating and `waterui-shape` was
added as a host-independent dependency (`default-features = false`; the Linux
entry still turns the GPU morph renderer back on). That makes it the one module
of this backend that compiles and is tested on every host.

## How this was verified

`shape_geometry` has 10 unit tests, including the exact defect this fixes: a
200x50 rect with a 12pt corner radius must come out 12 on **both** axes, and the
same shape rotated to 50x200 must too.

```
cargo nextest run -p waterui-gtk
     Summary [0.015s] 10 tests run: 10 passed, 0 skipped

cargo clippy -p waterui-gtk --all-targets -- -D warnings
    Finished `dev` profile

cargo fmt -p waterui-gtk -- --check
    (clean)
```

The GTK half is `cfg(target_os = "linux")` and compiles to nothing on macOS, so
it was additionally compile-checked against real GTK 4.20 headers (Homebrew,
via pkg-config) by temporarily lifting that gate in a scratch tree: the whole
backend — `WuiClipShape`, the rewritten fill, and the edited renderer — type-checks
and is clippy-clean, with the only errors coming from `gpu_surface.rs`, which is
GLES-only by construction and carries its own `compile_error!`. The scratch edits
were reverted before committing; they are not in this diff. A GTK session
screenshot still needs a Linux host.

Fixes #157