### PR TITLE
fix(graphics): drop the Mali negative-viewport wgpu fork

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6970,7 +6970,8 @@ dependencies = [
 [[package]]
 name = "naga"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2bf919621e7975acb27d881bae2fb993e0d45c8e0446e85e6272971e00dc8df"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -13690,7 +13691,8 @@ dependencies = [
 [[package]]
 name = "wgpu"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76e8840e1ba2881d4cbb18d2147627a56af426ff064c0401eb0c8410c6325d07"
 dependencies = [
  "arrayvec",
  "bitflags 2.13.1",
@@ -13719,7 +13721,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f519832254e56965a9940c4af57dcb75f702b6f6fa4a0b172f685395843a4d7"
 dependencies = [
  "arrayvec",
  "bit-set 0.9.1",
@@ -13751,7 +13754,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-apple"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5e39e26c4c0e07589e67d18546cf79ff45383659fc72fca4dd293358a0347f3"
 dependencies = [
  "wgpu-hal",
 ]
@@ -13759,7 +13763,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-emscripten"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01e09be551dc939498bdd5f6b2c66e55ab275dad25825267a08605a80fc9f0af"
 dependencies = [
  "wgpu-hal",
 ]
@@ -13767,7 +13772,8 @@ dependencies = [
 [[package]]
 name = "wgpu-core-deps-windows-linux-android"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e592c1bbef6ad047647ae6e666ebd8cee7a32bb4544d9700ec96cbf73230257"
 dependencies = [
  "wgpu-hal",
 ]
@@ -13793,7 +13799,8 @@ dependencies = [
 [[package]]
 name = "wgpu-hal"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97ace1c17727311c22a46e4e3faf56ea6de81af99dcc839bdfb54857b94d448d"
 dependencies = [
  "android_system_properties",
  "arrayvec",
@@ -13846,7 +13853,8 @@ dependencies = [
 [[package]]
 name = "wgpu-naga-bridge"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95226013f547544b223281cd16a4fb549aa9dcb562adbda0faae4c73ffbbc161"
 dependencies = [
  "naga 29.0.4",
  "wgpu-types",
@@ -13855,7 +13863,8 @@ dependencies = [
 [[package]]
 name = "wgpu-types"
 version = "29.0.4"
-source = "git+https://github.com/lexoliu/wgpu?branch=mali-negative-viewport#3b9bdf1c8aa5193ca7766a31e665f1d689dfd2b6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84bf84cd9ca8ca45e2b223a3868f1adf9bfc0c66aeac212e76ee7e40fdadf8f5"
 dependencies = [
  "bitflags 2.13.1",
  "bytemuck",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -438,14 +438,3 @@ vello_sparse_shaders = { git = "https://github.com/lexoliu/vello", rev = "d68d9e
 # `vello_hybrid`'s text API takes glyphs from `glifo`, which that repo also
 # carries by path; the same rev keeps one `Glyph` type in the graph.
 glifo = { git = "https://github.com/lexoliu/vello", rev = "d68d9e9825bcd1ffee762323881c13a2e7a3f639" }
-
-# Arm's proprietary Vulkan driver (r54p2 on Pixel 9 Pro / Android 16)
-# rasterizes as if viewport heights were positive, ignoring the negative-height
-# viewport wgpu uses to flip Y, so every render pass comes out upside down.
-# This branch flips Y in the vertex shader on that driver instead; drop the
-# patch when upstream ships an equivalent workaround.
-wgpu = { git = "https://github.com/lexoliu/wgpu", branch = "mali-negative-viewport" }
-wgpu-core = { git = "https://github.com/lexoliu/wgpu", branch = "mali-negative-viewport" }
-wgpu-hal = { git = "https://github.com/lexoliu/wgpu", branch = "mali-negative-viewport" }
-wgpu-types = { git = "https://github.com/lexoliu/wgpu", branch = "mali-negative-viewport" }
-naga = { git = "https://github.com/lexoliu/wgpu", branch = "mali-negative-viewport" }


### PR DESCRIPTION
Fixes #240

Removes the `lexoliu/wgpu` `mali-negative-viewport` `[patch.crates-io]` block (wgpu, wgpu-core, wgpu-hal, wgpu-types, naga) so the nine wgpu crates come from crates.io again; `Cargo.lock` changes only their `source` lines.

**Evidence (Pixel 9 Pro, Android 16, Vulkan, Mali r54p2).** Same app (the HDR flame `GpuSurface` example, a fullscreen render-pass pipeline with bloom and tonemap), built and installed through `water run --platform android`, screenshot with `screencap`:

| run | orientation | logcat |
| --- | --- | --- |
| with fork (current dev) | upright | clean |
| without fork, first capture | upright; one transient frame showed noise on one triangle of the fullscreen pass, gone in the next two captures | clean, no `VK_ERROR`, no device loss |
| without fork, later captures (×2) | upright, identical to the fork run | clean |

The upside-down frames that motivated the fork were shaderloom's `ADJUST_COORDINATE_SPACE` flip stacked on wgpu's own negative-height viewport (#239); with #239 fixed the driver honours the viewport and the fork is dead weight.

Host: `cargo check --locked -p hydrolysis` passes on the new lock.
