### PR TITLE
fix(graphics): pad image brushes to texel centres on the hybrid engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4360,7 +4360,7 @@ dependencies = [
 [[package]]
 name = "glifo"
 version = "0.3.0"
-source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
+source = "git+https://github.com/lexoliu/vello?rev=d68d9e9825bcd1ffee762323881c13a2e7a3f639#d68d9e9825bcd1ffee762323881c13a2e7a3f639"
 dependencies = [
  "bytemuck",
  "foldhash 0.2.0",
@@ -11689,7 +11689,7 @@ dependencies = [
 [[package]]
 name = "vello_common"
 version = "0.2.0"
-source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
+source = "git+https://github.com/lexoliu/vello?rev=d68d9e9825bcd1ffee762323881c13a2e7a3f639#d68d9e9825bcd1ffee762323881c13a2e7a3f639"
 dependencies = [
  "bytemuck",
  "fearless_simd",
@@ -11728,7 +11728,7 @@ dependencies = [
 [[package]]
 name = "vello_hybrid"
 version = "0.2.0"
-source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
+source = "git+https://github.com/lexoliu/vello?rev=d68d9e9825bcd1ffee762323881c13a2e7a3f639#d68d9e9825bcd1ffee762323881c13a2e7a3f639"
 dependencies = [
  "bytemuck",
  "glifo 0.3.0",
@@ -11755,7 +11755,7 @@ dependencies = [
 [[package]]
 name = "vello_sparse_shaders"
 version = "0.2.0"
-source = "git+https://github.com/lexoliu/vello?rev=30322fbc330a0627f4b486c97e3c0fe8946606ba#30322fbc330a0627f4b486c97e3c0fe8946606ba"
+source = "git+https://github.com/lexoliu/vello?rev=d68d9e9825bcd1ffee762323881c13a2e7a3f639#d68d9e9825bcd1ffee762323881c13a2e7a3f639"
 dependencies = [
  "wesl",
  "wesl-macros",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -423,17 +423,21 @@ vello = { git = "https://github.com/lexoliu/vello", rev = "5e5f538556be16527f673
 # vello_hybrid 0.2.0 keeps only one physical layer in its image atlas off wasm,
 # and wgpu's GL backend then makes that texture `TEXTURE_2D` while the shader
 # samples a `texture_2d_array`, so every image brush renders black on a GL
-# adapter (#366). This rev is the 0.2.0 release plus a two-layer floor decided
-# by the adapter backend. The other two sparse-strip crates come from the same
-# rev because `vello_hybrid` names them by path there, and a second copy of
-# `vello_common` would make its paint types different types. Drop when a
-# release with linebender/vello#1859 (one 2D texture per atlas) ships.
-vello_hybrid = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
-vello_common = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
-vello_sparse_shaders = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
+# adapter (#366). It also clamps `Extend::Pad` to the last texel's leading
+# corner and only then subtracts the half texel that turns a corner into a
+# centre, so a bilinear image brush never reaches its final source row or
+# column (#234). This rev is the 0.2.0 release plus a two-layer floor decided
+# by the adapter backend and a pad that clamps to the texel centres. The other
+# two sparse-strip crates come from the same rev because `vello_hybrid` names
+# them by path there, and a second copy of `vello_common` would make its paint
+# types different types. Drop when a release carrying both fixes ships —
+# linebender/vello#1859 (one 2D texture per atlas) covers the first.
+vello_hybrid = { git = "https://github.com/lexoliu/vello", rev = "d68d9e9825bcd1ffee762323881c13a2e7a3f639" }
+vello_common = { git = "https://github.com/lexoliu/vello", rev = "d68d9e9825bcd1ffee762323881c13a2e7a3f639" }
+vello_sparse_shaders = { git = "https://github.com/lexoliu/vello", rev = "d68d9e9825bcd1ffee762323881c13a2e7a3f639" }
 # `vello_hybrid`'s text API takes glyphs from `glifo`, which that repo also
 # carries by path; the same rev keeps one `Glyph` type in the graph.
-glifo = { git = "https://github.com/lexoliu/vello", rev = "30322fbc330a0627f4b486c97e3c0fe8946606ba" }
+glifo = { git = "https://github.com/lexoliu/vello", rev = "d68d9e9825bcd1ffee762323881c13a2e7a3f639" }
 
 # Arm's proprietary Vulkan driver (r54p2 on Pixel 9 Pro / Android 16)
 # rasterizes as if viewport heights were positive, ignoring the negative-height

--- a/components/visual/graphics/tests/scene_image.rs
+++ b/components/visual/graphics/tests/scene_image.rs
@@ -158,20 +158,8 @@ fn hybrid_scene_engine_draws_an_image_brush() {
     // colour under either filtering quality. Each source pixel has a colour of
     // its own and the three channels run in three directions, so a transposed,
     // mirrored, shifted or channel-swapped blit fails here.
-    // The final row and column are skipped: `vello_hybrid`'s bilinear image
-    // sampling clamps `Extend::Pad` to the last texel's leading corner
-    // (`clamp(t, 0.0, size - 1.0)` in `render.wesl`) and only then subtracts
-    // the half texel that turns a corner into a centre, so every sample from
-    // that corner onwards resolves to one fixed half-and-half blend of the last
-    // two texels instead of running on into the last one. Skipped rather than
-    // asserted, because asserting it would pin the defect in place; see
-    // water-rs/waterui#234.
-    let last_centre = IMAGE_SIDE - 1;
     for y in 0..IMAGE_SIDE {
         for x in 0..IMAGE_SIDE {
-            if x == last_centre || y == last_centre {
-                continue;
-            }
             let expected = source_pixel(x, y);
             let point = (x * SCALE + SCALE / 2, y * SCALE + SCALE / 2);
             let actual = pixel_at(&hybrid, point.0, point.1);


### PR DESCRIPTION
`vello_hybrid`'s shader clamped `Extend::Pad` to the last texel's *leading
corner* (`clamp(t, 0.0, size - 1.0)` in `render.wesl`) and only afterwards
subtracted the half texel that turns a corner into a centre for
`IMAGE_QUALITY_MEDIUM`. Every bilinear sample from `size - 1` onwards therefore
resolved to the single coordinate `size - 1.5`, a fixed half-and-half blend of
the final two texels, so an image brush's last source row and column were never
drawn — the whole trailing band was that one frozen blend.

The clamp and the half-texel shift now happen in the same space: padding
saturates the sampling position at the outermost texel centres,
`[0.5, size - 0.5]`. Nearest sampling is unchanged, because both bounds
truncate to the same texel index, and repeat/reflect are untouched. Bilinear
padding now agrees with `vello_cpu`, which extends each tap *after* offsetting
it, and with the classic renderer, which clamps to `[0, size]`.

The shader fix is one commit on the existing fork,
lexoliu/vello@d68d9e9825bcd1ffee762323881c13a2e7a3f639, branch
`vello-hybrid-pad-texel-centre`, built on the rev this workspace already
carried for #366. Upstream `linebender/vello` main has not fixed this: its
`helpers/extend.wesl` still clamps pad to `max - 1.0`. All four
`[patch.crates-io]` entries move to the new rev together so the graph keeps one
`vello_common` and one `glifo`; only those four `source` lines move in
`Cargo.lock`.

`hybrid_scene_engine_draws_an_image_brush` no longer skips the final row and
column, so it compares the full 8x8 grid of source-pixel centres.

At output row 62, before and after, alongside the classic engine:

| output x | classic | hybrid before | hybrid after |
| --- | --- | --- | --- |
| 174 | `[67, 188, 157]` | `[67, 188, 157]` | `[67, 188, 157]` |
| 175 | `[68, 187, 158]` | `[68, 187, 158]` | `[68, 187, 158]` |
| 187 | `[69, 186, 161]` | `[68, 187, 158]` | `[69, 186, 161]` |
| 199 | `[69, 186, 161]` | `[68, 187, 158]` | `[69, 186, 161]` |

The largest whole-image channel difference between the two engines falls from
32 to 1.

Verified on an Apple M2 Max (Metal): the test failed before the rev bump with
the exclusion removed (`[156, 99, 108]` drawn where source pixel (0, 7) puts
`[168, 87, 136]`) and passes after; `cargo nextest run -p waterui-graphics`
(48 passed), `cargo clippy -p waterui-graphics --all-targets -- -D warnings`,
`cargo check --locked -p waterui-graphics`, `cargo check -p hydrolysis`,
rustfmt on the changed test. The rendered snapshot was read directly: the
gradient now runs continuously to the right and bottom edges with no frozen
band.

Fixes #234
