### PR TITLE
fix(hydrolysis): rasterize layers with multisampling so a scene renders to the same bytes twice

### DIFF
--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -202,6 +202,48 @@ pub(crate) use input::{
     text_editing,
 };
 
+/// The antialiasing vello runs for every Hydrolysis layer.
+///
+/// Multisampling rather than vello's analytic `Area` coverage, because `Area`
+/// cannot produce the same bytes twice. `path_count.wgsl` hands each segment
+/// its slot inside a tile with an `atomicAdd`, so the order the `fine` stage
+/// walks a tile's segments in is whatever order the dispatch happened to claim
+/// those slots; `fine` then accumulates coverage as `area += a * dy`, and
+/// floating-point addition is not associative. An unchanged scene therefore
+/// rasterizes to coverages an ULP apart between two renders, which quantizes to
+/// pixels 1/255 apart (#271). The multisampled fine stage accumulates winding
+/// numbers and sample masks with integer `atomicAdd`s instead, and integer
+/// addition does not care what order it is applied in, so the same scene always
+/// composites to the same bytes.
+pub(crate) const LAYER_ANTIALIASING: vello::AaConfig = vello::AaConfig::Msaa16;
+
+/// The fine-stage variants a Hydrolysis `vello::Renderer` compiles: exactly the
+/// one [`LAYER_ANTIALIASING`] asks for, so pipeline creation does not pay for
+/// variants no layer will ever select.
+pub(crate) const LAYER_ANTIALIASING_SUPPORT: vello::AaSupport =
+    antialiasing_support_for(LAYER_ANTIALIASING);
+
+/// The single-method [`vello::AaSupport`] that lets a renderer serve `config`.
+const fn antialiasing_support_for(config: vello::AaConfig) -> vello::AaSupport {
+    match config {
+        vello::AaConfig::Area => vello::AaSupport {
+            area: true,
+            msaa8: false,
+            msaa16: false,
+        },
+        vello::AaConfig::Msaa8 => vello::AaSupport {
+            area: false,
+            msaa8: true,
+            msaa16: false,
+        },
+        vello::AaConfig::Msaa16 => vello::AaSupport {
+            area: false,
+            msaa8: false,
+            msaa16: true,
+        },
+    }
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub(crate) struct ContentSizeLimits {
     pub(crate) minimum: LayoutSize,
@@ -337,7 +379,7 @@ impl HydrolysisRenderer {
             device,
             vello::RendererOptions {
                 use_cpu: false,
-                antialiasing_support: vello::AaSupport::area_only(),
+                antialiasing_support: LAYER_ANTIALIASING_SUPPORT,
                 // Hydrolysis is the high-end, multi-core renderer: let vello parallelize
                 // pipeline initialization across all available cores instead of pinning
                 // it to a single thread.

--- a/backends/hydrolysis/src/renderer/render/compositor.rs
+++ b/backends/hydrolysis/src/renderer/render/compositor.rs
@@ -17,13 +17,13 @@ const GPU_SURFACE_COMPOSITOR_SHADER: CompiledShader =
     include!(concat!(env!("OUT_DIR"), "/gpu_surface_compositor.rs"));
 
 /// Builds a fresh `vello::Renderer` for the parallel-encode pool, matching the main
-/// renderer's options (GPU-only, area AA, multi-core init).
+/// renderer's options (GPU-only, [`LAYER_ANTIALIASING`], multi-core init).
 fn build_pooled_vello_renderer(device: &wgpu::Device) -> vello::Renderer {
     vello::Renderer::new(
         device,
         vello::RendererOptions {
             use_cpu: false,
-            antialiasing_support: vello::AaSupport::area_only(),
+            antialiasing_support: LAYER_ANTIALIASING_SUPPORT,
             num_init_threads: std::thread::available_parallelism().ok(),
             pipeline_cache: None,
         },
@@ -61,7 +61,7 @@ fn encode_vello_layers_parallel(
             base_color: vello::peniko::Color::TRANSPARENT,
             width,
             height,
-            antialiasing_method: vello::AaConfig::Area,
+            antialiasing_method: LAYER_ANTIALIASING,
         };
         renderer
             .render_to_texture(device, queue, scene, &leased.view, &params)
@@ -1432,7 +1432,7 @@ impl HydrolysisRenderer {
             base_color: vello::peniko::Color::TRANSPARENT,
             width,
             height,
-            antialiasing_method: vello::AaConfig::Area,
+            antialiasing_method: LAYER_ANTIALIASING,
         };
         self.vello_renderer
             .render_to_texture(device, queue, scene, &leased.view, &params)

--- a/backends/hydrolysis/src/renderer/tests/tree.rs
+++ b/backends/hydrolysis/src/renderer/tests/tree.rs
@@ -947,6 +947,39 @@ fn gesture_wrapper_keeps_reactive_descendant_live() {
     );
 }
 
+/// Window size the tree-grid screen is rendered at, shared by the export
+/// snapshot and the determinism test so both observe the same layout.
+const TREE_GRID_WIDTH: u32 = 440;
+/// See [`TREE_GRID_WIDTH`].
+const TREE_GRID_HEIGHT: u32 = 920;
+
+/// The chart example's mode-button screen: a 3x3 `grid` of fixed-width buttons
+/// above a fixed-size coloured block. Shared by [`render_tree_grid_snapshot`]
+/// and [`tree_grid_frame_is_byte_identical_across_runtimes`] so the exported
+/// evidence and the determinism assertion describe the same scene.
+fn tree_grid_screen() -> AnyView {
+    use waterui::layout::grid::{grid, row};
+    use waterui::prelude::*;
+    fn cell(label: &str) -> impl View {
+        button(label.to_owned()).width(92.0)
+    }
+    let controls = grid(
+        3,
+        [
+            row((cell("Bar"), cell("Line"), cell("Pie"))),
+            row((cell("Scatter"), cell("Candle"), cell("Depth"))),
+            row((cell("Heatmap"), cell("Contour"), cell("Radar"))),
+        ],
+    )
+    .spacing(10.0);
+    AnyView::new(vstack((
+        controls,
+        spacer(),
+        ().size(200.0, 100.0).background(Color::srgb_hex("#2563EB")),
+        spacer(),
+    )))
+}
+
 /// Diagnostic: a 3-column `grid` of fixed-size colour cells must render all rows
 /// (the chart example's mode-button grid regressed to a single overlapping row on
 /// the tree path). The exported PNG must show three stacked rows of three cells.
@@ -960,32 +993,10 @@ fn render_tree_grid_snapshot() {
         image.save(path).expect("snapshot png must be writable");
     }
 
-    fn screen() -> AnyView {
-        use waterui::layout::grid::{grid, row};
-        use waterui::prelude::*;
-        fn cell(label: &str) -> impl View {
-            button(label.to_owned()).width(92.0)
-        }
-        let controls = grid(
-            3,
-            [
-                row((cell("Bar"), cell("Line"), cell("Pie"))),
-                row((cell("Scatter"), cell("Candle"), cell("Depth"))),
-                row((cell("Heatmap"), cell("Contour"), cell("Radar"))),
-            ],
-        )
-        .spacing(10.0);
-        AnyView::new(vstack((
-            controls,
-            spacer(),
-            ().size(200.0, 100.0).background(Color::srgb_hex("#2563EB")),
-            spacer(),
-        )))
-    }
-
-    let builder = AnyViewBuilder::<AnyView>::new(screen);
+    let builder = AnyViewBuilder::<AnyView>::new(tree_grid_screen);
     let env = test_environment();
-    let mut rt = crate::HeadlessRuntime::new_for_tests(env, builder, 440, 920);
+    let mut rt =
+        crate::HeadlessRuntime::new_for_tests(env, builder, TREE_GRID_WIDTH, TREE_GRID_HEIGHT);
 
     let snapshot = rt
         .pump_at(true, std::time::Instant::now())
@@ -998,6 +1009,78 @@ fn render_tree_grid_snapshot() {
         snapshot.rgba8,
     );
     eprintln!("wrote /tmp/waterui_tree_grid.png");
+}
+
+/// Identical source must rasterize to identical bytes. Rendering the tree-grid
+/// screen — the one #271 caught drifting by a single antialiased pixel inside a
+/// glyph — through eight independently built runtimes must produce eight
+/// byte-identical RGBA buffers. Each runtime builds its own view tree, renderer
+/// and retained scene; only the wgpu device is shared, because requesting one
+/// device per sample exhausts a runner whose only adapter is a software
+/// rasterizer. Every run is pumped at its own `Instant::now()` on purpose: this
+/// screen declares no animation, so the captured frame must not depend on the
+/// wall-clock phase it was captured at.
+#[test]
+fn tree_grid_frame_is_byte_identical_across_runtimes() {
+    use crate::platform::OffscreenGpuContext;
+    use waterui_core::handler::AnyViewBuilder;
+
+    /// Independently built runtimes rendering the same screen.
+    const RUNS: usize = 8;
+
+    let gpu = OffscreenGpuContext::new_for_tests_blocking();
+    let frames: Vec<_> = (0..RUNS)
+        .map(|run| {
+            let builder = AnyViewBuilder::<AnyView>::new(tree_grid_screen);
+            let env = test_environment();
+            let mut rt = crate::HeadlessRuntime::new_for_tests_on_context(
+                gpu.clone(),
+                env,
+                builder,
+                TREE_GRID_WIDTH,
+                TREE_GRID_HEIGHT,
+            );
+            rt.pump_at(true, std::time::Instant::now())
+                .snapshot
+                .unwrap_or_else(|| panic!("run {run} must capture a snapshot"))
+        })
+        .collect();
+
+    let (first, rest) = frames.split_first().expect("RUNS is non-zero");
+    for (run, frame) in rest
+        .iter()
+        .enumerate()
+        .map(|(index, frame)| (index + 1, frame))
+    {
+        assert_eq!(
+            (frame.width, frame.height),
+            (first.width, first.height),
+            "run {run} captured a differently sized frame"
+        );
+        if frame.rgba8 == first.rgba8 {
+            continue;
+        }
+        let differing = first
+            .rgba8
+            .iter()
+            .zip(&frame.rgba8)
+            .filter(|(a, b)| a != b)
+            .count();
+        let (index, (expected, found)) = first
+            .rgba8
+            .iter()
+            .zip(&frame.rgba8)
+            .enumerate()
+            .find(|(_, (a, b))| a != b)
+            .expect("the buffers differ, so a differing byte exists");
+        let pixel = u32::try_from(index / 4).expect("a frame index fits in u32");
+        let (x, y) = (pixel % first.width, pixel / first.width);
+        let channel = ["r", "g", "b", "a"][index % 4];
+        panic!(
+            "run {run} differs from run 0: {differing} differing bytes; first at \
+             pixel ({x}, {y}) channel {channel}: run 0 has {expected}, run {run} has {found}"
+        );
+    }
 }
 
 /// Lifecycle hooks are node-owned on the retained tree: `.on_appear` fires once


### PR DESCRIPTION
Rendering an unchanged scene through vello's analytic `Area` antialiasing does not produce the same pixels twice.

## Root cause

`path_count.wgsl:189` assigns each path segment its slot inside a tile with an `atomicAdd`, so the order the `fine` stage walks a tile's segment list in is whatever order that dispatch happened to claim the slots. `fine.wgsl`'s `fill_path` then integrates coverage as `area[i] += a * dy` over that list — a floating-point sum, and floating-point addition is not associative. Two renders of a byte-identical scene therefore land an ULP apart on antialiased edges, which quantizes to pixels 1/255 apart.

Nothing on the WaterUI side was at fault: the vello `Scene` encoding handed to `render_to_texture` hashes identically on every frame, and the divergence appears in the layer texture that comes back.

## Evidence

Bisected by hashing the scene encoding and reading back the vello layer texture before compositing, on the tree-grid screen (440x920, one Vello layer):

| observation | `Area` (before) | `Msaa16` (after) |
| --- | --- | --- |
| vello scene encoding hash, 12 pumps of one runtime | identical every pump | identical every pump |
| vello layer texture, consecutive pumps of that identical scene | 454-794 differing bytes each pump, all +/-1..3 on glyph edges | 0 differing bytes, all 12 pumps |
| composited window frame, 8 fresh runtimes in one process | differs at (200, 133) g: 139 vs 140 | byte-identical |
| determinism test, 6 separate processes | 5 of 6 FAIL, always (200, 133) g, flipping 139 <-> 140 | 6 of 6 pass |
| `render_tree_grid_snapshot` PNG sha, 6 separate debug processes | all 6 equal (a single frame lands on the same side most of the time) | all 6 equal |
| same export, 2 release processes | the two differ from each other; run 1 matches debug, run 2 does not | both equal, and equal to debug |

(200, 133) is the pixel #271 reported, inside the `Contour` button's label.

Frame instant is not involved: pumping one runtime twice at the *same* `Instant` reproduces the difference, and pumping at +500 ms does not change it. Neither is `encode_vello_layers_parallel` — this scene has a single Vello layer, so the parallel branch is never entered.

## The change

The multisampled fine stage accumulates winding numbers and sample masks with integer `atomicAdd`s (`fine.wgsl` msaa section), and integer addition does not care what order it is applied in, so the same scene always composites to the same bytes. Every Hydrolysis layer now renders with `Msaa16`, expressed as one `LAYER_ANTIALIASING` constant with the matching single-variant `AaSupport` derived from it, so a renderer still compiles exactly one fine-stage variant.

## Trade-off

The two rasterizers do not agree pixel-for-pixel. On the tree-grid frame 0.4% of bytes move, by 6.4/255 on average and 27/255 at most; on the MD3 shape set 2.6% of bytes move, by at most 10/255. Both pairs are indistinguishable side by side at 3x — text stems and curved shape edges look the same.

No cost was measurable on Apple Silicon: 120 captured frames of 160 text buttons at 1600x1200, median 9.59 ms under `Area` against 9.39 ms under `Msaa16` (p10 9.00 vs 8.84). vello's own docs say `Area` "generally has better performance than the multi-sampling methods", so this deserves a look on a bench lane and on a mobile GPU before it is taken as free everywhere. `Msaa16`'s workgroup storage (~4.6 KB) is inside the WebGPU baseline of 16 KB, so it is not expected to fail pipeline creation on any adapter that already runs Hydrolysis.

Reverting is three lines: set `LAYER_ANTIALIASING` back to `vello::AaConfig::Area`.

## Test

`tree_grid_frame_is_byte_identical_across_runtimes` renders the tree-grid screen through eight independently built runtimes — fresh view tree, renderer and retained scene each, sharing only the wgpu device — and requires all eight RGBA buffers to be byte-identical, printing the first differing pixel, channel, both values and the differing-byte count when they are not. Each run is pumped at its own `Instant::now()`, since the screen declares no animation and must not depend on the wall-clock phase it was captured at. The screen builder is now shared with `render_tree_grid_snapshot` instead of duplicated.

The test fails on the parent commit.

## Verification

- `cargo clippy -p hydrolysis --all-targets -- -D warnings`: clean
- `cargo nextest run -p hydrolysis`: 210 passed, 1 skipped (209 passed / 1 failed before the fix, the failure being the new test)
- `cargo nextest run -p hydrolysis-m3`: 191 passed, 24 skipped
- MD3 shape-set and tree-grid PNGs reviewed by eye under both rasterizers

## Left as-is, deliberately

`components/visual/graphics` still renders Scene2D GPU surfaces with `AaConfig::Area` (`gpu/shared_context.rs:193`, `scene/scene_surface.rs:268`), so a scene drawn through a `GpuSurface` keeps the same non-determinism. That is a different crate and outside this issue's scope; it wants its own issue.

Fixes #271
