### PR TITLE
fix(dew): honour application accessibility labels on every node

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12683,6 +12683,7 @@ dependencies = [
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
+ "waterui-math",
  "waterui-navigation",
  "waterui-shape",
  "waterui-svg",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13142,10 +13142,12 @@ dependencies = [
  "toml 1.1.4+spec-1.1.0",
  "tracing",
  "ttf-parser",
+ "waterui",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
  "waterui-str",
+ "waterui-testing",
  "wgpu",
 ]
 

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -121,6 +121,11 @@ waterui = { path = "../..", default-features = false }
 # built from the library alone, stays GPU-free.
 waterui-canvas.workspace = true
 waterui-svg.workspace = true
+# A formula is the scene content that has something to say about itself: it
+# answers `SceneContent::accessibility_label` with its MathML, which is what
+# proves dew's scene leaf publishes a content-supplied name rather than a bare
+# unnamed image. Test-only for the same reason as the two crates above.
+waterui-math.workspace = true
 # The component issue #180 is actually about: an interactive chart wraps its
 # canvas in `Metadata<GestureObserver>` and `Metadata<OnEvent>`, and every one
 # of those wrappers used to abort dew's dispatch. Test-only, like the scene

--- a/backends/dew/src/accessibility.rs
+++ b/backends/dew/src/accessibility.rs
@@ -11,6 +11,7 @@ use std::collections::BTreeMap;
 use accesskit::{Action, ActionData, ActionRequest, Node, NodeId, Role, Tree, TreeId, TreeUpdate};
 use kurbo::Rect;
 use nami::{Binding, Computed, Signal};
+use waterui_core::Str;
 use waterui_core::id::Id;
 
 use crate::pointer::PointerTargetHandle;
@@ -45,6 +46,36 @@ pub(crate) enum ActionTarget {
     },
 }
 
+/// One `.a11y_label(..)` / `.a11y_id(..)` wrapper, open for the duration of the
+/// subtree it names.
+///
+/// Naming metadata is nearest-consumer, exactly as in hydrolysis: whichever
+/// node ends up *representing* the wrapped view owns the name, and nothing
+/// below may say it again — a button named "Play episode" must answer to that
+/// name once, not once per node its chrome happens to publish. Dew has no
+/// environment to carry that decision in (its retained nodes read the
+/// environment they captured at build time, and the metadata never reached
+/// it), so the scope lives on the render stack and `claimed` records whether
+/// the node that represents the view has already taken the name this frame.
+struct NamingScope {
+    value: Str,
+    claimed: bool,
+}
+
+impl NamingScope {
+    const fn new(value: Str) -> Self {
+        Self {
+            value,
+            claimed: false,
+        }
+    }
+
+    /// The name, if this scope is still unclaimed; claiming it in the process.
+    fn claim(&mut self) -> Option<&Str> {
+        (!core::mem::replace(&mut self.claimed, true)).then_some(&self.value)
+    }
+}
+
 pub(crate) struct AccessibilityBuilder {
     nodes: Vec<(NodeId, Node)>,
     roots: Vec<NodeId>,
@@ -55,6 +86,8 @@ pub(crate) struct AccessibilityBuilder {
     root_bounds: Rect,
     pending_update: Option<TreeUpdate>,
     suppression_depth: usize,
+    labels: Vec<NamingScope>,
+    identifiers: Vec<NamingScope>,
 }
 
 impl Default for AccessibilityBuilder {
@@ -69,6 +102,8 @@ impl Default for AccessibilityBuilder {
             root_bounds: Rect::ZERO,
             pending_update: None,
             suppression_depth: 0,
+            labels: Vec::new(),
+            identifiers: Vec::new(),
         }
     }
 }
@@ -90,6 +125,8 @@ impl AccessibilityBuilder {
         self.actions.clear();
         self.pending_update = None;
         self.suppression_depth = 0;
+        self.labels.clear();
+        self.identifiers.clear();
         self.root_bounds = root_bounds;
     }
 
