### PR TITLE
fix(dew): resolve the Body font slot for bare string leaves and watch font signals

### DIFF
--- a/backends/dew/src/dispatch.rs
+++ b/backends/dew/src/dispatch.rs
@@ -40,7 +40,7 @@ use waterui_layout::scroll::ScrollView;
 use waterui_layout::spacer::Spacer;
 use waterui_navigation::{NavigationSplitLayout, NavigationStack, NavigationView, TabsLayout};
 use waterui_shape::{ClipShape, ResolvedShape};
-use waterui_text::{TextConfig, font::ResolvedFont, styled::StyledStr};
+use waterui_text::{TextConfig, styled::StyledStr};
 
 use crate::accessibility::{AccessibilityBuilder, ActionTarget};
 use crate::display_list::DisplayList;
@@ -646,9 +646,15 @@ fn build_unmeasured_node(
             .downcast::<Native<TextConfig>>()
             .expect("dew TextConfig downcast must match its type id");
         let config = text.into_inner();
+        let content = WatchedSignal::new(config.content, renderer.signals());
         return Box::new(TextNode {
-            content: WatchedSignal::new(config.content, renderer.signals()),
-            font: theme::watch_body_font(env, renderer.signals()),
+            fonts: RefCell::new(theme::WatchedFonts::styled(
+                &content.get(),
+                content.revision(),
+                env,
+                renderer.signals(),
+            )),
+            content,
             env: env.clone(),
             cache: RefCell::new(TextLayoutCache::default()),
             line_limit: config.line_limit.map(core::num::NonZeroUsize::get),
@@ -661,7 +667,7 @@ fn build_unmeasured_node(
                 .downcast::<Str>()
                 .expect("dew Str downcast must match its type id"),
             cache: RefCell::new(TextLayoutCache::default()),
-            font: theme::watch_body_font(env, renderer.signals()),
+            fonts: theme::WatchedFonts::plain(env, renderer.signals()),
             env: env.clone(),
             accessibility_id: renderer.allocate_accessibility_id(),
         });
@@ -966,9 +972,11 @@ fn render_color(renderer: &mut DewRenderer, ctx: RenderContext, color: ResolvedC
 
 struct TextNode {
     content: WatchedSignal<Computed<StyledStr>>,
-    /// The theme body font spans without their own font shape at; watched so a
-    /// reactive type scale invalidates the layout and asks for a frame.
-    font: WatchedSignal<Computed<ResolvedFont>>,
+    /// The font slots this text shapes with — the layout default plus each
+    /// span's own — watched so a reactive type scale invalidates the layout
+    /// and asks for a frame. Behind a `RefCell` because the set is rebuilt
+    /// from the content, and measurement runs behind `&self`.
+    fonts: RefCell<theme::WatchedFonts>,
     env: Environment,
     cache: RefCell<TextLayoutCache>,
     /// Maximum laid-out lines, from `TextConfig::line_limit`.
@@ -977,9 +985,14 @@ struct TextNode {
 }
 
 impl TextNode {
-    /// Everything that re-shapes this node: its content and the theme font.
+    /// Everything that re-shapes this node: its content and the fonts that
+    /// content reads. New content may name different slots, so the watcher
+    /// set is brought up to date here, before its revision is read.
     fn revision(&self) -> TextRevision {
-        TextRevision::new(self.content.revision(), self.font.revision())
+        let content = self.content.revision();
+        let mut fonts = self.fonts.borrow_mut();
+        fonts.sync(content, || self.content.get());
+        TextRevision::new(content, fonts.revision())
     }
 }
 
@@ -1048,8 +1061,9 @@ struct StrNode {
     value: Str,
     cache: RefCell<TextLayoutCache>,
     /// The theme body font this leaf shapes at — the same slot `text("…")`
-    /// resolves, watched for the same reason.
-    font: WatchedSignal<Computed<ResolvedFont>>,
+    /// resolves, watched for the same reason. A fixed string names no other,
+    /// so this set never changes.
+    fonts: theme::WatchedFonts,
     env: Environment,
     accessibility_id: NodeId,
 }
@@ -1059,7 +1073,7 @@ impl DewNode for StrNode {
         let foreground = theme::foreground(&self.env);
         let mut cache = self.cache.borrow_mut();
         let ((width, height), outcome) = cache.measure(
-            TextRevision::font_only(self.font.revision()),
+            TextRevision::font_only(self.fonts.revision()),
             TextLayoutKey::new(proposal.width, foreground),
             None,
             || {
@@ -1081,7 +1095,7 @@ impl DewNode for StrNode {
         let max_width = max_width_from_bounds(ctx.bounds);
         let transform = ctx.transform * Affine::translate((ctx.bounds.x0, ctx.bounds.y0));
         let outcome = self.cache.borrow_mut().emit(
-            TextRevision::font_only(self.font.revision()),
+            TextRevision::font_only(self.fonts.revision()),
             TextLayoutKey::new(max_width, foreground),
             None,
             transform,
@@ -1122,7 +1136,17 @@ pub(crate) struct WatchedSignal<S: Signal> {
 
 impl<S: Signal> WatchedSignal<S> {
     pub(crate) fn new(signal: S, signals: FrameSignals) -> Self {
-        let revision = Rc::new(Cell::new(0u64));
+        Self::shared(signal, signals, Rc::new(Cell::new(0u64)))
+    }
+
+    /// Watches `signal` against a counter shared with other signals, so a
+    /// change to any of them moves one number.
+    ///
+    /// For a cache that depends on a *set* of signals whose membership itself
+    /// changes — the font slots a styled string's spans name, which are
+    /// rebuilt whenever the content does — one shared counter is what keeps
+    /// the cache's revision a single comparison.
+    pub(crate) fn shared(signal: S, signals: FrameSignals, revision: Rc<Cell<u64>>) -> Self {
         let guard = signal.watch({
             let revision = Rc::clone(&revision);
             move |_| {

--- a/backends/dew/src/dispatch.rs
+++ b/backends/dew/src/dispatch.rs
@@ -40,12 +40,12 @@ use waterui_layout::scroll::ScrollView;
 use waterui_layout::spacer::Spacer;
 use waterui_navigation::{NavigationSplitLayout, NavigationStack, NavigationView, TabsLayout};
 use waterui_shape::{ClipShape, ResolvedShape};
-use waterui_text::{TextConfig, styled::StyledStr};
+use waterui_text::{TextConfig, font::ResolvedFont, styled::StyledStr};
 
 use crate::accessibility::{AccessibilityBuilder, ActionTarget};
 use crate::display_list::DisplayList;
 use crate::pointer::{PointerRouter, PointerTargetHandle};
-use crate::text::{DewState, TextLayoutCache, TextLayoutKey};
+use crate::text::{DewState, TextLayoutCache, TextLayoutKey, TextRevision};
 use crate::theme;
 use crate::views;
 
@@ -641,6 +641,7 @@ fn build_unmeasured_node(
         let config = text.into_inner();
         return Box::new(TextNode {
             content: WatchedSignal::new(config.content, renderer.signals()),
+            font: theme::watch_body_font(env, renderer.signals()),
             env: env.clone(),
             cache: RefCell::new(TextLayoutCache::default()),
             line_limit: config.line_limit.map(core::num::NonZeroUsize::get),
@@ -653,6 +654,7 @@ fn build_unmeasured_node(
                 .downcast::<Str>()
                 .expect("dew Str downcast must match its type id"),
             cache: RefCell::new(TextLayoutCache::default()),
+            font: theme::watch_body_font(env, renderer.signals()),
             env: env.clone(),
             accessibility_id: renderer.allocate_accessibility_id(),
         });
@@ -957,6 +959,9 @@ fn render_color(renderer: &mut DewRenderer, ctx: RenderContext, color: ResolvedC
 
 struct TextNode {
     content: WatchedSignal<Computed<StyledStr>>,
+    /// The theme body font spans without their own font shape at; watched so a
+    /// reactive type scale invalidates the layout and asks for a frame.
+    font: WatchedSignal<Computed<ResolvedFont>>,
     env: Environment,
     cache: RefCell<TextLayoutCache>,
     /// Maximum laid-out lines, from `TextConfig::line_limit`.
@@ -964,10 +969,17 @@ struct TextNode {
     accessibility_id: NodeId,
 }
 
+impl TextNode {
+    /// Everything that re-shapes this node: its content and the theme font.
+    fn revision(&self) -> TextRevision {
+        TextRevision::new(self.content.revision(), self.font.revision())
+    }
+}
+
 impl DewNode for TextNode {
     fn measure(&self, state: &RefCell<DewState>, proposal: ProposalSize) -> ViewDimensions {
         let foreground = theme::foreground(&self.env);
-        let revision = self.content.revision();
+        let revision = self.revision();
         let mut cache = self.cache.borrow_mut();
         let ((width, height), outcome) = cache.measure(
             revision,
@@ -992,7 +1004,7 @@ impl DewNode for TextNode {
         // own foreground has to be painted in it, and a render that disagreed
         // with the measurement would re-shape the text a second time.
         let foreground = theme::foreground(&self.env);
-        let revision = self.content.revision();
+        let revision = self.revision();
         let max_width = max_width_from_bounds(ctx.bounds);
         let transform = ctx.transform * Affine::translate((ctx.bounds.x0, ctx.bounds.y0));
         let outcome = self.cache.borrow_mut().emit(
@@ -1028,6 +1040,9 @@ impl DewNode for TextNode {
 struct StrNode {
     value: Str,
     cache: RefCell<TextLayoutCache>,
+    /// The theme body font this leaf shapes at — the same slot `text("…")`
+    /// resolves, watched for the same reason.
+    font: WatchedSignal<Computed<ResolvedFont>>,
     env: Environment,
     accessibility_id: NodeId,
 }
@@ -1037,13 +1052,16 @@ impl DewNode for StrNode {
         let foreground = theme::foreground(&self.env);
         let mut cache = self.cache.borrow_mut();
         let ((width, height), outcome) = cache.measure(
-            0,
+            TextRevision::font_only(self.font.revision()),
             TextLayoutKey::new(proposal.width, foreground),
             None,
             || {
-                state
-                    .borrow_mut()
-                    .build_plain_layout(&self.value, proposal.width, foreground)
+                state.borrow_mut().build_plain_layout(
+                    &self.value,
+                    &self.env,
+                    proposal.width,
+                    foreground,
+                )
             },
         );
         let dimensions = ViewDimensions::new(Size::new(width, height));
@@ -1056,16 +1074,18 @@ impl DewNode for StrNode {
         let max_width = max_width_from_bounds(ctx.bounds);
         let transform = ctx.transform * Affine::translate((ctx.bounds.x0, ctx.bounds.y0));
         let outcome = self.cache.borrow_mut().emit(
-            0,
+            TextRevision::font_only(self.font.revision()),
             TextLayoutKey::new(max_width, foreground),
             None,
             transform,
             &mut renderer.list,
             || {
-                renderer
-                    .state
-                    .borrow_mut()
-                    .build_plain_layout(&self.value, max_width, foreground)
+                renderer.state.borrow_mut().build_plain_layout(
+                    &self.value,
+                    &self.env,
+                    max_width,
+                    foreground,
+                )
             },
         );
         renderer.state.borrow_mut().record_layout(outcome);

--- a/backends/dew/src/dispatch.rs
+++ b/backends/dew/src/dispatch.rs
@@ -257,6 +257,12 @@ impl DewRenderer {
     ///
     /// Runtime code calls this exactly once. Explicit callers may use it to
     /// render unrelated one-shot trees in tests and tools.
+    ///
+    /// Dew's built-in type scale is installed for every font slot the caller's
+    /// environment does not already carry, so an app that installs no theme
+    /// still renders text; see [`crate::theme::install_default_fonts`]. It
+    /// belongs here rather than at any one host's entry point because this is
+    /// the single funnel every dew view tree is dispatched through.
     pub fn render_tree(
         &mut self,
         view: AnyView,
@@ -268,7 +274,8 @@ impl DewRenderer {
         // rasterizer, so a `SceneView` must reach the dispatcher as a native
         // leaf instead of resolving to the GPU surface it would otherwise fall
         // back on — dew's graph has no GPU in it at all.
-        let env = env.extending(SceneViewMergeToParent);
+        let mut env = env.extending(SceneViewMergeToParent);
+        theme::install_default_fonts(&mut env);
         self.theme = Some(theme::ThemePalette::new(&env, self.signals()));
         self.root = Some(build_node(self, view, &env, 0));
         self.refresh_tree(width, height)

--- a/backends/dew/src/lib.rs
+++ b/backends/dew/src/lib.rs
@@ -27,8 +27,9 @@
 //! - [`display`]: the flush boundary — where rasterized regions leave the
 //!   renderer toward a concrete screen (in-memory buffer on desktop,
 //!   RGB565 LCD stream on embedded targets)
-//! - [`theme`]: the built-in widget palette — named colors every handler
-//!   draws with until environment-driven theming lands
+//! - [`theme`]: the built-in appearance — named colors every handler draws
+//!   with, and the type scale [`DewRuntime`] installs for the font slots an
+//!   application's theme leaves unset
 //!
 //! # Deliberately unsupported: the GPU stack
 //!
@@ -50,7 +51,7 @@
 //! # Interaction beyond controls: the `gestures` feature
 //!
 //! Controls (buttons, toggles, sliders, tabs) hit-test through
-//! [`pointer::PointerRouter`] and are always available. The richer pointer
+//! dew's internal pointer router and are always available. The richer pointer
 //! semantics a view asks for with `.gesture(...)` / `.on_hover_*` —
 //! `Metadata<GestureObserver>` and `Metadata<OnEvent>`, which is what makes an
 //! interactive chart interactive — recognize through `waterui-backend-core`'s

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -68,12 +68,17 @@ impl<B: Board> DewRuntime<B> {
     /// into bands at most `band_height` rows tall.
     ///
     /// `build_root` is invoked exactly once, on the first pump.
+    ///
+    /// Dew's built-in type scale is installed into `env` for every font slot it
+    /// does not already carry, so an app that installs no theme still renders
+    /// text; see [`crate::theme::install_default_fonts`].
     pub fn new(
         mut board: B,
-        env: Environment,
+        mut env: Environment,
         band_height: u32,
         build_root: impl Fn() -> AnyView + 'static,
     ) -> Self {
+        crate::theme::install_default_fonts(&mut env);
         let render_settings = board.render_settings();
         let fonts = board.fonts();
         let signals = waterui_backend_core::frame_signals::FrameSignals::new(board.now());
@@ -250,6 +255,7 @@ mod tests {
     use std::rc::Rc;
     use waterui_backend_core::input::TouchPhase;
     use waterui_controls::toggle::Toggle;
+    use waterui_text::text;
 
     struct CountingToggle {
         body_calls: Rc<Cell<usize>>,
@@ -289,6 +295,19 @@ mod tests {
 
         assert!(!frame.dirty.is_empty());
         assert_eq!(body_calls.get(), 1, "refresh must not evaluate body again");
+    }
+
+    /// Dew supplies its own type scale, so an application that installs no
+    /// theme still renders text: the body font slot is resolved inside
+    /// `waterui-text`, which panics when the environment carries no token.
+    #[test]
+    fn text_renders_without_an_installed_theme() {
+        let mut runtime = DewRuntime::new(HostBoard::new(200, 40), Environment::new(), 16, || {
+            AnyView::new(text("Dew"))
+        });
+
+        let frame = runtime.pump().expect("initial frame must render");
+        assert!(!frame.dirty.is_empty(), "text must paint something");
     }
 
     #[test]

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -69,16 +69,14 @@ impl<B: Board> DewRuntime<B> {
     ///
     /// `build_root` is invoked exactly once, on the first pump.
     ///
-    /// Dew's built-in type scale is installed into `env` for every font slot it
-    /// does not already carry, so an app that installs no theme still renders
-    /// text; see [`crate::theme::install_default_fonts`].
+    /// `env` needs no theme: [`DewRenderer::render_tree`] installs dew's
+    /// built-in type scale for every font slot it does not already carry.
     pub fn new(
         mut board: B,
-        mut env: Environment,
+        env: Environment,
         band_height: u32,
         build_root: impl Fn() -> AnyView + 'static,
     ) -> Self {
-        crate::theme::install_default_fonts(&mut env);
         let render_settings = board.render_settings();
         let fonts = board.fonts();
         let signals = waterui_backend_core::frame_signals::FrameSignals::new(board.now());

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -349,6 +349,48 @@ mod tests {
         );
     }
 
+    /// A span's own slot must be watched too, not only the body font a bare
+    /// `text("…")` shapes at: `.font(Title)` reads the Title slot, and a
+    /// theme that drives that slot has to re-shape the span it styles.
+    #[test]
+    fn span_font_change_reshapes_retained_text() {
+        use waterui::Plugin as _;
+        use waterui::theme::{FontSettings, Theme};
+        use waterui_text::font::{FontWeight, ResolvedFont, Title};
+
+        let title = binding(ResolvedFont::new(22.0, FontWeight::Normal));
+        let mut env = Environment::new();
+        Theme::new()
+            .fonts(FontSettings::new().title(title.clone()))
+            .install(&mut env);
+
+        let mut runtime = DewRuntime::new(HostBoard::new(240, 80), env, 16, || {
+            AnyView::new(text("Dew").font(Title))
+        });
+
+        runtime.pump().expect("initial frame must render");
+        assert_eq!(
+            shaped_font_sizes(&runtime.current),
+            vec![22.0_f32.to_bits()],
+            "the installed title font shapes the span on the first frame"
+        );
+
+        title.set(ResolvedFont::new(34.0, FontWeight::Normal));
+        let frame = runtime
+            .pump()
+            .expect("a title font change must request a frame of its own");
+
+        assert_eq!(
+            shaped_font_sizes(&runtime.current),
+            vec![34.0_f32.to_bits()],
+            "the new title font must re-shape the span"
+        );
+        assert!(
+            !frame.dirty.is_empty(),
+            "re-shaped text must flush the region it changed"
+        );
+    }
+
     /// Dew supplies its own type scale, so an application that installs no
     /// theme still renders text: the body font slot is resolved inside
     /// `waterui-text`, which panics when the environment carries no token.

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -247,6 +247,7 @@ pub fn render_view_png<V: View>(
 #[cfg(all(test, feature = "host"))]
 mod tests {
     use super::*;
+    use crate::DrawCommand;
     use crate::display_list::DisplayList;
     use core::cell::Cell;
     use kurbo::Affine;
@@ -295,6 +296,59 @@ mod tests {
 
         assert!(!frame.dirty.is_empty());
         assert_eq!(body_calls.get(), 1, "refresh must not evaluate body again");
+    }
+
+    /// Every shaped glyph size in the frame the runtime last flushed.
+    fn shaped_font_sizes(list: &DisplayList) -> Vec<u32> {
+        list.commands()
+            .iter()
+            .filter_map(|placed| match placed.command() {
+                DrawCommand::GlyphRun { font_size, .. } => Some(font_size.to_bits()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    /// A reactive body font must re-shape the retained text: the change has to
+    /// request a frame of its own, and the layout cached at the old size must
+    /// not be replayed at the new one.
+    #[test]
+    fn body_font_change_reshapes_retained_text() {
+        use waterui::Plugin as _;
+        use waterui::theme::{FontSettings, Theme};
+        use waterui_text::font::{FontWeight, ResolvedFont};
+
+        let font = binding(ResolvedFont::new(16.0, FontWeight::Normal));
+        let mut env = Environment::new();
+        Theme::new()
+            .fonts(FontSettings::new().body(font.clone()))
+            .install(&mut env);
+
+        let mut runtime = DewRuntime::new(HostBoard::new(200, 60), env, 16, || {
+            AnyView::new(text("Dew"))
+        });
+
+        runtime.pump().expect("initial frame must render");
+        assert_eq!(
+            shaped_font_sizes(&runtime.current),
+            vec![16.0_f32.to_bits()],
+            "the installed body font shapes the first frame"
+        );
+
+        font.set(ResolvedFont::new(28.0, FontWeight::Normal));
+        let frame = runtime
+            .pump()
+            .expect("a body font change must request a frame of its own");
+
+        assert_eq!(
+            shaped_font_sizes(&runtime.current),
+            vec![28.0_f32.to_bits()],
+            "the new body font must re-shape the retained text"
+        );
+        assert!(
+            !frame.dirty.is_empty(),
+            "re-shaped text must flush the region it changed"
+        );
     }
 
     /// Dew supplies its own type scale, so an application that installs no

--- a/backends/dew/src/text.rs
+++ b/backends/dew/src/text.rs
@@ -98,8 +98,9 @@ struct RetainedText {
 /// Everything a node's shaped text depends on that is *not* a per-probe key.
 ///
 /// Both counters invalidate every entry the cache holds at once — new content
-/// and a new theme font each re-shape the node at every width it was probed
-/// at — so they belong on the cache's revision rather than in
+/// and a new font in any slot the text reads each re-shape the node at every
+/// width it was probed at — so they belong on the cache's revision rather than
+/// in
 /// [`TextLayoutKey`]: a key dimension would leave the sizes it invalidated
 /// behind in the table, growing it once per change on a backend whose peak
 /// heap is a budget.
@@ -112,7 +113,10 @@ pub(crate) struct TextRevision {
     ///
     /// [`WatchedSignal`]: crate::dispatch::WatchedSignal
     content: u64,
-    /// Revision of the theme font the node shapes with.
+    /// Shared revision of every font slot the node's text reads — the layout
+    /// default and each span's own — from [`WatchedFonts`].
+    ///
+    /// [`WatchedFonts`]: crate::theme::WatchedFonts
     font: u64,
 }
 
@@ -122,8 +126,8 @@ impl TextRevision {
         Self { content, font }
     }
 
-    /// The revision of a node whose text is a fixed string, so only the
-    /// theme font can move.
+    /// The revision of a node whose text is a fixed string, so only the font
+    /// slot it reads can move.
     pub(crate) const fn font_only(font: u64) -> Self {
         Self { content: 0, font }
     }

--- a/backends/dew/src/text.rs
+++ b/backends/dew/src/text.rs
@@ -57,7 +57,7 @@ pub(crate) enum CacheOutcome {
     Built,
 }
 
-/// Per-text-node layout cache keyed by signal revision and width proposal.
+/// Per-text-node layout cache keyed by [`TextRevision`] and width proposal.
 ///
 /// Dew confines layout to the main render thread, so the cache stays with the
 /// retained node instead of adding synchronization or global state.
@@ -76,7 +76,7 @@ pub(crate) enum CacheOutcome {
 ///   derived from it.
 #[derive(Debug, Default)]
 pub(crate) struct TextLayoutCache {
-    revision: u64,
+    revision: TextRevision,
     /// Laid-out size per proposal key, in probe order (a handful per node).
     sizes: Vec<(TextLayoutKey, (f32, f32))>,
     /// Full shaped state for the most recently emitted (or, before the first
@@ -95,12 +95,47 @@ struct RetainedText {
     runs: Option<Vec<RetainedGlyphRun>>,
 }
 
+/// Everything a node's shaped text depends on that is *not* a per-probe key.
+///
+/// Both counters invalidate every entry the cache holds at once — new content
+/// and a new theme font each re-shape the node at every width it was probed
+/// at — so they belong on the cache's revision rather than in
+/// [`TextLayoutKey`]: a key dimension would leave the sizes it invalidated
+/// behind in the table, growing it once per change on a backend whose peak
+/// heap is a budget.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub(crate) struct TextRevision {
+    /// Revision of the content signal, from its [`WatchedSignal`].
+    ///
+    /// A bare [`waterui_core::Str`] leaf has no content signal and leaves this
+    /// at zero for its whole life.
+    ///
+    /// [`WatchedSignal`]: crate::dispatch::WatchedSignal
+    content: u64,
+    /// Revision of the theme font the node shapes with.
+    font: u64,
+}
+
+impl TextRevision {
+    /// The revision of a node whose text comes from a signal.
+    pub(crate) const fn new(content: u64, font: u64) -> Self {
+        Self { content, font }
+    }
+
+    /// The revision of a node whose text is a fixed string, so only the
+    /// theme font can move.
+    pub(crate) const fn font_only(font: u64) -> Self {
+        Self { content: 0, font }
+    }
+}
+
 /// What a cached layout depends on.
 ///
 /// The width proposal changes the line breaking; the default brush is baked
 /// into the shaped runs, and controls vary it (a disabled button's label is
 /// painted in a muted colour), so a layout cached for one brush cannot be
-/// replayed for another.
+/// replayed for another. The font is not here — it moves every entry at once,
+/// so it rides on [`TextRevision`] instead.
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub(crate) struct TextLayoutKey {
     /// Width proposal the text was laid out against.
@@ -126,8 +161,8 @@ struct RetainedGlyphRun {
 }
 
 impl TextLayoutCache {
-    /// Discards everything when the text's content revision moved on.
-    fn sync_revision(&mut self, revision: u64) {
+    /// Discards everything when the content or the theme font moved on.
+    fn sync_revision(&mut self, revision: TextRevision) {
         if self.revision != revision {
             self.sizes.clear();
             self.retained = None;
@@ -144,7 +179,7 @@ impl TextLayoutCache {
     /// never painted).
     pub(crate) fn measure(
         &mut self,
-        revision: u64,
+        revision: TextRevision,
         key: TextLayoutKey,
         max_lines: Option<usize>,
         build: impl FnOnce() -> parley::Layout<[u8; 4]>,
@@ -177,7 +212,7 @@ impl TextLayoutCache {
     /// unchanged text costs no shaping and no outline lookups.
     pub(crate) fn emit(
         &mut self,
-        revision: u64,
+        revision: TextRevision,
         key: TextLayoutKey,
         max_lines: Option<usize>,
         transform: Affine,
@@ -351,25 +386,27 @@ impl DewState {
     }
 }
 
-/// Font size for plain [`waterui_core::Str`] leaves in logical pixels,
-/// matching the [`waterui_text::font::Body`] preset default.
-const PLAIN_FONT_SIZE: f32 = 16.0;
-
 impl DewState {
-    /// Shapes a plain string with the default body style — the fast path
+    /// Shapes a plain string with the theme's body style — the fast path
     /// for bare [`waterui_core::Str`] leaves that carry no span styling.
+    ///
+    /// The body slot is resolved from `env` exactly as
+    /// [`DewState::build_styled_layout`] resolves the default style of styled
+    /// text, so a bare `"literal"` and `text("literal")` beside it shape
+    /// identically under whatever type scale the theme installed.
     pub(crate) fn build_plain_layout(
         &mut self,
         text: &str,
+        env: &Environment,
         max_width: Option<f32>,
         brush: peniko::Color,
     ) -> parley::Layout<[u8; 4]> {
         self.assert_has_fonts();
+        let font = Font::default().resolve(env).get();
         let mut builder = self
             .layout_cx
             .ranged_builder(&mut self.font_cx, text, 1.0, true);
-        builder.push_default(parley::StyleProperty::Brush(peniko_to_rgba8(brush)));
-        builder.push_default(parley::StyleProperty::FontSize(PLAIN_FONT_SIZE));
+        push_layout_defaults(&mut builder, &font, brush);
         let mut layout = builder.build(text);
         layout.break_all_lines(max_width);
         layout.align(
@@ -407,14 +444,7 @@ impl DewState {
         let mut builder = self
             .layout_cx
             .ranged_builder(&mut self.font_cx, &plain, 1.0, true);
-        builder.push_default(parley::StyleProperty::Brush(peniko_to_rgba8(default_brush)));
-        builder.push_default(parley::StyleProperty::FontSize(default_font.size));
-        builder.push_default(parley::StyleProperty::FontWeight(parley_font_weight(
-            default_font.weight,
-        )));
-        builder.push_default(parley::StyleProperty::FontFamily(font_family(
-            default_font.family.as_deref(),
-        )));
+        push_layout_defaults(&mut builder, &default_font, default_brush);
 
         for (range, style) in spans {
             push_span_style(&mut builder, style, env, range);
@@ -440,6 +470,27 @@ impl DewState {
         let layout = self.build_styled_layout(styled, env, max_width, theme::foreground(env));
         (layout.width(), layout.height())
     }
+}
+
+/// Pushes the layout-wide defaults every dew text layout starts from: the
+/// brush spans without an explicit colour paint in, and the theme font they
+/// shape with.
+///
+/// Shared by the plain and styled paths so the two cannot drift apart — the
+/// divergence that let a bare string leaf keep its own font size.
+fn push_layout_defaults(
+    builder: &mut parley::RangedBuilder<'_, [u8; 4]>,
+    font: &ResolvedFont,
+    brush: peniko::Color,
+) {
+    builder.push_default(parley::StyleProperty::Brush(peniko_to_rgba8(brush)));
+    builder.push_default(parley::StyleProperty::FontSize(font.size));
+    builder.push_default(parley::StyleProperty::FontWeight(parley_font_weight(
+        font.weight,
+    )));
+    builder.push_default(parley::StyleProperty::FontFamily(font_family(
+        font.family.as_deref(),
+    )));
 }
 
 /// Pushes one [`StyledStr`] chunk's resolved style as parley range styles.
@@ -780,30 +831,70 @@ mod tests {
         };
 
         cache.measure(
-            0,
+            TextRevision::new(0, 0),
             TextLayoutKey::new(Some(120.0), theme::FOREGROUND),
             None,
             build,
         );
         cache.measure(
-            0,
+            TextRevision::new(0, 0),
             TextLayoutKey::new(Some(120.0), theme::FOREGROUND),
             None,
             build,
         );
         cache.measure(
-            0,
+            TextRevision::new(0, 0),
             TextLayoutKey::new(Some(80.0), theme::FOREGROUND),
             None,
             build,
         );
         cache.measure(
-            1,
+            TextRevision::new(1, 0),
+            TextLayoutKey::new(Some(120.0), theme::FOREGROUND),
+            None,
+            build,
+        );
+        // A new theme font re-shapes the node exactly as new content does.
+        cache.measure(
+            TextRevision::new(1, 1),
             TextLayoutKey::new(Some(120.0), theme::FOREGROUND),
             None,
             build,
         );
 
-        assert_eq!(builds.get(), 3);
+        assert_eq!(builds.get(), 4);
+    }
+
+    /// A bare string leaf and `text("…")` shape at the same theme body font,
+    /// whatever the theme installed — the leaf carries no size of its own.
+    #[test]
+    fn plain_and_styled_layouts_agree_on_the_body_font() {
+        let mut env = Environment::new();
+        Theme::new()
+            .fonts(FontSettings::new().body(ResolvedFont::new(20.0, FontWeight::Normal)))
+            .install(&mut env);
+        let mut state = DewState::new(crate::test_fonts());
+
+        let plain = state.build_plain_layout("Bare", &env, None, theme::FOREGROUND);
+        let styled =
+            state.build_styled_layout(&StyledStr::plain("Bare"), &env, None, theme::FOREGROUND);
+
+        assert_eq!(run_font_sizes(&plain), vec![20.0]);
+        assert_eq!(run_font_sizes(&plain), run_font_sizes(&styled));
+        assert_eq!(
+            (plain.width().to_bits(), plain.height().to_bits()),
+            (styled.width().to_bits(), styled.height().to_bits()),
+            "the two paths must lay out to the same size"
+        );
+
+        let default_scale = test_environment();
+        let default_plain =
+            state.build_plain_layout("Bare", &default_scale, None, theme::FOREGROUND);
+        assert_eq!(run_font_sizes(&default_plain), vec![16.0]);
+        assert_ne!(
+            plain.width().to_bits(),
+            default_plain.width().to_bits(),
+            "a 20pt body must not measure the same as the 16pt default"
+        );
     }
 }

--- a/backends/dew/src/theme.rs
+++ b/backends/dew/src/theme.rs
@@ -3,10 +3,13 @@
 use nami::{Computed, Signal};
 use peniko::Color;
 use waterui_backend_core::frame_signals::FrameSignals;
-use waterui_core::Environment;
+use waterui_core::{Environment, env::Store};
 use waterui_graphics::color::{
     AccentColor, AccentForegroundColor, BackgroundColor, BorderColor, ForegroundColor,
     MutedForegroundColor, ResolvedColor, Srgb, SurfaceColor, SurfaceVariantColor,
+};
+use waterui_text::font::{
+    Body, Caption, FontWeight, Footnote, Headline, ResolvedFont, Subheadline, Title,
 };
 
 use crate::dispatch::WatchedSignal;
@@ -38,6 +41,57 @@ pub const TRACK: Color = Color::from_rgb8(229, 229, 234);
 
 /// Movable control knobs: toggle and slider thumbs.
 pub const THUMB: Color = Color::WHITE;
+
+/// Body text: the size and weight `text("…")` shapes at.
+pub const BODY_FONT: ResolvedFont = ResolvedFont::new(16.0, FontWeight::Normal);
+
+/// Screen and section titles.
+pub const TITLE_FONT: ResolvedFont = ResolvedFont::new(22.0, FontWeight::Normal);
+
+/// The most prominent line on a screen.
+pub const HEADLINE_FONT: ResolvedFont = ResolvedFont::new(24.0, FontWeight::Normal);
+
+/// Body-sized text carrying a heading's emphasis.
+pub const SUBHEADLINE_FONT: ResolvedFont = ResolvedFont::new(16.0, FontWeight::Medium);
+
+/// Secondary annotations beside content.
+pub const CAPTION_FONT: ResolvedFont = ResolvedFont::new(12.0, FontWeight::Normal);
+
+/// The smallest supporting text.
+pub const FOOTNOTE_FONT: ResolvedFont = ResolvedFont::new(11.0, FontWeight::Medium);
+
+/// Installs dew's built-in type scale for every font slot the application's
+/// theme left unset.
+///
+/// Font slots are the one part of the palette dew cannot resolve at draw time:
+/// a colour an application never chose falls back to this module's constants
+/// where it is drawn, while a font is resolved inside `waterui-text`, which
+/// requires the token to be in the environment and panics when it is not. Supplying a default appearance is
+/// the backend's job rather than the view code's, so [`crate::DewRuntime`]
+/// applies this to the environment it renders under — a device app that
+/// installs no theme still renders `text("…")`, exactly as it renders a
+/// foreground colour it never chose.
+///
+/// The scale matches the one every other `WaterUI` backend defaults to, so the
+/// same view has the same proportions on a panel and on a desktop window. No
+/// family is named: firmware shapes with the faces its board bundles, and a
+/// desktop simulator with the system collection.
+pub fn install_default_fonts(env: &mut Environment) {
+    install_default::<Body>(env, BODY_FONT);
+    install_default::<Title>(env, TITLE_FONT);
+    install_default::<Headline>(env, HEADLINE_FONT);
+    install_default::<Subheadline>(env, SUBHEADLINE_FONT);
+    install_default::<Caption>(env, CAPTION_FONT);
+    install_default::<Footnote>(env, FOOTNOTE_FONT);
+}
+
+fn install_default<T: 'static>(env: &mut Environment, font: ResolvedFont) {
+    if env.query::<T, Computed<ResolvedFont>>().is_none() {
+        env.insert(Store::<T, Computed<ResolvedFont>>::new(Computed::constant(
+            font,
+        )));
+    }
+}
 
 /// Theme signals retained for the renderer lifetime. Every slot requests a
 /// frame when it changes, so controls repaint without rebuilding the tree.

--- a/backends/dew/src/theme.rs
+++ b/backends/dew/src/theme.rs
@@ -1,5 +1,8 @@
 //! Dew's reactive widget palette.
 
+use core::cell::Cell;
+use std::rc::Rc;
+
 use nami::{Computed, Signal};
 use peniko::Color;
 use waterui_backend_core::frame_signals::FrameSignals;
@@ -11,6 +14,7 @@ use waterui_graphics::color::{
 use waterui_text::font::{
     Body, Caption, Font, FontWeight, Footnote, Headline, ResolvedFont, Subheadline, Title,
 };
+use waterui_text::styled::StyledStr;
 
 use crate::dispatch::WatchedSignal;
 
@@ -184,19 +188,106 @@ fn watch<T: 'static>(
     WatchedSignal::new(slot::<T>(env, default), signals)
 }
 
-/// The body font a text node shapes with, watched for frame requests.
+/// The font signals one text node actually shapes with, watched together.
 ///
 /// Fonts get the same treatment colours do: a change bumps a revision the
 /// layout cache keys on, and requests a frame so the re-shaped text reaches
-/// the panel without anything rebuilding the tree. Unlike the colour palette
-/// this is one signal per text node rather than one per renderer, because the
-/// slot is read from the node's own environment — a subtree is free to install
-/// its own type scale, exactly as it is free to install its own foreground.
-pub(crate) fn watch_body_font(
-    env: &Environment,
+/// the panel without anything rebuilding the tree. Two things differ from the
+/// colour palette, and both follow from what a font is here.
+///
+/// It is per text node rather than per renderer, because a slot is read from
+/// the node's own environment — a subtree is free to install its own type
+/// scale, exactly as it is free to install its own foreground.
+///
+/// And the *set* of slots is content-dependent: a styled string's spans name
+/// their own (`.title()`, `.caption()`, an explicit size), so the watchers are
+/// rebuilt whenever the content revision moves, which is precisely when a span
+/// could have started or stopped reading a slot. That keeps the cost
+/// proportional to the slots a node uses rather than to the size of the type
+/// scale. Every watcher shares one counter, so the layout cache still compares
+/// a single number.
+pub(crate) struct WatchedFonts {
+    env: Environment,
     signals: FrameSignals,
-) -> WatchedSignal<Computed<ResolvedFont>> {
-    WatchedSignal::new(Font::default().resolve(env), signals)
+    revision: Rc<Cell<u64>>,
+    /// Content revision `watched` was built for.
+    content_revision: u64,
+    watched: Vec<WatchedSignal<Computed<ResolvedFont>>>,
+}
+
+impl WatchedFonts {
+    /// Watches the body slot alone — the whole type scale a bare
+    /// [`waterui_core::Str`] leaf can read, and a set that never changes.
+    pub(crate) fn plain(env: &Environment, signals: FrameSignals) -> Self {
+        let mut fonts = Self::empty(env, signals, 0);
+        fonts.watch(&Font::default());
+        fonts
+    }
+
+    /// Watches what `content` shapes with: the layout default plus the font
+    /// each span names.
+    pub(crate) fn styled(
+        content: &StyledStr,
+        content_revision: u64,
+        env: &Environment,
+        signals: FrameSignals,
+    ) -> Self {
+        let mut fonts = Self::empty(env, signals, content_revision);
+        fonts.rebuild(content);
+        fonts
+    }
+
+    /// Rebuilds the watcher set when the content revision has moved on: the
+    /// new string may name slots the old one did not.
+    ///
+    /// `content` is sampled only on an actual change, so the width probes a
+    /// layout pass makes cost nothing.
+    pub(crate) fn sync(&mut self, content_revision: u64, content: impl FnOnce() -> StyledStr) {
+        if self.content_revision != content_revision {
+            self.rebuild(&content());
+            self.content_revision = content_revision;
+        }
+    }
+
+    /// The revision every watched slot shares.
+    pub(crate) fn revision(&self) -> u64 {
+        self.revision.get()
+    }
+
+    fn empty(env: &Environment, signals: FrameSignals, content_revision: u64) -> Self {
+        Self {
+            env: env.clone(),
+            signals,
+            revision: Rc::new(Cell::new(0)),
+            content_revision,
+            watched: Vec::new(),
+        }
+    }
+
+    fn rebuild(&mut self, content: &StyledStr) {
+        self.watched.clear();
+        self.watch(&Font::default());
+        for (_, style) in content.chunks() {
+            self.watch(&style.font);
+        }
+    }
+
+    fn watch(&mut self, font: &Font) {
+        self.watched.push(WatchedSignal::shared(
+            font.resolve(&self.env),
+            self.signals.clone(),
+            Rc::clone(&self.revision),
+        ));
+    }
+}
+
+impl core::fmt::Debug for WatchedFonts {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("WatchedFonts")
+            .field("revision", &self.revision.get())
+            .field("watched", &self.watched.len())
+            .finish_non_exhaustive()
+    }
 }
 
 pub(crate) fn foreground(env: &Environment) -> Color {

--- a/backends/dew/src/theme.rs
+++ b/backends/dew/src/theme.rs
@@ -9,7 +9,7 @@ use waterui_graphics::color::{
     MutedForegroundColor, ResolvedColor, Srgb, SurfaceColor, SurfaceVariantColor,
 };
 use waterui_text::font::{
-    Body, Caption, FontWeight, Footnote, Headline, ResolvedFont, Subheadline, Title,
+    Body, Caption, Font, FontWeight, Footnote, Headline, ResolvedFont, Subheadline, Title,
 };
 
 use crate::dispatch::WatchedSignal;
@@ -179,6 +179,21 @@ fn watch<T: 'static>(
     default: Color,
 ) -> WatchedSignal<Computed<ResolvedColor>> {
     WatchedSignal::new(slot::<T>(env, default), signals)
+}
+
+/// The body font a text node shapes with, watched for frame requests.
+///
+/// Fonts get the same treatment colours do: a change bumps a revision the
+/// layout cache keys on, and requests a frame so the re-shaped text reaches
+/// the panel without anything rebuilding the tree. Unlike the colour palette
+/// this is one signal per text node rather than one per renderer, because the
+/// slot is read from the node's own environment — a subtree is free to install
+/// its own type scale, exactly as it is free to install its own foreground.
+pub(crate) fn watch_body_font(
+    env: &Environment,
+    signals: FrameSignals,
+) -> WatchedSignal<Computed<ResolvedFont>> {
+    WatchedSignal::new(Font::default().resolve(env), signals)
 }
 
 pub(crate) fn foreground(env: &Environment) -> Color {

--- a/backends/dew/src/theme.rs
+++ b/backends/dew/src/theme.rs
@@ -66,11 +66,14 @@ pub const FOOTNOTE_FONT: ResolvedFont = ResolvedFont::new(11.0, FontWeight::Medi
 /// Font slots are the one part of the palette dew cannot resolve at draw time:
 /// a colour an application never chose falls back to this module's constants
 /// where it is drawn, while a font is resolved inside `waterui-text`, which
-/// requires the token to be in the environment and panics when it is not. Supplying a default appearance is
-/// the backend's job rather than the view code's, so [`crate::DewRuntime`]
-/// applies this to the environment it renders under — a device app that
-/// installs no theme still renders `text("…")`, exactly as it renders a
-/// foreground colour it never chose.
+/// requires the token to be in the environment and panics when it is not.
+/// Supplying a default appearance is the backend's job rather than the view
+/// code's, so [`DewRenderer::render_tree`] applies this to the environment
+/// every view tree is dispatched under — a device app that installs no theme
+/// still renders `text("…")`, exactly as it renders a foreground colour it
+/// never chose.
+///
+/// [`DewRenderer::render_tree`]: crate::DewRenderer::render_tree
 ///
 /// The scale matches the one every other `WaterUI` backend defaults to, so the
 /// same view has the same proportions on a panel and on a desktop window. No

--- a/backends/dew/src/views/mod.rs
+++ b/backends/dew/src/views/mod.rs
@@ -18,7 +18,6 @@ use waterui_backend_core::frame_signals::FrameSignals;
 use waterui_controls::label::{Label, LabelDisplayMode};
 use waterui_core::Environment;
 use waterui_core::layout::Size;
-use waterui_text::font::ResolvedFont;
 use waterui_text::styled::StyledStr;
 
 use crate::dispatch::{DewRenderer, RenderContext, WatchedSignal};
@@ -74,9 +73,11 @@ pub const fn to_f32(value: f64) -> f32 {
 pub struct LabelText {
     display_mode: LabelDisplayMode,
     content: WatchedSignal<Computed<StyledStr>>,
-    /// The theme body font the label shapes at, watched so a reactive type
-    /// scale re-shapes it and asks for a frame.
-    font: WatchedSignal<Computed<ResolvedFont>>,
+    /// The font slots the label shapes with — the layout default plus each
+    /// span's own — watched so a reactive type scale re-shapes it and asks for
+    /// a frame. Behind a `RefCell` because the set is rebuilt from the
+    /// content, and measurement runs behind `&self`.
+    fonts: RefCell<theme::WatchedFonts>,
     cache: RefCell<TextLayoutCache>,
 }
 
@@ -84,20 +85,29 @@ impl LabelText {
     /// Retains `label`'s semantic text, subscribing to its reactive content.
     #[must_use]
     pub fn new(label: &Label, env: &Environment, signals: FrameSignals) -> Self {
+        let content =
+            WatchedSignal::new(label.semantic_text().resolve(env).content, signals.clone());
         Self {
             display_mode: label.display_mode_preference(),
-            content: WatchedSignal::new(
-                label.semantic_text().resolve(env).content,
-                signals.clone(),
-            ),
-            font: theme::watch_body_font(env, signals),
+            fonts: RefCell::new(theme::WatchedFonts::styled(
+                &content.get(),
+                content.revision(),
+                env,
+                signals,
+            )),
+            content,
             cache: RefCell::new(TextLayoutCache::default()),
         }
     }
 
-    /// Everything that re-shapes this label: its content and the theme font.
+    /// Everything that re-shapes this label: its content and the fonts that
+    /// content reads. New content may name different slots, so the watcher set
+    /// is brought up to date here, before its revision is read.
     fn revision(&self) -> TextRevision {
-        TextRevision::new(self.content.revision(), self.font.revision())
+        let content = self.content.revision();
+        let mut fonts = self.fonts.borrow_mut();
+        fonts.sync(content, || self.content.get());
+        TextRevision::new(content, fonts.revision())
     }
 
     /// Whether this label draws nothing.

--- a/backends/dew/src/views/mod.rs
+++ b/backends/dew/src/views/mod.rs
@@ -18,10 +18,11 @@ use waterui_backend_core::frame_signals::FrameSignals;
 use waterui_controls::label::{Label, LabelDisplayMode};
 use waterui_core::Environment;
 use waterui_core::layout::Size;
+use waterui_text::font::ResolvedFont;
 use waterui_text::styled::StyledStr;
 
 use crate::dispatch::{DewRenderer, RenderContext, WatchedSignal};
-use crate::text::{DewState, TextLayoutCache, TextLayoutKey};
+use crate::text::{DewState, TextLayoutCache, TextLayoutKey, TextRevision};
 use crate::theme;
 
 pub mod button;
@@ -73,6 +74,9 @@ pub const fn to_f32(value: f64) -> f32 {
 pub struct LabelText {
     display_mode: LabelDisplayMode,
     content: WatchedSignal<Computed<StyledStr>>,
+    /// The theme body font the label shapes at, watched so a reactive type
+    /// scale re-shapes it and asks for a frame.
+    font: WatchedSignal<Computed<ResolvedFont>>,
     cache: RefCell<TextLayoutCache>,
 }
 
@@ -82,9 +86,18 @@ impl LabelText {
     pub fn new(label: &Label, env: &Environment, signals: FrameSignals) -> Self {
         Self {
             display_mode: label.display_mode_preference(),
-            content: WatchedSignal::new(label.semantic_text().resolve(env).content, signals),
+            content: WatchedSignal::new(
+                label.semantic_text().resolve(env).content,
+                signals.clone(),
+            ),
+            font: theme::watch_body_font(env, signals),
             cache: RefCell::new(TextLayoutCache::default()),
         }
+    }
+
+    /// Everything that re-shapes this label: its content and the theme font.
+    fn revision(&self) -> TextRevision {
+        TextRevision::new(self.content.revision(), self.font.revision())
     }
 
     /// Whether this label draws nothing.
@@ -108,7 +121,7 @@ impl LabelText {
         }
         let key = TextLayoutKey::new(None, theme::foreground(env));
         let mut cache = self.cache.borrow_mut();
-        let ((width, height), outcome) = cache.measure(self.content.revision(), key, None, || {
+        let ((width, height), outcome) = cache.measure(self.revision(), key, None, || {
             state
                 .borrow_mut()
                 .build_styled_layout(&self.content.get(), env, None, key.brush)
@@ -149,7 +162,7 @@ impl LabelText {
         }
         let max_width = (rect.width() > 0.0).then(|| to_f32(rect.width()));
         let key = TextLayoutKey { max_width, brush };
-        let revision = self.content.revision();
+        let revision = self.revision();
         let mut cache = self.cache.borrow_mut();
         let (list, state) = renderer.list_and_state();
         // Vertical centring needs the laid-out height, which is only known

--- a/backends/dew/tests/dispatch_views.rs
+++ b/backends/dew/tests/dispatch_views.rs
@@ -8,7 +8,9 @@ use core::cell::Cell;
 use std::rc::Rc;
 
 use nami::binding;
+use waterui::Plugin as _;
 use waterui::prelude::{Color, text, vstack};
+use waterui::theme::{FontSettings, Theme};
 use waterui_backend_core::input::TouchPhase;
 use waterui_controls::button::button;
 use waterui_controls::slider::slider;
@@ -16,7 +18,8 @@ use waterui_controls::stepper::stepper;
 use waterui_controls::toggle::toggle;
 use waterui_core::interaction::Disabled;
 use waterui_core::{AnyView, Environment, Metadata, env::use_env};
-use waterui_dew::{DewRuntime, HostBoard, PointerSample, render_view_png};
+use waterui_dew::{DewRuntime, DrawCommand, HostBoard, PointerSample, render_view_png};
+use waterui_text::font::{FontWeight, ResolvedFont};
 
 mod support;
 
@@ -54,6 +57,68 @@ fn vstack_of_colors_splits_the_screen() {
     };
     assert_eq!(pixel(64, 20), [244, 67, 54, 255]);
     assert_eq!(pixel(64, 108), [33, 150, 243, 255]);
+}
+
+/// Every shaped glyph run in `list`, as (font size, laid-out width, laid-out
+/// height) — the layout-local geometry, so two runs of the same string shape
+/// to the same triple exactly when they were laid out the same way.
+fn shaped_runs(list: &waterui_dew::DisplayList) -> Vec<(f32, f64, f64)> {
+    list.commands()
+        .iter()
+        .filter_map(|placed| match placed.command() {
+            DrawCommand::GlyphRun {
+                font_size, bounds, ..
+            } => Some((*font_size, bounds.width(), bounds.height())),
+            _ => None,
+        })
+        .collect()
+}
+
+/// A bare `"literal"` leaf and `text("literal")` beside it must shape at the
+/// theme's body font — the same one — rather than the leaf carrying a font
+/// size of its own. Regression test for the leaf that shaped at a hardcoded
+/// 16px whatever the theme installed.
+#[test]
+fn bare_string_and_text_shape_at_the_theme_body_font() {
+    let mut env = support::test_environment();
+    Theme::new()
+        .fonts(FontSettings::new().body(ResolvedFont::new(20.0, FontWeight::Normal)))
+        .install(&mut env);
+
+    let mut renderer = support::test_renderer();
+    let list = renderer.render_tree(
+        AnyView::new(vstack(("Bare", text("Bare")))),
+        &env,
+        240.0,
+        120.0,
+    );
+
+    let runs = shaped_runs(&list);
+    assert_eq!(
+        runs.len(),
+        2,
+        "the bare leaf and the text view must each emit one run, got {runs:?}"
+    );
+    assert_eq!(
+        runs[0].0.to_bits(),
+        runs[1].0.to_bits(),
+        "both must shape at the same size, got {:?} and {:?}",
+        runs[0],
+        runs[1]
+    );
+    assert_eq!(
+        (runs[0].1.to_bits(), runs[0].2.to_bits()),
+        (runs[1].1.to_bits(), runs[1].2.to_bits()),
+        "both must lay out to the same size, got {:?} and {:?}",
+        runs[0],
+        runs[1]
+    );
+    assert_eq!(
+        runs[0].0.to_bits(),
+        20.0_f32.to_bits(),
+        "the installed 20pt body font must win over the 16pt default, got {:?}",
+        runs[0]
+    );
 }
 
 /// Text must produce a real shaped glyph run in the retained display list.


### PR DESCRIPTION
`backends/dew/src/text.rs` shaped every bare `Str` leaf at a hardcoded 16px
while `build_styled_layout` resolved `Font::default()` — the Body slot — from
the environment. The two agreed only while the theme's body font happened to be
16pt: an app installing `FontSettings::new().body(ResolvedFont::new(20.0, …))`
got 20pt from `text("…")` and 16pt from a bare `"literal"` beside it in the
same stack. Both paths now push the same layout defaults through one shared
`push_layout_defaults`, so they cannot drift apart again, and `PLAIN_FONT_SIZE`
is gone. The plain path previously pushed only brush and size, so it ignored
the theme's weight and family too, not just its size.

## Watching the font signals

Resolving the slot alone would leave a stale-layout path behind it. Dew watched
no font signal at all: `ThemePalette` wraps every colour slot in a
`WatchedSignal` while fonts had no equivalent, and the layout cache keyed on
width and brush only, so a reactive font neither invalidated a shaped layout
nor requested a frame.

Which slots a text node reads is content-dependent — `text("…")` reads the
layout default, and each span of a `StyledStr` names its own (`.title()`,
`.caption()`, an explicit size) — so a single watcher per node cannot cover it,
and watching all six slots everywhere would pay for a type scale most nodes
never touch. `theme::WatchedFonts` holds one watcher per font a node actually
shapes with: the layout default plus each span's font, resolved through
`Font::resolve` so a mapped or directly-overridden font is covered as well as a
slot token. The set is rebuilt when the content revision moves — precisely when
a span could have started or stopped reading a slot — and the content is
sampled only on that change, so the width probes a layout pass makes cost
nothing. A bare `Str` leaf names no font of its own, so its set is the body
slot and never changes.

Every watcher shares one revision counter through the new
`WatchedSignal::shared`, so the cache still compares a single number.
`TextLayoutCache`'s revision becomes a `TextRevision` pairing the content
revision with that font one. The font rides on the revision rather than on
`TextLayoutKey` because it invalidates every probed width at once; as a key
dimension it would leave the sizes it invalidated behind in the size table,
growing it once per change on a backend whose peak heap is a budget.

Watching per node rather than once per renderer keeps the slot scoped the way
the foreground colour already is: a subtree that installs its own type scale is
shaped in it.

## Tests

- `dispatch_views::bare_string_and_text_shape_at_the_theme_body_font` renders
  `vstack(("Bare", text("Bare")))` under a 20pt body font and asserts the two
  glyph runs shape and lay out identically, at 20pt rather than the 16pt
  default.
- `runtime::tests::body_font_change_reshapes_retained_text` drives a
  `Binding<ResolvedFont>` body font from 16pt to 28pt and asserts the change
  requests a frame of its own and re-shapes the retained text on it.
- `runtime::tests::span_font_change_reshapes_retained_text` does the same for
  `text("Dew").font(Title)` against a `Binding`-driven Title slot, 22pt to
  34pt — the half a body-only watcher would have missed.
- `text::tests::plain_and_styled_layouts_agree_on_the_body_font` pins the two
  shaping paths together at the layout level, and the cache test gained a
  font-revision case.

## Depends on #381

Resolving the Body slot on a path that previously carried its own constant
makes bare string leaves and hidden control labels inherit #377: without a
theme there is no Body token and `waterui-text` panics. That is fixed on
`agent/dew-watch-sim-font-377`, which is merged into this branch rather than
duplicated — six dew tests build a runtime from a bare `Environment::new()` and
need it. **Merge #381 first**; once it is on `dev` this branch's merge commit
contributes nothing of its own.

One further pre-existing gap surfaced with it: `install_default_fonts` was
applied in `DewRuntime::new`, so a tree dispatched through the public
`DewRenderer::render_tree` (tests and tools) carried no font slot at all and
four dew control tests panicked. It moves to `render_tree`, the single funnel
every dew view tree goes through, and is removed from the runtime rather than
duplicated.

## Verification

`cargo nextest run -p waterui-dew` — 108 passed. Firmware shape
(`--no-default-features --features progress`) — 44 passed, including
`vending_machine_holds_its_embedded_work_budget`: the per-node watcher set does
not breach the embedded work or peak-heap gate. `cargo clippy -p waterui-dew
--all-targets -- -D warnings` and `cargo check -p waterui-dew
--no-default-features` clean; `cargo doc -p waterui-dew` warning-free.

Fixes #382
