### PR TITLE
fix(ci): check out submodules in the dependency check and fail on tooling errors

### DIFF
--- a/.github/workflows/dep-check.yml
+++ b/.github/workflows/dep-check.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          submodules: recursive
 
       - name: Detect project type
         id: detect
@@ -40,8 +42,18 @@ jobs:
         if: steps.detect.outputs.type == 'rust'
         run: |
           cargo install cargo-outdated --locked
-          cargo outdated -R --exit-code 1 > outdated.txt 2>&1 || true
+          # Exit code 1 means "something is outdated"; anything else is a
+          # tooling failure and must fail the job instead of being filed as
+          # the outdated list.
+          set +e
+          cargo outdated -R --exit-code 1 > outdated.txt 2>&1
+          rc=$?
+          set -e
           cat outdated.txt
+          if [ "$rc" -gt 1 ]; then
+            echo "cargo outdated failed with exit code $rc" >&2
+            exit "$rc"
+          fi
 
       - name: Setup Node
         if: steps.detect.outputs.type == 'node'


### PR DESCRIPTION
Fixes #195

The weekly dependency check checked out the superproject without submodules, so `cargo outdated` failed loading the `kit/` path dependencies and `|| true` filed the error text as the outdated list (that is what #195 contains). Now: `submodules: recursive` on checkout, and any exit code other than cargo-outdated's own `1` fails the job.

Validated with actionlint. After merge I will dispatch the workflow once so #195 is rewritten (or closed) by a real run.