@@ -103,6 +140,7 @@ impl AccessibilityBuilder {
         if self.suppression_depth > 0 || bounds.width() <= 0.0 || bounds.height() <= 0.0 {
             return;
         }
+        self.apply_naming(&mut node);
         node.set_bounds(accesskit::Rect {
             x0: bounds.x0,
             y0: bounds.y0,
@@ -118,6 +156,50 @@ impl AccessibilityBuilder {
         if let Some(target) = target {
             self.actions.insert(id, target);
         }
+    }
+
+    /// Gives `node` the name the application asked for.
+    ///
+    /// The application's label replaces whatever default the node arrived with
+    /// — a control's own title, a scene's description of what it drew — because
+    /// the application is the one that knows what the view means; that is the
+    /// same precedence hydrolysis' `default_label` fallback expresses. Only the
+    /// innermost open scope can apply, and only to the first node that reaches
+    /// it: an outer scope shadowed by an inner one names nothing, exactly as an
+    /// environment insert shadows the key it overwrites.
+    ///
+    /// An automation identifier a node set for itself is an explicit backend
+    /// decision and stands; the scope's identifier fills in for nodes that have
+    /// none.
+    fn apply_naming(&mut self, node: &mut Node) {
+        if let Some(label) = self.labels.last_mut().and_then(NamingScope::claim) {
+            node.set_label(label.as_str());
+        }
+        if node.author_id().is_none()
+            && let Some(identifier) = self.identifiers.last_mut().and_then(NamingScope::claim)
+        {
+            node.set_author_id(identifier.as_str());
+        }
+    }
+
+    pub(crate) fn push_label(&mut self, label: Str) {
+        self.labels.push(NamingScope::new(label));
+    }
+
+    pub(crate) fn pop_label(&mut self) {
+        self.labels
+            .pop()
+            .expect("dew accessibility label scope underflow");
+    }
+
+    pub(crate) fn push_identifier(&mut self, identifier: Str) {
+        self.identifiers.push(NamingScope::new(identifier));
+    }
+
+    pub(crate) fn pop_identifier(&mut self) {
+        self.identifiers
+            .pop()
+            .expect("dew accessibility identifier scope underflow");
     }
 
     pub(crate) fn push_parent(&mut self, id: NodeId) {
@@ -156,6 +238,10 @@ impl AccessibilityBuilder {
         assert_eq!(
             self.suppression_depth, 0,
             "dew accessibility suppression stack must balance within a frame"
+        );
+        assert!(
+            self.labels.is_empty() && self.identifiers.is_empty(),
+            "dew accessibility naming scopes must balance within a frame"
         );
         let mut root = Node::new(Role::Window);
         root.set_label("WaterUI Window");

--- a/backends/dew/src/dispatch.rs
+++ b/backends/dew/src/dispatch.rs
@@ -24,6 +24,7 @@ use waterui_controls::slider::SliderConfig;
 use waterui_controls::stepper::StepperConfig;
 use waterui_controls::text_field::ResolvedTextFieldConfig;
 use waterui_controls::toggle::ToggleConfig;
+use waterui_core::accessibility::{AccessibilityIdentifier, AccessibilityLabel};
 use waterui_core::dynamic::Dynamic;
 use waterui_core::event::OnEvent;
 use waterui_core::gesture::GestureObserver;
@@ -31,7 +32,9 @@ use waterui_core::layout::{
     ProposalSize, Rect as LayoutRect, Size, StretchAxis, SubView, ViewDimensions,
 };
 use waterui_core::views::Views;
-use waterui_core::{AnyView, Environment, MainThreadBound, Metadata, Native, Retain, Str, View};
+use waterui_core::{
+    AnyView, Environment, IgnorableMetadata, MainThreadBound, Metadata, Native, Retain, Str, View,
+};
 use waterui_graphics::color::{Color, ResolvedColor};
 use waterui_graphics::{SceneView, SceneViewMergeToParent};
 use waterui_layout::Divider;
@@ -446,6 +449,29 @@ impl DewRenderer {
         }
     }
 
+    /// Opens the accessibility naming scope of an `.a11y_label(..)` wrapper for
+    /// the subtree rendered inside it.
+    ///
+    /// Guarded by the caller, like every other accessibility emission in dew:
+    /// a board with no assistive interface publishes no tree, and the label
+    /// signal is then not read at all.
+    pub(crate) fn push_accessibility_label(&mut self, label: Str) {
+        self.accessibility.push_label(label);
+    }
+
+    pub(crate) fn pop_accessibility_label(&mut self) {
+        self.accessibility.pop_label();
+    }
+
+    /// Opens the automation-identifier scope of an `.a11y_id(..)` wrapper.
+    pub(crate) fn push_accessibility_identifier(&mut self, identifier: Str) {
+        self.accessibility.push_identifier(identifier);
+    }
+
+    pub(crate) fn pop_accessibility_identifier(&mut self) {
+        self.accessibility.pop_identifier();
+    }
+
     pub(crate) fn handle_accessibility_action(
         &mut self,
         request: &AccessibilityActionRequest,
@@ -537,6 +563,34 @@ fn build_unmeasured_node(
         return Box::new(RetainNode {
             _retain: value,
             child: build_node(renderer, content, env, depth + 1),
+        });
+    }
+    // Accessibility naming metadata (`.a11y_label()` / `.a11y_id()`) reaches the
+    // dispatcher as an ignorable wrapper whose `body` is its content, so falling
+    // through to the generic expansion below would render the content correctly
+    // and drop the name — an application could not name anything for a screen
+    // reader. The name is captured here, once, and re-read from the captured
+    // signal at each flush; the retained node opens it as a scope around the
+    // subtree it names (see `NamingNode`).
+    if type_id == TypeId::of::<IgnorableMetadata<AccessibilityLabel>>() {
+        let IgnorableMetadata { content, value } = *view
+            .downcast::<IgnorableMetadata<AccessibilityLabel>>()
+            .expect("dew accessibility label downcast must match its type id");
+        return Box::new(NamingNode {
+            naming: Naming::Label(WatchedSignal::new(
+                value.signal().clone(),
+                renderer.signals(),
+            )),
+            child: build_unmeasured_node(renderer, content, env, depth + 1),
+        });
+    }
+    if type_id == TypeId::of::<IgnorableMetadata<AccessibilityIdentifier>>() {
+        let IgnorableMetadata { content, value } = *view
+            .downcast::<IgnorableMetadata<AccessibilityIdentifier>>()
+            .expect("dew accessibility identifier downcast must match its type id");
+        return Box::new(NamingNode {
+            naming: Naming::Identifier(value.into_str()),
+            child: build_unmeasured_node(renderer, content, env, depth + 1),
         });
     }
     if type_id == TypeId::of::<Native<LazyContainer>>() {
@@ -820,6 +874,62 @@ impl DewNode for ContainerNode {
         self.children
             .iter_mut()
             .fold(false, |changed, child| child.patch(renderer) | changed)
+    }
+}
+
+/// What one naming wrapper says, held for the life of the node it wraps.
+///
+/// A label is a signal — `"3 unread messages"` follows the state it is derived
+/// from — so it is watched, and a change asks for a frame the way every other
+/// dew signal does. An identifier names the view for automation and is
+/// deliberately constant.
+enum Naming {
+    Label(WatchedSignal<Computed<Str>>),
+    Identifier(Str),
+}
+
+/// The retained node of an `.a11y_label(..)` / `.a11y_id(..)` wrapper.
+///
+/// Layout-transparent: it measures, stretches and patches as its child. Its
+/// only work is to hold the name open while the subtree it wraps publishes its
+/// accessibility nodes, so the node representing that subtree — a control, a
+/// text, a scene leaf, a container that publishes one — takes the name at the
+/// single funnel every dew node registers through.
+struct NamingNode {
+    naming: Naming,
+    child: Box<dyn DewNode>,
+}
+
+impl DewNode for NamingNode {
+    fn measure(&self, state: &RefCell<DewState>, proposal: ProposalSize) -> ViewDimensions {
+        self.child.measure(state, proposal)
+    }
+
+    fn render(&mut self, renderer: &mut DewRenderer, ctx: RenderContext) {
+        if !renderer.accessibility_enabled() {
+            self.child.render(renderer, ctx);
+            return;
+        }
+        match &self.naming {
+            Naming::Label(label) => {
+                renderer.push_accessibility_label(label.get());
+                self.child.render(renderer, ctx);
+                renderer.pop_accessibility_label();
+            }
+            Naming::Identifier(identifier) => {
+                renderer.push_accessibility_identifier(identifier.clone());
+                self.child.render(renderer, ctx);
+                renderer.pop_accessibility_identifier();
+            }
+        }
+    }
+
+    fn stretch_axis(&self) -> StretchAxis {
+        self.child.stretch_axis()
+    }
+
+    fn patch(&mut self, renderer: &mut DewRenderer) -> bool {
+        self.child.patch(renderer)
     }
 }
 

--- a/backends/dew/src/views/scene.rs
+++ b/backends/dew/src/views/scene.rs
@@ -128,10 +128,22 @@ impl DewNode for SceneNode {
         );
         list.pop_clip();
         if renderer.accessibility_enabled() {
+            // What the drawing says about itself — a formula's MathML, say.
+            // A scene reaches the panel as anonymous fills, so this node is the
+            // only place its content can be announced, and the content is the
+            // only thing that knows what it drew. Read every frame, so content
+            // that follows a signal republishes what it currently draws.
+            let label = self.content.accessibility_label();
             renderer.register_built_accessibility_node(
                 self.accessibility_id,
                 ctx.window_bounds(),
-                || (AccessibilityNode::new(Role::Image), None),
+                || {
+                    let mut node = AccessibilityNode::new(Role::Image);
+                    if let Some(label) = label {
+                        node.set_label(label);
+                    }
+                    (node, None)
+                },
             );
         }
     }

--- a/backends/dew/tests/accessibility.rs
+++ b/backends/dew/tests/accessibility.rs
@@ -4,12 +4,18 @@ use core::cell::Cell;
 use std::rc::Rc;
 
 use accesskit::{Action, ActionRequest, Role, TreeId};
-use nami::binding;
+use nami::{SignalExt as _, binding};
 use waterui::prelude::Color;
+use waterui::view::ViewExt as _;
 use waterui_controls::button::button;
-use waterui_core::AnyView;
+use waterui_controls::toggle::toggle;
+use waterui_core::{AnyView, Str};
 use waterui_dew::{DewRuntime, HostBoard};
+use waterui_math::ast::MathStyle;
+use waterui_math::view::Math;
+use waterui_math::{latex, mathml};
 use waterui_navigation::{NavigationStack, NavigationView, Tab, Tabs};
+use waterui_text::text;
 
 mod support;
 
@@ -163,5 +169,230 @@ fn navigation_publishes_a_group_with_its_visible_title() {
             .nodes
             .iter()
             .any(|(_, node)| { node.role() == Role::Label && node.value() == Some("Rooms") })
+    );
+}
+
+/// The application's own name for a control wins over the control's title.
+///
+/// A toggle names its node after its visible title, which is right until the
+/// application says otherwise: `.a11y_label(..)` exists precisely because the
+/// visible text is not always what a screen reader should hear. Dew consumed no
+/// naming metadata at all, so the override reached nothing and every node on
+/// this backend answered to whatever it had generated for itself.
+#[test]
+fn an_application_label_replaces_a_controls_own_title() {
+    let ready = binding(false);
+    let mut runtime = DewRuntime::new(
+        HostBoard::new(240, 64),
+        support::test_environment(),
+        16,
+        move || AnyView::new(toggle("Wi-Fi", &ready).a11y_label("Wireless network")),
+    );
+    runtime.pump().expect("the toggle frame renders");
+
+    let update = runtime
+        .board()
+        .accessibility_tree()
+        .expect("dew publishes an accessibility tree");
+    let switch = update
+        .nodes
+        .iter()
+        .find_map(|(_, node)| (node.role() == Role::Switch).then_some(node))
+        .expect("the toggle publishes a switch node");
+    assert_eq!(switch.label(), Some("Wireless network"));
+    assert!(
+        update
+            .nodes
+            .iter()
+            .all(|(_, node)| node.label() != Some("Wi-Fi")),
+        "the overridden title must not survive anywhere in the tree"
+    );
+}
+
+/// With nothing said about it, the control keeps naming itself: the override is
+/// a replacement for the default, not a requirement for having one.
+#[test]
+fn a_control_keeps_its_own_title_when_the_application_names_nothing() {
+    let ready = binding(false);
+    let mut runtime = DewRuntime::new(
+        HostBoard::new(240, 64),
+        support::test_environment(),
+        16,
+        move || AnyView::new(toggle("Wi-Fi", &ready)),
+    );
+    runtime.pump().expect("the toggle frame renders");
+
+    let update = runtime
+        .board()
+        .accessibility_tree()
+        .expect("dew publishes an accessibility tree");
+    let switch = update
+        .nodes
+        .iter()
+        .find_map(|(_, node)| (node.role() == Role::Switch).then_some(node))
+        .expect("the toggle publishes a switch node");
+    assert_eq!(switch.label(), Some("Wi-Fi"));
+}
+
+/// A scene leaf takes the application's name over the description its content
+/// generated for itself.
+///
+/// A formula answers `SceneContent::accessibility_label` with its `MathML`, which
+/// is the best a drawing can say about itself and still worse than a caption
+/// the application wrote. The two must not both be announced, so the override
+/// replaces it rather than adding to it.
+#[test]
+fn an_application_label_replaces_a_scene_leaf_default_description() {
+    const FORMULA: &str = r"\frac{a}{b}";
+
+    let mut runtime = DewRuntime::new(
+        HostBoard::new(160, 160),
+        support::test_environment(),
+        16,
+        || AnyView::new(Math::new(FORMULA).a11y_label("a over b")),
+    );
+    runtime.pump().expect("the formula frame renders");
+
+    let mathml = mathml::to_mathml(
+        &latex::parse(FORMULA).expect("the fixture formula parses"),
+        MathStyle::Text,
+    );
+    let update = runtime
+        .board()
+        .accessibility_tree()
+        .expect("dew publishes an accessibility tree");
+    let image = update
+        .nodes
+        .iter()
+        .find_map(|(_, node)| (node.role() == Role::Image).then_some(node))
+        .expect("the formula publishes an image node");
+    assert_eq!(image.label(), Some("a over b"));
+    assert!(
+        update
+            .nodes
+            .iter()
+            .all(|(_, node)| node.label() != Some(mathml.as_str())),
+        "the content's own description is replaced, not announced alongside"
+    );
+}
+
+/// A name on a parent scope belongs to the node that represents the wrapped
+/// view, and is said exactly once.
+///
+/// Padding, a frame, a background: the wrappers between `.a11y_label(..)` and
+/// the control it names publish nothing themselves, so the control is what the
+/// name is about. Hydrolysis expresses this as the naming scope being claimed
+/// by the node that represents the view, with everything below it silent; dew
+/// claims the same scope at the one funnel every node registers through.
+#[test]
+fn a_label_on_a_parent_scope_names_the_control_it_wraps_once() {
+    let mut runtime = DewRuntime::new(
+        HostBoard::new(240, 96),
+        support::test_environment(),
+        16,
+        || {
+            AnyView::new(
+                button("Save")
+                    .action(|| {})
+                    .padding()
+                    .a11y_label("Save draft"),
+            )
+        },
+    );
+    runtime.pump().expect("the button frame renders");
+
+    let update = runtime
+        .board()
+        .accessibility_tree()
+        .expect("dew publishes an accessibility tree");
+    let named = update
+        .nodes
+        .iter()
+        .filter(|(_, node)| node.label() == Some("Save draft"))
+        .collect::<Vec<_>>();
+    assert_eq!(
+        named.len(),
+        1,
+        "the scope names one node, not every node under it"
+    );
+    assert_eq!(named[0].1.role(), Role::Button);
+}
+
+/// A reactive label follows its signal without rebuilding the subtree.
+///
+/// The label is captured once, when the node is built, and re-read at each
+/// flush — the same contract every other dew signal holds — so a name derived
+/// from application state stays current on a backend whose whole point is not
+/// rebuilding what did not change.
+#[test]
+fn a_reactive_label_republishes_when_its_signal_changes() {
+    let unread = binding(3_i32);
+    let observed = unread.clone();
+    let mut runtime = DewRuntime::new(
+        HostBoard::new(240, 64),
+        support::test_environment(),
+        16,
+        move || {
+            let label = unread.map(|count| Str::from(format!("{count} unread")));
+            AnyView::new(text("Inbox").a11y_label(label))
+        },
+    );
+    runtime.pump().expect("the first frame renders");
+    assert!(
+        runtime
+            .board()
+            .accessibility_tree()
+            .expect("dew publishes an accessibility tree")
+            .nodes
+            .iter()
+            .any(|(_, node)| node.label() == Some("3 unread"))
+    );
+
+    observed.set(4);
+    runtime
+        .pump()
+        .expect("a label change asks for one more frame");
+    assert!(
+        runtime
+            .board()
+            .accessibility_tree()
+            .expect("dew publishes an accessibility tree")
+            .nodes
+            .iter()
+            .any(|(_, node)| node.label() == Some("4 unread")),
+        "the retained node re-reads the label it captured"
+    );
+}
+
+/// An automation identifier reaches the same node the label does.
+///
+/// `.a11y_id(..)` is what `waterui-testing` selectors and the native automation
+/// frameworks match on; it is never spoken, so it fills in beside the name
+/// rather than replacing it.
+#[test]
+fn an_automation_identifier_lands_on_the_named_node() {
+    let ready = binding(false);
+    let mut runtime = DewRuntime::new(
+        HostBoard::new(240, 64),
+        support::test_environment(),
+        16,
+        move || AnyView::new(toggle("Wi-Fi", &ready).a11y_id("settings.wifi")),
+    );
+    runtime.pump().expect("the toggle frame renders");
+
+    let update = runtime
+        .board()
+        .accessibility_tree()
+        .expect("dew publishes an accessibility tree");
+    let switch = update
+        .nodes
+        .iter()
+        .find_map(|(_, node)| (node.role() == Role::Switch).then_some(node))
+        .expect("the toggle publishes a switch node");
+    assert_eq!(switch.author_id(), Some("settings.wifi"));
+    assert_eq!(
+        switch.label(),
+        Some("Wi-Fi"),
+        "an identifier is not a name: the control keeps the one it had"
     );
 }

--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -30,6 +30,9 @@ use waterui_dew::{ClipRegion, DewRuntime, DisplayList, DrawCommand, HostBoard, r
 use waterui_graphics::color::Srgb;
 use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, invalidate_on_change};
 use waterui_layout::scroll::ScrollView;
+use waterui_math::ast::MathStyle;
+use waterui_math::view::Math;
+use waterui_math::{latex, mathml};
 use waterui_svg::Svg;
 
 mod support;
@@ -131,6 +134,51 @@ fn a_scene_publishes_an_accessibility_node() {
             .iter()
             .any(|(_, node)| node.role() == Role::Image),
         "a scene view is published as an image node"
+    );
+}
+
+/// Scene content that knows what it drew names its own node.
+///
+/// A formula reaches the panel as anonymous filled paths, so this node is the
+/// only place its content can be announced at all. Dew published it unnamed:
+/// the tree said "image" and nothing else. The content's own
+/// `SceneContent::accessibility_label` — the formula's `MathML` — is what names
+/// it, the same answer hydrolysis offers for the same drawing, so a formula is
+/// readable on both self-drawn backends rather than on whichever one the test
+/// happened to run.
+#[test]
+fn scene_content_names_its_own_accessibility_node() {
+    const FORMULA: &str = r"\frac{a}{b}";
+
+    let mut runtime = DewRuntime::new(
+        HostBoard::new(160, 160),
+        support::test_environment(),
+        16,
+        || AnyView::new(Math::new(FORMULA)),
+    );
+    runtime.pump().expect("the first frame renders");
+
+    // The expectation comes from the same public converter the view publishes
+    // through, so it tracks the converter instead of rotting into a stale
+    // literal.
+    let expected = mathml::to_mathml(
+        &latex::parse(FORMULA).expect("the fixture formula parses"),
+        MathStyle::Text,
+    );
+
+    let update = runtime
+        .board()
+        .accessibility_tree()
+        .expect("dew publishes an accessibility tree");
+    let labels: Vec<Option<&str>> = update
+        .nodes
+        .iter()
+        .filter(|(_, node)| node.role() == Role::Image)
+        .map(|(_, node)| node.label())
+        .collect();
+    assert!(
+        labels.contains(&Some(expected.as_str())),
+        "the formula's image node must carry its MathML, got {labels:?}"
     );
 }
 

--- a/backends/hydrolysis/src/renderer/tree/flush.rs
+++ b/backends/hydrolysis/src/renderer/tree/flush.rs
@@ -268,9 +268,12 @@ impl RenderNode {
                 renderer.pop_accessibility_owner();
             }
             RenderNode::SceneView(node) => {
+                // The drawing's own name, read every flush: content that follows
+                // a signal answers with what it currently draws.
+                let content_label = node.content.borrow().accessibility_label();
                 #[cfg(feature = "accessibility")]
                 renderer.push_accessibility_owner(&node.accessibility_identity);
-                emit_graphics_image_accessibility(renderer, ctx, env);
+                emit_graphics_image_accessibility(renderer, ctx, env, content_label);
                 #[cfg(feature = "accessibility")]
                 renderer.pop_accessibility_owner();
                 let mut scene = vello::Scene::new();
@@ -299,7 +302,7 @@ impl RenderNode {
             RenderNode::GpuSurface(node) => {
                 #[cfg(feature = "accessibility")]
                 renderer.push_accessibility_owner(&node.accessibility_identity);
-                emit_graphics_image_accessibility(renderer, ctx, env);
+                emit_graphics_image_accessibility(renderer, ctx, env, None);
                 #[cfg(feature = "accessibility")]
                 renderer.pop_accessibility_owner();
                 node.flush(renderer, ctx);

--- a/backends/hydrolysis/src/renderer/tree/nodes.rs
+++ b/backends/hydrolysis/src/renderer/tree/nodes.rs
@@ -872,11 +872,17 @@ impl TextNode {
 /// wrappers. These leaves draw their own pixels, so the node tree is the only place
 /// their semantic node can be emitted — mirroring `TextNode::emit_accessibility`
 /// for the text leaf. Suppressed when the subtree is accessibility-hidden.
+///
+/// `default_label` is what the drawing says about itself
+/// ([`SceneContent::accessibility_label`](waterui_graphics::SceneContent::accessibility_label)):
+/// a formula's `MathML`, say. It names the node only when the application named
+/// nothing, so `.a11y_label(…)` still wins.
 #[cfg(feature = "accessibility")]
 pub(super) fn emit_graphics_image_accessibility(
     renderer: &mut HydrolysisRenderer,
     ctx: RenderContext,
     env: &Environment,
+    default_label: Option<String>,
 ) {
     if env
         .get::<AccessibilityHidden>()
@@ -887,7 +893,7 @@ pub(super) fn emit_graphics_image_accessibility(
     let mut node = AccessibilityNode::new(
         renderer.resolve_accessibility_role(env, AccessibilityNodeRole::Image),
     );
-    if let Some(label) = renderer.resolve_accessibility_label(env, None) {
+    if let Some(label) = renderer.resolve_accessibility_label(env, default_label) {
         node.set_label(label);
     }
     let _ = renderer.register_accessibility_node(
@@ -903,5 +909,6 @@ pub(super) fn emit_graphics_image_accessibility(
     _renderer: &mut HydrolysisRenderer,
     _ctx: RenderContext,
     _env: &Environment,
+    _default_label: Option<String>,
 ) {
 }

--- a/components/visual/graphics/src/scene/scene_view.rs
+++ b/components/visual/graphics/src/scene/scene_view.rs
@@ -1,5 +1,6 @@
 use alloc::boxed::Box;
 use alloc::rc::Rc;
+use alloc::string::String;
 use core::fmt;
 
 use nami::Signal;
@@ -65,6 +66,25 @@ pub trait SceneContent: 'static {
     /// It must be finite and positive on both axes; a drawing with no honest size
     /// answers `None` instead of a degenerate one.
     fn intrinsic_size(&self) -> Option<Size> {
+        None
+    }
+
+    /// What this drawing says, for a screen reader.
+    ///
+    /// A scene reaches the screen as anonymous fills and glyph runs, so the node
+    /// a backend emits for the leaf is the only place its content can be
+    /// announced at all, and the backend has nothing to read it from but this. A
+    /// formula answers with its `MathML`, a chart with what it plots; content
+    /// that is decoration, or that cannot say anything true about itself,
+    /// answers `None` — the default — and the node stays unnamed.
+    ///
+    /// This is the name the content *offers*, not the name it imposes: the
+    /// application's own `.a11y_label(…)` wins over it wherever both exist,
+    /// because the application knows what the drawing is for and the content
+    /// only knows what it drew. It is read on every emission rather than once,
+    /// so content whose drawing follows a signal answers with what it currently
+    /// draws.
+    fn accessibility_label(&self) -> Option<String> {
         None
     }
 }
@@ -180,6 +200,15 @@ impl SceneView {
     #[must_use]
     pub fn intrinsic_size(&self) -> Option<Size> {
         self.content.intrinsic_size()
+    }
+
+    /// What the wrapped content says about itself, for a screen reader.
+    ///
+    /// See [`SceneContent::accessibility_label`]; a backend emitting the leaf's
+    /// semantic node offers this as the node's default name.
+    #[must_use]
+    pub fn accessibility_label(&self) -> Option<String> {
+        self.content.accessibility_label()
     }
 
     /// Takes ownership of the wrapped scene content.

--- a/components/visual/math/Cargo.toml
+++ b/components/visual/math/Cargo.toml
@@ -32,6 +32,8 @@ tracing.workspace = true
 # The gallery drives a headless surface, which is the only thing in this crate
 # that touches the GPU stack at all.
 waterui-graphics = { workspace = true, features = ["gpu"] }
+waterui = { path = "../../.." }
+waterui-testing = { path = "../../../testing" }
 pollster.workspace = true
 wgpu.workspace = true
 

--- a/components/visual/math/README.md
+++ b/components/visual/math/README.md
@@ -49,6 +49,13 @@ The semantic tree is kept after layout, not consumed by it. `mathml::to_mathml`
 publishes it as MathML, which is what assistive technology reads — a formula
 drawn as anonymous filled paths has no content at all to a screen reader.
 
+That markup reaches the accessibility tree: the drawing answers
+`SceneContent::accessibility_label` with it, and the backend names the formula's
+node with it. The markup follows the source signal, so a formula bound to state
+stays current. `.a11y_label("Quadratic formula")` still wins wherever the
+application names the formula itself — the markup is what the node says when
+nobody named it.
+
 ## Fonts
 
 Only a face carrying an OpenType `MATH` table can set mathematics. The default

--- a/components/visual/math/src/lib.rs
+++ b/components/visual/math/src/lib.rs
@@ -31,7 +31,7 @@
 //! use waterui_math::{latex, mathml};
 //!
 //! let formula = latex::parse(r"\frac{a}{b}")?;
-//! let markup = mathml::to_mathml(&formula, MathStyle::Display)?;
+//! let markup = mathml::to_mathml(&formula, MathStyle::Display);
 //!
 //! assert!(markup.contains("<mfrac>"));
 //! assert!(markup.contains(r#"display="block""#));

--- a/components/visual/math/src/mathml.rs
+++ b/components/visual/math/src/mathml.rs
@@ -9,7 +9,7 @@
 //! strings, so tags balance and content is escaped by construction — a formula
 //! containing `<` or `&` is ordinary, not an edge case.
 
-use alloc::string::{String, ToString};
+use alloc::string::String;
 use alloc::vec::Vec;
 
 use quick_xml::Writer;
@@ -17,26 +17,33 @@ use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
 
 use crate::ast::{MathItem, MathStyle};
 
-/// Why a tree could not be written as `MathML`.
-#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
-pub enum MathMlError {
-    /// The writer failed, or produced bytes that are not UTF-8.
-    #[error("could not write MathML: {message}")]
-    Write {
-        /// What went wrong.
-        message: String,
-    },
-}
+/// What the writer is told when it refuses a byte it cannot refuse.
+///
+/// The buffer is a [`Vec<u8>`], whose [`std::io::Write`] impl has no failure
+/// mode, so every `io::Result` threaded through this module is `Ok` by
+/// construction. Saying so once here is what keeps [`to_mathml`] total.
+const WRITE_CANNOT_FAIL: &str = "writing MathML into an in-memory buffer cannot fail";
 
 /// Renders `item` as a `MathML` `<math>` element.
 ///
 /// `style` sets the `display` attribute, which is the difference between a
 /// formula announced as set on its own line and one announced inline.
 ///
-/// # Errors
+/// This is total: a tree that parsed always has markup. The buffer is a
+/// [`Vec<u8>`] that never refuses a write, and every byte put into it comes
+/// either from `&str` content or from the escaper's ASCII entities, so the
+/// bytes are always UTF-8. A `Result` here would be an error no caller could
+/// act on, and the caller that had one discarded it and published an empty
+/// accessibility payload instead.
 ///
-/// Returns [`MathMlError`] if the underlying writer fails.
-pub fn to_mathml(item: &MathItem, style: MathStyle) -> Result<String, MathMlError> {
+/// # Panics
+///
+/// Panics if the buffer refuses a write or if the bytes it collected are not
+/// UTF-8 — neither of which the paragraph above leaves reachable. The
+/// assertion is what makes the function total; it is not a failure mode a
+/// caller can encounter or handle.
+#[must_use]
+pub fn to_mathml(item: &MathItem, style: MathStyle) -> String {
     let mut writer = Writer::new(Vec::new());
 
     let mut root = BytesStart::new("math");
@@ -49,42 +56,32 @@ pub fn to_mathml(item: &MathItem, style: MathStyle) -> Result<String, MathMlErro
             "inline"
         },
     ));
-    write(&mut writer, Event::Start(root))?;
-    element(&mut writer, item)?;
-    write(&mut writer, Event::End(BytesEnd::new("math")))?;
+    write(&mut writer, Event::Start(root));
+    element(&mut writer, item);
+    write(&mut writer, Event::End(BytesEnd::new("math")));
 
-    String::from_utf8(writer.into_inner()).map_err(|error| MathMlError::Write {
-        message: error.to_string(),
-    })
+    String::from_utf8(writer.into_inner()).expect("MathML is written from UTF-8 text")
 }
 
-fn write(writer: &mut Writer<Vec<u8>>, event: Event<'_>) -> Result<(), MathMlError> {
-    writer
-        .write_event(event)
-        .map_err(|error| MathMlError::Write {
-            message: error.to_string(),
-        })
+fn write(writer: &mut Writer<Vec<u8>>, event: Event<'_>) {
+    writer.write_event(event).expect(WRITE_CANNOT_FAIL);
 }
 
-fn leaf(writer: &mut Writer<Vec<u8>>, tag: &str, text: &str) -> Result<(), MathMlError> {
-    write(writer, Event::Start(BytesStart::new(tag)))?;
-    write(writer, Event::Text(BytesText::new(text)))?;
-    write(writer, Event::End(BytesEnd::new(tag)))
+fn leaf(writer: &mut Writer<Vec<u8>>, tag: &str, text: &str) {
+    write(writer, Event::Start(BytesStart::new(tag)));
+    write(writer, Event::Text(BytesText::new(text)));
+    write(writer, Event::End(BytesEnd::new(tag)));
 }
 
-fn wrap(
-    writer: &mut Writer<Vec<u8>>,
-    tag: &str,
-    children: &[&MathItem],
-) -> Result<(), MathMlError> {
-    write(writer, Event::Start(BytesStart::new(tag)))?;
+fn wrap(writer: &mut Writer<Vec<u8>>, tag: &str, children: &[&MathItem]) {
+    write(writer, Event::Start(BytesStart::new(tag)));
     for child in children {
-        element(writer, child)?;
+        element(writer, child);
     }
-    write(writer, Event::End(BytesEnd::new(tag)))
+    write(writer, Event::End(BytesEnd::new(tag)));
 }
 
-fn element(writer: &mut Writer<Vec<u8>>, item: &MathItem) -> Result<(), MathMlError> {
+fn element(writer: &mut Writer<Vec<u8>>, item: &MathItem) {
     match item {
         MathItem::Ident(text) => leaf(writer, "mi", text.as_str()),
         MathItem::Number(text) => leaf(writer, "mn", text.as_str()),
@@ -94,11 +91,11 @@ fn element(writer: &mut Writer<Vec<u8>>, item: &MathItem) -> Result<(), MathMlEr
             let mut space = BytesStart::new("mspace");
             let width = alloc::format!("{em}em");
             space.push_attribute(("width", width.as_str()));
-            write(writer, Event::Empty(space))
+            write(writer, Event::Empty(space));
         }
         MathItem::Row(items) => {
             let children: Vec<&MathItem> = items.iter().collect();
-            wrap(writer, "mrow", &children)
+            wrap(writer, "mrow", &children);
         }
         MathItem::Fraction {
             numerator,
@@ -115,15 +112,15 @@ fn element(writer: &mut Writer<Vec<u8>>, item: &MathItem) -> Result<(), MathMlEr
             (None, None) => element(writer, base),
         },
         MathItem::Fenced { open, body, close } => {
-            write(writer, Event::Start(BytesStart::new("mrow")))?;
+            write(writer, Event::Start(BytesStart::new("mrow")));
             if let Some(open) = open {
-                leaf(writer, "mo", open.glyph.as_str())?;
+                leaf(writer, "mo", open.glyph.as_str());
             }
-            element(writer, body)?;
+            element(writer, body);
             if let Some(close) = close {
-                leaf(writer, "mo", close.glyph.as_str())?;
+                leaf(writer, "mo", close.glyph.as_str());
             }
-            write(writer, Event::End(BytesEnd::new("mrow")))
+            write(writer, Event::End(BytesEnd::new("mrow")));
         }
     }
 }
@@ -135,7 +132,7 @@ mod tests {
 
     fn mathml(source: &str) -> String {
         let item = latex::parse(source).unwrap_or_else(|error| panic!("`{source}`: {error}"));
-        to_mathml(&item, MathStyle::Text).expect("MathML must be writable")
+        to_mathml(&item, MathStyle::Text)
     }
 
     #[test]
@@ -170,8 +167,8 @@ mod tests {
     #[test]
     fn display_mode_reaches_the_markup() {
         let item = latex::parse(r"\frac{a}{b}").expect("parses");
-        let block = to_mathml(&item, MathStyle::Display).expect("writes");
-        let inline = to_mathml(&item, MathStyle::Text).expect("writes");
+        let block = to_mathml(&item, MathStyle::Display);
+        let inline = to_mathml(&item, MathStyle::Text);
         assert!(block.contains("display=\"block\""), "got {block}");
         assert!(inline.contains("display=\"inline\""), "got {inline}");
     }

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -158,7 +158,7 @@ pub fn prepare(
         .map_err(|error| MathError::Layout(crate::layout::LayoutError::Font(error)))?;
     let layouter = Layouter::new(&math_font)?;
     let layout = layouter.layout(&item, font_size, style)?;
-    let mathml = mathml::to_mathml(&item, style).unwrap_or_else(|_| String::new());
+    let mathml = mathml::to_mathml(&item, style);
 
     Ok(PreparedMath {
         item,
@@ -362,6 +362,18 @@ impl SceneContent for MathContent {
         Some(size)
     }
 
+    /// The formula as `MathML`, which is what a screen reader reads.
+    ///
+    /// A formula reaches the screen as filled paths and glyph runs — to
+    /// assistive technology that is a picture with no content — so this node is
+    /// the only place the formula can be said at all. It is read fresh on every
+    /// emission, and the source watcher installed by [`Self::set_invalidator`]
+    /// is what schedules the frame that re-emits it, so a formula bound to
+    /// state stays current without its subtree being rebuilt.
+    fn accessibility_label(&self) -> Option<String> {
+        Some(accessibility_markup(&self.source.get(), self.style))
+    }
+
     fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
         // A formula is typeset from the source read in `build_scene`, so a
         // surface that is never told the source changed keeps presenting the
@@ -393,7 +405,34 @@ impl View for Math {
 
         let content = MathContent::new(self.source, self.font_size, self.style, self.family, brush);
 
+        // The formula's accessibility node is the leaf's own: `MathContent`
+        // answers `SceneContent::accessibility_label` with the markup, which
+        // the backend offers as the node's name when the application named
+        // nothing itself. It cannot be attached here as `.a11y_label(…)`
+        // metadata — that is nearest-consumer and would beat the application's
+        // own label instead of yielding to it.
         Frame::new(SceneView::new(content))
+    }
+}
+
+/// The formula's accessibility payload: its `MathML`.
+///
+/// A source that does not parse has no semantic tree and therefore no markup,
+/// and it does not draw either — so the only content that exists is the LaTeX
+/// the author wrote, and that is what the node says. The parse failure is
+/// reported: a formula that silently reads as its own source is a formula that
+/// silently did not render.
+fn accessibility_markup(source: &Str, style: MathStyle) -> String {
+    match latex::parse(source.as_str()) {
+        Ok(item) => mathml::to_mathml(&item, style),
+        Err(error) => {
+            tracing::error!(
+                %error,
+                formula = %source,
+                "formula does not parse; its source is all the accessibility node can say"
+            );
+            String::from(source.as_str())
+        }
     }
 }
 
@@ -426,8 +465,9 @@ mod tests {
     use waterui_graphics::{SceneContent, SceneInvalidator};
     use waterui_str::Str;
 
-    use super::{DEFAULT_MATH_FAMILY, MathContent};
+    use super::{DEFAULT_MATH_FAMILY, MathContent, accessibility_markup};
     use crate::ast::MathStyle;
+    use crate::{latex, mathml};
 
     /// A [`SceneInvalidator`] that counts the frames it was asked for.
     fn counting_invalidator() -> (SceneInvalidator, Rc<Cell<usize>>) {
@@ -445,6 +485,42 @@ mod tests {
             DEFAULT_MATH_FAMILY,
             Brush::Solid(PenikoColor::BLACK),
         )
+    }
+
+    /// The accessibility payload is the converter's markup, never a blank.
+    ///
+    /// It used to be: the conversion's `Result` was discarded into an empty
+    /// string, so a node that was supposed to carry the formula carried
+    /// nothing at all. The converter is total now, and this pins that the view
+    /// publishes exactly what it produces.
+    #[test]
+    fn the_accessibility_payload_is_the_converters_markup() {
+        let source = Str::from_static(r"\frac{a}{b}");
+        let expected = mathml::to_mathml(
+            &latex::parse(source.as_str()).expect("the fixture formula parses"),
+            MathStyle::Text,
+        );
+
+        assert!(!expected.is_empty(), "a parsed formula always has markup");
+        assert_eq!(accessibility_markup(&source, MathStyle::Text), expected);
+    }
+
+    /// A source that does not parse has no tree and therefore no markup, and it
+    /// does not draw either. The one thing that does exist is what the author
+    /// wrote, so that is what the node says — never an empty payload.
+    #[test]
+    fn a_source_that_does_not_parse_still_says_something() {
+        let source = Str::from_static(r"\begin{matrix}a & b\\c & d\end{matrix}");
+        assert!(
+            latex::parse(source.as_str()).is_err(),
+            "this fixture exists to be refused by the parser"
+        );
+
+        assert_eq!(
+            accessibility_markup(&source, MathStyle::Text),
+            source.as_str(),
+            "the node must carry the source when there is no markup to carry"
+        );
     }
 
     #[test]

--- a/components/visual/math/tests/e2e_semantics.rs
+++ b/components/visual/math/tests/e2e_semantics.rs
@@ -1,0 +1,111 @@
+//! End-to-end accessibility-semantics tests for the `math` component.
+//!
+//! A formula is drawn as anonymous filled paths and glyph runs, so the node the
+//! leaf publishes is the only place a screen reader can learn what the formula
+//! says. These tests pin what that node carries.
+
+use core::time::Duration;
+
+use nami::Binding;
+use waterui::ViewExt as _;
+use waterui_math::ast::MathStyle;
+use waterui_math::view::Math;
+use waterui_math::{latex, mathml};
+use waterui_str::Str;
+use waterui_testing::{Role, SemanticApp, UiBuilder};
+
+const FRACTION: &str = r"\frac{a}{b}";
+const ROOT: &str = r"\sqrt{x}";
+
+/// The markup the converter produces for `source`.
+///
+/// Computed through the same public converter the view publishes from rather
+/// than pasted as a literal, so the expectation tracks the converter instead of
+/// rotting into a stale string the next `MathML` change silently invalidates.
+fn markup(source: &str, style: MathStyle) -> String {
+    let item = latex::parse(source).unwrap_or_else(|error| panic!("`{source}`: {error}"));
+    mathml::to_mathml(&item, style)
+}
+
+fn unlabelled_formula() -> impl waterui::View {
+    Math::new(FRACTION)
+}
+
+fn labelled_formula() -> impl waterui::View {
+    Math::new(FRACTION).a11y_label("Ratio of a to b")
+}
+
+fn display_formula() -> impl waterui::View {
+    Math::new(FRACTION).display()
+}
+
+/// The formula reaches the tree as an image node carrying its `MathML`.
+#[waterui::test(unlabelled_formula)]
+fn an_unnamed_formula_publishes_its_mathml(app: &mut SemanticApp) {
+    let node = app
+        .query()
+        .role(Role::IMAGE)
+        .label(markup(FRACTION, MathStyle::Text))
+        .single();
+
+    let bounds = node.bounds();
+    assert!(
+        bounds.width() > 0.0 && bounds.height() > 0.0,
+        "the formula's node must occupy the box it draws into, got {}x{}",
+        bounds.width(),
+        bounds.height()
+    );
+}
+
+/// The style the formula is set in reaches the markup, because a formula
+/// announced as set on its own line is not the same announcement as an inline
+/// one.
+#[waterui::test(display_formula)]
+fn display_style_reaches_the_published_markup(app: &mut SemanticApp) {
+    app.query()
+        .role(Role::IMAGE)
+        .label(markup(FRACTION, MathStyle::Display))
+        .assert_exists();
+}
+
+/// What the application named the formula wins: it knows what the formula is
+/// for, and the markup is only the payload of last resort.
+#[waterui::test(labelled_formula)]
+fn an_application_label_wins_over_the_markup(app: &mut SemanticApp) {
+    app.query()
+        .role(Role::IMAGE)
+        .label("Ratio of a to b")
+        .assert_exists();
+
+    assert!(
+        !app.query()
+            .role(Role::IMAGE)
+            .label(markup(FRACTION, MathStyle::Text))
+            .exists(),
+        "a formula the application named must not also be announced as raw markup"
+    );
+}
+
+/// The markup follows the source signal, so a formula bound to state does not
+/// freeze at the markup it had when its subtree was built.
+#[waterui::test]
+fn the_published_markup_follows_the_source_signal(ui: UiBuilder) {
+    let source = Binding::container(Str::from_static(FRACTION));
+    let mounted = source.clone();
+    let mut app = ui.mount(move || Math::new(mounted.clone()));
+
+    app.query()
+        .role(Role::IMAGE)
+        .label(markup(FRACTION, MathStyle::Text))
+        .assert_exists();
+
+    source.set(Str::from_static(ROOT));
+
+    assert!(
+        app.query()
+            .role(Role::IMAGE)
+            .label(markup(ROOT, MathStyle::Text))
+            .wait_for_existence(Duration::from_secs(2)),
+        "the published markup must follow the formula's signal"
+    );
+}


### PR DESCRIPTION
Fixes #397

`.a11y_label(..)` and `.a11y_id(..)` reach dew's dispatch as `IgnorableMetadata`, whose `body` is its content, so the dispatcher fell through to the generic body expansion and dropped the value. No dew node carried an application-supplied name: every control, text and scene leaf announced whatever default it had generated for itself, and an app could not name anything for a screen reader on the embedded backend.

The two naming wrappers are retained nodes of their own now (`NamingNode`). Each captures its metadata once, when the node is built — the label as a `WatchedSignal`, so a name derived from app state republishes without rebuilding the subtree — and holds it open as a scope around the subtree it names. `AccessibilityBuilder::register`, the single funnel every dew node publishes through, applies the innermost open scope to the first node that reaches it. So:

- the application's label replaces the default the node arrived with (a control's title, `SceneContent::accessibility_label`), which is hydrolysis' `default_label` precedence;
- the name is said exactly once, by the node representing the wrapped view, and nothing below repeats it — hydrolysis' nearest-consumer claim, expressed on dew's render stack instead of in an environment dew has no other reason to clone;
- an automation identifier a node set for itself still stands, as it does in hydrolysis.

Every node kind that publishes is covered by construction, since they all register through that one funnel; no per-node copy.

Tests in `backends/dew/tests/accessibility.rs`: an app label wins over a toggle's title and over a formula's MathML on a `Math` scene leaf; the default is kept when the app names nothing; a label on a parent scope names the control it wraps exactly once; a reactive label republishes when its signal changes; an `.a11y_id(..)` lands as the node's author id without displacing its name.

Verified: `cargo clippy -p waterui-dew --all-targets -- -D warnings`, `cargo nextest run -p waterui-dew` (115 passed), `cargo nextest run -p waterui-dew --no-default-features --features progress` (44 passed, including `vending_machine_holds_its_embedded_work_budget`, which stays green untouched), `cargo check -p waterui-dew --no-default-features`, rustfmt on the three changed files. No `core/` change.

Branched on #392, whose two commits this PR carries until that one merges: dew's scene leaf publishes its content's label there, and the `waterui-math` dev-dependency these tests need arrives with it.
