### PR TITLE
feat(text): share one font collection through the environment

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13149,6 +13149,7 @@ dependencies = [
  "waterui-layout",
  "waterui-str",
  "waterui-testing",
+ "waterui-text",
  "wgpu",
 ]
 
@@ -13342,6 +13343,7 @@ dependencies = [
  "executor-core",
  "hydrolysis-m3",
  "nami",
+ "parley",
  "pulldown-cmark",
  "smallvec",
  "syntect",

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -73,7 +73,10 @@ waterui-navigation.workspace = true
 # Default features off: the shape crate's default is a wgpu-backed morph
 # renderer, and dew's graph is GPU-free by design.
 waterui-shape = { workspace = true, default-features = false }
-waterui-text.workspace = true
+# `font-collection` for the one `parley` collection this renderer shapes with
+# and installs into the environment. Not `system-fonts`: the faces come from
+# the board, and a firmware build has no system font source at all.
+waterui-text = { workspace = true, features = ["font-collection"] }
 nami.workspace = true
 # FrameWork and ChipBudget serialize into the performance report. The
 # workspace pins serde without default features, which suits a firmware graph.

--- a/backends/dew/src/dispatch.rs
+++ b/backends/dew/src/dispatch.rs
@@ -248,6 +248,14 @@ impl DewRenderer {
         self.signals.clone()
     }
 
+    /// The application's font collection: the one this renderer shapes text
+    /// with, which the runtime installs into the environment so a self-drawn
+    /// component that typesets text itself uses the same faces.
+    #[must_use]
+    pub fn fonts(&self) -> waterui_text::FontCollection {
+        self.state.borrow().fonts()
+    }
+
     pub(crate) const fn set_accessibility_enabled(&mut self, enabled: bool) {
         self.accessibility_enabled = enabled;
     }

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -83,6 +83,11 @@ impl<B: Board> DewRuntime<B> {
         let (width, height) = board.display().size();
         let mut renderer = DewRenderer::new(signals, fonts);
         renderer.set_accessibility_enabled(board.supports_accessibility());
+        // The board's fonts, shared rather than duplicated: a self-drawn
+        // component that typesets text itself reads this collection out of the
+        // environment and shapes against the very faces the board supplied.
+        let mut env = env;
+        renderer.fonts().install(&mut env);
         Self {
             renderer,
             painter: Painter::new(render_settings),

--- a/backends/dew/src/text.rs
+++ b/backends/dew/src/text.rs
@@ -18,6 +18,7 @@ use nami::Signal;
 use skrifa::prelude::{FontRef, GlyphId, LocationRef, MetadataProvider, Size};
 use waterui_core::Environment;
 use waterui_graphics::color::ResolvedColor;
+use waterui_text::FontCollection;
 use waterui_text::font::{Font, FontWeight, ResolvedFont};
 use waterui_text::styled::{Style, StyledStr};
 
@@ -30,7 +31,11 @@ use crate::theme;
 ///
 /// One per renderer; rebuilding it is expensive (font enumeration).
 pub struct DewState {
-    font_cx: parley::FontContext,
+    /// The application's font collection, shared with the environment rather
+    /// than owned outright: a self-drawn component that typesets text itself —
+    /// a formula, a canvas — shapes against exactly these faces instead of
+    /// building a second collection of its own.
+    fonts: FontCollection,
     layout_cx: parley::LayoutContext<[u8; 4]>,
     /// Whether the collection holds any face at all. Shaping against an
     /// empty collection silently produces no glyphs, so it fails fast
@@ -350,10 +355,10 @@ impl DewState {
             }
         };
         Self {
-            font_cx: parley::FontContext {
+            fonts: FontCollection::new(parley::FontContext {
                 collection,
                 source_cache: parley::fontique::SourceCache::default(),
-            },
+            }),
             layout_cx: parley::LayoutContext::new(),
             has_fonts,
             work: FrameWork::ZERO,
@@ -374,6 +379,12 @@ impl DewState {
              FontSources::bundled(&[include_bytes!(\"YourFont.ttf\")]) from the \
              board (or register fonts on HostBoard::with_font in tests)."
         );
+    }
+
+    /// The application's font collection, for the host to install into the
+    /// environment so self-drawn components shape against the same faces.
+    pub(crate) fn fonts(&self) -> FontCollection {
+        self.fonts.clone()
     }
 
     /// Takes the work accumulated since the previous call.
@@ -407,11 +418,14 @@ impl DewState {
     ) -> parley::Layout<[u8; 4]> {
         self.assert_has_fonts();
         let font = Font::default().resolve(env).get();
-        let mut builder = self
-            .layout_cx
-            .ranged_builder(&mut self.font_cx, text, 1.0, true);
-        push_layout_defaults(&mut builder, &font, brush);
-        let mut layout = builder.build(text);
+        let Self {
+            fonts, layout_cx, ..
+        } = self;
+        let mut layout = fonts.use_fonts(|font_cx| {
+            let mut builder = layout_cx.ranged_builder(font_cx, text, 1.0, true);
+            push_layout_defaults(&mut builder, &font, brush);
+            builder.build(text)
+        });
         layout.break_all_lines(max_width);
         layout.align(
             parley::Alignment::Start,
@@ -445,16 +459,19 @@ impl DewState {
         self.assert_has_fonts();
 
         let default_font = Font::default().resolve(env).get();
-        let mut builder = self
-            .layout_cx
-            .ranged_builder(&mut self.font_cx, &plain, 1.0, true);
-        push_layout_defaults(&mut builder, &default_font, default_brush);
+        let Self {
+            fonts, layout_cx, ..
+        } = self;
+        let mut layout = fonts.use_fonts(|font_cx| {
+            let mut builder = layout_cx.ranged_builder(font_cx, &plain, 1.0, true);
+            push_layout_defaults(&mut builder, &default_font, default_brush);
 
-        for (range, style) in spans {
-            push_span_style(&mut builder, style, env, range);
-        }
+            for (range, style) in spans {
+                push_span_style(&mut builder, style, env, range);
+            }
 
-        let mut layout = builder.build(&plain);
+            builder.build(&plain)
+        });
         layout.break_all_lines(max_width);
         layout.align(
             parley::Alignment::Start,

--- a/backends/gtk/src/app.rs
+++ b/backends/gtk/src/app.rs
@@ -118,10 +118,11 @@ impl GtkApp {
     /// Panics if the GPU runtime cannot be created.
     #[must_use = "the returned value is the process exit status"]
     pub fn run<V: View + Clone + 'static>(self, view: V, env: Environment) -> i32 {
-        // `env` is only mutated when the system WebView bridge installs its
-        // controller into it.
-        #[cfg(feature = "webview-system")]
         let mut env = env;
+        // GTK draws text with Pango and owns no `parley` collection, so a
+        // component that typesets text itself gets the system's fonts here,
+        // once for the application rather than once per view.
+        waterui_text::install_system_font_collection(&mut env);
         #[cfg(feature = "webview-system")]
         ensure_webview_controller(&mut env);
         let env = env;
@@ -165,10 +166,11 @@ impl GtkApp {
     #[must_use = "the returned value is the process exit status"]
     pub fn run_app(self, waterui_app: App) -> i32 {
         let (windows, _menu_bar, env) = waterui_app.into_parts();
-        // `env` is only mutated when the system WebView bridge installs its
-        // controller into it.
-        #[cfg(feature = "webview-system")]
         let mut env = env;
+        // GTK draws text with Pango and owns no `parley` collection, so a
+        // component that typesets text itself gets the system's fonts here,
+        // once for the application rather than once per view.
+        waterui_text::install_system_font_collection(&mut env);
         let main_window = windows
             .into_iter()
             .next()

--- a/backends/hydrolysis/Cargo.toml
+++ b/backends/hydrolysis/Cargo.toml
@@ -22,7 +22,10 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 nami.workspace = true
 waterui-graphics = { workspace = true, features = ["gpu"] }
 shaderloom.workspace = true
-waterui-text.workspace = true
+# `font-collection` for the one `parley` collection this runner builds and
+# installs into the environment; the faces come from the resource loader and
+# the system source `parley/system` provides, so `system-fonts` is not needed.
+waterui-text = { workspace = true, features = ["font-collection"] }
 waterui-icon.workspace = true
 waterui-shape.workspace = true
 waterui-map.workspace = true

--- a/backends/hydrolysis/src/runner/fonts.rs
+++ b/backends/hydrolysis/src/runner/fonts.rs
@@ -4,8 +4,18 @@
 //! Noto Sans families). Classification and fallback installation are shared by the
 //! native loader (which scans `resources/fonts` directories) and the web
 //! loader in [`super::web_runner`] (which fetches fonts from a manifest).
+//!
+//! The result is built **once per application**, installed into the root
+//! environment as the shared [`FontCollection`], and every window's renderer is
+//! seeded from it by [`seed_renderer`]. Building it per window meant scanning
+//! the resource directories and enumerating the system's fonts again for each
+//! one, and a self-drawn component reading the environment would have had no
+//! single collection to read.
 
 use parley::fontique::{Collection, FallbackKey, FamilyId, FontInfo, GenericFamily, Script};
+use waterui_text::FontCollection;
+
+use crate::renderer::HydrolysisRenderer;
 
 /// Font-family buckets recognized from WaterUI's bundled resource fonts.
 #[derive(Default)]
@@ -94,7 +104,7 @@ impl ResourceFontFamilies {
 /// script should say so loudly rather than silently depending on the host's
 /// fallback set.
 #[cfg(any(test, feature = "testing"))]
-pub(crate) fn install_deterministic_test_fonts(renderer: &mut crate::renderer::HydrolysisRenderer) {
+pub(crate) fn deterministic_test_fonts() -> parley::FontContext {
     use parley::fontique::{Blob, CollectionOptions};
     use std::sync::Arc;
 
@@ -117,11 +127,13 @@ pub(crate) fn install_deterministic_test_fonts(renderer: &mut crate::renderer::H
         ),
     ];
 
-    let font_cx = renderer.state_mut().text_fonts_mut();
-    font_cx.collection = Collection::new(CollectionOptions {
-        system_fonts: false,
-        ..CollectionOptions::default()
-    });
+    let mut font_cx = parley::FontContext {
+        collection: Collection::new(CollectionOptions {
+            system_fonts: false,
+            ..CollectionOptions::default()
+        }),
+        source_cache: parley::fontique::SourceCache::default(),
+    };
     let mut resource_fonts = ResourceFontFamilies::default();
     for (name, bytes) in FONTS {
         let families = font_cx
@@ -130,12 +142,13 @@ pub(crate) fn install_deterministic_test_fonts(renderer: &mut crate::renderer::H
         resource_fonts.classify(name, &families);
     }
     resource_fonts.install(&mut font_cx.collection);
+    font_cx
 }
 
-/// Register every `.ttf`/`.otf` under the app's `resources/fonts` directories
-/// and install the recognized script fallbacks.
+/// The system's fonts plus every `.ttf`/`.otf` under the app's `resources/fonts`
+/// directories, with the recognized script fallbacks installed.
 #[cfg(not(target_arch = "wasm32"))]
-pub(super) fn load_native_resource_fonts(renderer: &mut crate::renderer::HydrolysisRenderer) {
+pub(super) fn native_resource_fonts() -> parley::FontContext {
     use parley::fontique::Blob;
     use std::sync::Arc;
 
@@ -161,7 +174,7 @@ pub(super) fn load_native_resource_fonts(renderer: &mut crate::renderer::Hydroly
         }
     }
 
-    let font_cx = renderer.state_mut().text_fonts_mut();
+    let mut font_cx = parley::FontContext::new();
     let mut resource_fonts = ResourceFontFamilies::default();
     for root in roots {
         if !root.exists() {
@@ -215,4 +228,15 @@ pub(super) fn load_native_resource_fonts(renderer: &mut crate::renderer::Hydroly
         }
     }
     resource_fonts.install(&mut font_cx.collection);
+    font_cx
+}
+
+/// Gives `renderer` the application's fonts to shape with.
+///
+/// Every window shapes against the one collection the runner installed, so a
+/// popup opened later measures text exactly as the window that opened it does.
+/// The renderer keeps its own copy because it shapes across worker threads and
+/// `parley`'s contexts are not `Sync`; the faces in it are the same ones.
+pub(super) fn seed_renderer(renderer: &mut HydrolysisRenderer, fonts: &FontCollection) {
+    *renderer.state_mut().text_fonts_mut() = fonts.use_fonts(|fonts| fonts.clone());
 }

--- a/backends/hydrolysis/src/runner/headless.rs
+++ b/backends/hydrolysis/src/runner/headless.rs
@@ -224,10 +224,11 @@ pub struct HeadlessRuntime {
     /// window, and each popup it later vends. Requesting a device per window
     /// made a runtime that opens a popup pay for two.
     gpu: OffscreenGpuContext,
-    /// Popup windows get their own renderer, which must shape with the same
-    /// fonts as the main one — deterministic bundled fonts under a test host,
-    /// the app's resource fonts everywhere else.
-    install_fonts: fn(&mut HydrolysisRenderer),
+    /// The application's font collection, the same one the environment carries.
+    /// Popup windows get their own renderer, which is seeded from this so it
+    /// shapes with the same faces as the main one — deterministic bundled fonts
+    /// under a test host, the app's resource fonts everywhere else.
+    fonts: FontCollection,
     local_executor: HeadlessMainThreadExecutor,
     /// Declared last so it drops after the runtime state above: consumes any
     /// still-queued spawned work while this thread's locals are intact, so no
@@ -279,7 +280,7 @@ impl HeadlessRuntime {
             content,
             width,
             height,
-            load_native_resource_fonts,
+            native_resource_fonts,
         )
     }
 
@@ -314,7 +315,7 @@ impl HeadlessRuntime {
             content,
             width,
             height,
-            super::fonts::install_deterministic_test_fonts,
+            super::fonts::deterministic_test_fonts,
         )
     }
 
@@ -342,7 +343,7 @@ impl HeadlessRuntime {
             content,
             width,
             height,
-            super::fonts::install_deterministic_test_fonts,
+            super::fonts::deterministic_test_fonts,
         )
     }
 
@@ -352,7 +353,7 @@ impl HeadlessRuntime {
         content: AnyViewBuilder<AnyView>,
         width: u32,
         height: u32,
-        install_fonts: fn(&mut HydrolysisRenderer),
+        build_fonts: fn() -> parley::FontContext,
     ) -> Self {
         let inspector = init_main_thread_executors();
         let inspector_probe = inspector
@@ -367,6 +368,12 @@ impl HeadlessRuntime {
         env.insert(waterui_core::ViewRenderer::new(
             crate::view_renderer::HydrolysisViewRenderer::default(),
         ));
+        // The application's fonts, built once. Every window's renderer is
+        // seeded from this collection, and a self-drawn component that typesets
+        // text itself reads it out of the environment instead of enumerating
+        // the system's fonts for itself.
+        let fonts = FontCollection::new(build_fonts());
+        fonts.clone().install(&mut env);
 
         // Headless binaries (preview, tests) have no platform runner to install
         // a tracing subscriber; honor `RUST_LOG` here so they stay debuggable.
@@ -405,7 +412,7 @@ impl HeadlessRuntime {
             let surface = platform.surface();
             HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
-        install_fonts(&mut renderer);
+        super::seed_renderer(&mut renderer, &fonts);
 
         Self {
             env,
@@ -421,7 +428,7 @@ impl HeadlessRuntime {
             ),
             pending_window_queue,
             popup_windows: Vec::new(),
-            install_fonts,
+            fonts,
             _executor_teardown: DrainExecutorOnDrop(local_executor.clone()),
             _gpu_reclaim: ReclaimGpuOnDrop(gpu.clone()),
             gpu,
@@ -444,7 +451,7 @@ impl HeadlessRuntime {
             let surface = platform.surface();
             HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
-        (self.install_fonts)(&mut renderer);
+        super::seed_renderer(&mut renderer, &self.fonts);
         RuntimeWindow::new(
             window,
             platform,

--- a/backends/hydrolysis/src/runner/mod.rs
+++ b/backends/hydrolysis/src/runner/mod.rs
@@ -45,6 +45,8 @@ use waterui_core::Native;
 #[cfg(not(target_arch = "wasm32"))]
 use waterui_core::handler::AnyViewBuilder;
 use waterui_core::view::Hook;
+#[cfg(not(target_arch = "wasm32"))]
+use waterui_text::FontCollection;
 
 mod diagnostics;
 mod fonts;
@@ -179,6 +181,12 @@ pub fn run(app: App) {
     env.insert(waterui_core::ViewRenderer::new(
         crate::view_renderer::HydrolysisViewRenderer::default(),
     ));
+    // The application's fonts, discovered once. Every window's renderer is
+    // seeded from this collection, and a self-drawn component that typesets
+    // text itself reads it out of the environment instead of enumerating the
+    // system's fonts for itself.
+    let fonts = FontCollection::new(native_resource_fonts());
+    fonts.clone().install(&mut env);
     let mut pending_windows = VecDeque::from(windows);
     while let Some(window) = pending_windows.pop_front() {
         let frame = window.frame.get();
@@ -191,7 +199,7 @@ pub fn run(app: App) {
             let surface = platform.surface();
             HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
-        load_native_resource_fonts(&mut renderer);
+        seed_renderer(&mut renderer, &fonts);
         let mut runtime = RuntimeWindow::new(window, platform, renderer, render_diagnostics_config);
         render_window(&mut runtime, &env, &mut || local_executor.drain());
         pending_windows.extend(pending_window_queue.borrow_mut().drain(..));

--- a/backends/hydrolysis/src/runner/web_runner.rs
+++ b/backends/hydrolysis/src/runner/web_runner.rs
@@ -23,6 +23,7 @@ use wasm_bindgen_futures::JsFuture;
 use waterui::app::App;
 use waterui::window::WindowState;
 use waterui_core::Environment;
+use waterui_text::FontCollection;
 use web_sys::Response;
 
 use super::fonts::ResourceFontFamilies;
@@ -85,7 +86,11 @@ async fn fetch_text(path: &str) -> String {
     })
 }
 
-async fn load_web_fonts(renderer: &mut HydrolysisRenderer) {
+/// The fonts named by the page's manifest, fetched and registered.
+///
+/// Built once for the application: the runner installs the result as the shared
+/// [`FontCollection`] and seeds the window's renderer from it.
+async fn load_web_fonts() -> parley::FontContext {
     let manifest_text = fetch_text(WEB_FONT_MANIFEST_PATH).await;
     let manifest: WebFontManifest = serde_json::from_str(&manifest_text).unwrap_or_else(|error| {
         panic!("hydrolysis web font manifest parse failed for `{WEB_FONT_MANIFEST_PATH}`: {error}")
@@ -93,7 +98,7 @@ async fn load_web_fonts(renderer: &mut HydrolysisRenderer) {
 
     let mut default_family_ids = Vec::new();
     let mut resource_fonts = ResourceFontFamilies::default();
-    let font_cx = renderer.state_mut().text_fonts_mut();
+    let mut font_cx = parley::FontContext::new();
     for font in manifest.fonts {
         let font_path = format!("fonts/{}", font.file_name);
         let font_data = fetch_bytes(&font_path).await;
@@ -116,6 +121,7 @@ async fn load_web_fonts(renderer: &mut HydrolysisRenderer) {
         manifest.default_family
     );
     resource_fonts.install(&mut font_cx.collection);
+    font_cx
 }
 
 #[derive(Clone)]
@@ -290,7 +296,13 @@ pub fn run(app: App, inspector: Option<waterui::inspector::InspectorRuntime>) {
             let surface = platform.surface();
             HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
-        load_web_fonts(&mut renderer).await;
+        // The application's fonts, fetched once. The window's renderer is
+        // seeded from this collection, and a self-drawn component that typesets
+        // text itself reads it out of the environment instead of building a
+        // collection of its own.
+        let fonts = FontCollection::new(load_web_fonts().await);
+        fonts.clone().install(&mut env);
+        super::fonts::seed_renderer(&mut renderer, &fonts);
         let runtime = RuntimeWindow::new(window, platform, renderer, render_diagnostics_config);
         let accessibility_actions = Rc::new(RefCell::new(VecDeque::new()));
         let accessibility_bridge =

--- a/backends/hydrolysis/src/runner/winit_runner.rs
+++ b/backends/hydrolysis/src/runner/winit_runner.rs
@@ -22,6 +22,7 @@ use nami::Signal;
 use waterui::app::App;
 use waterui::window::{Window, WindowState};
 use waterui_core::Environment;
+use waterui_text::FontCollection;
 
 use winit::application::ApplicationHandler;
 use winit::event::WindowEvent;
@@ -256,9 +257,16 @@ pub fn run(app: App, inspector: Option<waterui::inspector::InspectorRuntime>) {
     env.insert(waterui_core::ViewRenderer::new(
         crate::view_renderer::HydrolysisViewRenderer::default(),
     ));
+    // The application's fonts, discovered once. Every window's renderer is
+    // seeded from this collection, and a self-drawn component that typesets
+    // text itself reads it out of the environment instead of enumerating the
+    // system's fonts for itself.
+    let fonts = FontCollection::new(super::native_resource_fonts());
+    fonts.clone().install(&mut env);
     let window_icon = load_staged_window_icon();
     let mut runner = WinitRunner {
         env,
+        fonts,
         window_icon,
         pending_windows: windows
             .into_iter()
@@ -284,6 +292,9 @@ pub fn run(app: App, inspector: Option<waterui::inspector::InspectorRuntime>) {
 
 struct WinitRunner {
     env: Environment,
+    /// The application's font collection, the same one the environment carries.
+    /// Every window's renderer is seeded from it.
+    fonts: FontCollection,
     /// Taskbar/window icon staged by the water CLI next to the asset bundle.
     /// X11 and Windows honor it; macOS uses the bundle's icns and Wayland
     /// resolves icons through the desktop entry instead.
@@ -432,7 +443,7 @@ impl WinitRunner {
             let surface = platform.surface();
             HydrolysisRenderer::new(surface.adapter(), surface.device())
         };
-        super::load_native_resource_fonts(&mut renderer);
+        super::seed_renderer(&mut renderer, &self.fonts);
         let mut runtime =
             RuntimeWindow::new(window, platform, renderer, self.render_diagnostics_config);
         let _ = pump_window_semantics(&mut runtime, &self.env);

--- a/components/foundation/text/Cargo.toml
+++ b/components/foundation/text/Cargo.toml
@@ -21,6 +21,14 @@ syntect = { version = "5", default-features = false, features = ["default-themes
 two-face = { version = "0.5", default-features = false, features = ["syntect-fancy"], optional = true }
 pulldown-cmark = { version = "0.13", optional = true }
 smallvec.workspace = true
+# The font database behind `collection::FontCollection`, the one collection a
+# host installs and every self-drawing text component shares. Optional, and off
+# by default: an application whose text is drawn by the platform's own engine
+# never reaches for a `parley` collection and must not carry the font stack
+# behind it. `libm` rather than `std` because the collection is equally the one
+# an embedded renderer installs; a build that also enables `parley/std` gets
+# std's implementations regardless.
+parley = { workspace = true, optional = true, features = ["libm"] }
 # `Code`, the fenced-code widget, composes its block out of the layout
 # primitives and reports clipboard failures through `tracing`. Both sit behind
 # `highlight`, the feature the widget itself is behind.
@@ -67,6 +75,16 @@ highlight = [
 # Markdown parsing: `StyledStr::from_markdown` and the `pulldown-cmark` types
 # its inline builder is driven by.
 markdown = ["dep:pulldown-cmark"]
+# `collection::FontCollection`: the one `parley` font collection a host installs
+# into the environment and every component that shapes or typesets text itself
+# reads back out. Turned on by those components (`waterui-math` and friends),
+# not by applications.
+font-collection = ["dep:parley"]
+# Discovering the platform's fonts, which is how a host that owns no font stack
+# of its own — the native Apple, Android and GTK backends — obtains the
+# collection it installs. A renderer that registers its own faces (hydrolysis,
+# dew) installs those instead and leaves this off.
+system-fonts = ["font-collection", "parley/system"]
 
 [dev-dependencies]
 waterui = { path = "../../.." }
@@ -76,7 +94,7 @@ hydrolysis-m3 = { path = "../../../backends/hydrolysis_m3" }
 # This crate's own tests cover the Markdown parser, which is not in `default`.
 # A dev-dependency on itself turns the feature on for this crate's test targets
 # without turning it on for anything that depends on the crate.
-waterui-text = { path = ".", features = ["markdown"] }
+waterui-text = { path = ".", features = ["markdown", "system-fonts"] }
 
 [lints]
 workspace = true

--- a/components/foundation/text/README.md
+++ b/components/foundation/text/README.md
@@ -218,7 +218,19 @@ let highlighted = highlight_text(Language::Rust, &code, &mut highlighter);
 
 ## Features
 
-This crate has no optional features. All functionality is included by default.
+- `highlight` (default) — `DefaultHighlighter`, the bundled syntect/two-face
+  syntax highlighter, and the `Code` fenced-code widget built on it.
+- `markdown` — `StyledStr::from_markdown` and the `pulldown-cmark` grammar
+  behind it.
+- `font-collection` — `FontCollection`, the one `parley` font collection a host
+  installs into the `Environment` and every component that shapes or typesets
+  text itself reads back out. Turned on by those components, not by
+  applications: text drawn by the platform's own engine never reaches for it,
+  and a build that does not need it carries neither the type nor the font stack
+  behind it.
+- `system-fonts` — discovering the platform's fonts, which is how a host that
+  owns no font stack of its own obtains the collection it installs through
+  `install_system_font_collection`.
 
 ## Dependencies
 

--- a/components/foundation/text/src/collection.rs
+++ b/components/foundation/text/src/collection.rs
@@ -1,0 +1,226 @@
+//! The one font collection an application shapes and typesets with.
+//!
+//! A [`parley::FontContext`] is a database of every face the process can reach.
+//! Building one discovers the system's fonts, which is neither cheap nor
+//! something a view should be doing: a page with a dozen formulas used to run a
+//! dozen independent font enumerations and hold a dozen collections alive,
+//! because each component built its own.
+//!
+//! So the collection is a resource the *host* owns, exactly like the theme's
+//! font slots: whoever drives the event loop installs one into the root
+//! [`Environment`] at startup, and every component that has to shape or
+//! typeset something reads it back out with [`FontCollection::from_env`]. A
+//! component that finds none installed panics and names the host's
+//! responsibility — it does not quietly build a second collection, because
+//! that is the defect this module exists to remove.
+//!
+//! # Ownership
+//!
+//! `WaterUI` is a main-thread UI framework and `parley`'s contexts are not
+//! `Sync`, so the collection is shared as single-threaded interior mutability
+//! and handed out mutably for the duration of one call. A renderer that shapes
+//! text across worker threads keeps its own thread-safe arrangement and
+//! installs a collection carrying the same registered faces.
+
+use alloc::rc::Rc;
+use core::cell::RefCell;
+use core::fmt::{self, Debug, Formatter};
+
+use parley::FontContext;
+use waterui_core::Environment;
+
+/// The message a component reports when the host installed no collection.
+///
+/// It names the host rather than the component, because a missing collection is
+/// never something the view could have done differently.
+const NOT_INSTALLED: &str = "no font collection is installed in the environment: \
+     the host must install exactly one at startup with `FontCollection::install`, \
+     before it hands the environment to the application";
+
+/// The application's shared font collection.
+///
+/// Cloning it shares the one collection rather than copying it, so a component
+/// may keep a handle for as long as it draws.
+#[derive(Clone)]
+pub struct FontCollection(Rc<RefCell<FontContext>>);
+
+impl Debug for FontCollection {
+    fn fmt(&self, formatter: &mut Formatter<'_>) -> fmt::Result {
+        // `parley::FontContext` is not `Debug`, and its contents — every face
+        // the process can reach — would not be readable if it were. The
+        // identity is the useful part: it is what tells two handles apart.
+        formatter
+            .debug_struct("FontCollection")
+            .field("identity", &self.identity())
+            .finish()
+    }
+}
+
+impl FontCollection {
+    /// Shares `fonts` as the application's collection.
+    #[must_use]
+    pub fn new(fonts: FontContext) -> Self {
+        Self(Rc::new(RefCell::new(fonts)))
+    }
+
+    /// The system's fonts, discovered now.
+    ///
+    /// This is the collection a host with no font stack of its own installs —
+    /// the native Apple, Android and GTK backends draw text with the platform's
+    /// own text engine and own no `parley` collection, so the one a self-drawn
+    /// component reads is discovered here, once per application.
+    #[cfg(feature = "system-fonts")]
+    #[must_use]
+    pub fn system() -> Self {
+        Self::new(FontContext::new())
+    }
+
+    /// Installs this collection as the one the application shapes with.
+    ///
+    /// Called by the host on the root environment, before the application's own
+    /// views are built. Installing twice replaces the first, which is a host
+    /// bug rather than a supported way to swap collections mid-flight.
+    pub fn install(self, env: &mut Environment) {
+        env.insert(self);
+    }
+
+    /// The collection installed in `env`.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the host installed none. There is deliberately no fallback:
+    /// building one here would be the per-component enumeration this type
+    /// exists to replace, and it would shape against the system's faces while
+    /// the rest of the window shapes against the host's registered ones.
+    #[must_use]
+    pub fn from_env(env: &Environment) -> Self {
+        env.get::<Self>().cloned().expect(NOT_INSTALLED)
+    }
+
+    /// Runs `use_fonts` against the collection.
+    ///
+    /// # Panics
+    ///
+    /// Panics when called from inside another `use_fonts`: the collection is
+    /// handed out exclusively, and shaping that re-enters shaping is a bug in
+    /// the caller.
+    pub fn use_fonts<R>(&self, use_fonts: impl FnOnce(&mut FontContext) -> R) -> R {
+        use_fonts(&mut self.0.borrow_mut())
+    }
+
+    /// A stable identity for the collection behind this handle.
+    ///
+    /// Two handles onto the same collection report the same value; handles onto
+    /// two different collections never do.
+    #[must_use]
+    pub fn identity(&self) -> usize {
+        Rc::as_ptr(&self.0) as usize
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use waterui_core::Environment;
+
+    use super::{FontCollection, NOT_INSTALLED};
+
+    /// An empty collection: these tests are about sharing, not about faces, and
+    /// enumerating the runner's fonts would make them slow and host-dependent.
+    fn empty() -> FontCollection {
+        FontCollection::new(parley::FontContext {
+            collection: parley::fontique::Collection::new(parley::fontique::CollectionOptions {
+                system_fonts: false,
+                ..parley::fontique::CollectionOptions::default()
+            }),
+            source_cache: parley::fontique::SourceCache::default(),
+        })
+    }
+
+    /// Two components reading the environment get the same collection, not two
+    /// copies of one. This is the whole point of the type: the defect it
+    /// replaces was every component holding a collection of its own.
+    #[test]
+    fn two_components_share_one_collection() {
+        let mut env = Environment::new();
+        empty().install(&mut env);
+
+        let first = FontCollection::from_env(&env);
+        let second = FontCollection::from_env(&env);
+
+        assert_eq!(
+            first.identity(),
+            second.identity(),
+            "every component must read back the one collection the host installed"
+        );
+    }
+
+    /// A child scope sees the collection its parent installed.
+    #[test]
+    fn an_extended_environment_keeps_the_collection() {
+        let mut env = Environment::new();
+        let installed = empty();
+        let identity = installed.identity();
+        installed.install(&mut env);
+
+        let child = env.extending(7_u32);
+
+        assert_eq!(FontCollection::from_env(&child).identity(), identity);
+    }
+
+    /// Two collections are two collections. Without this, the sharing test
+    /// above would pass against a type that handed out a fresh one every time.
+    #[test]
+    fn separate_collections_are_told_apart() {
+        assert_ne!(empty().identity(), empty().identity());
+    }
+
+    /// Nothing installed is a host bug, and it is reported as one rather than
+    /// papered over with a collection built on the spot.
+    #[test]
+    #[should_panic(expected = "no font collection is installed in the environment")]
+    fn reading_an_uninstalled_collection_names_the_host() {
+        let _ = FontCollection::from_env(&Environment::new());
+    }
+
+    /// The mutable loan is what a shaping call takes, and it is the same
+    /// collection every time.
+    #[test]
+    fn the_loan_reaches_the_installed_collection() {
+        let collection = empty();
+        let first = collection.use_fonts(|fonts| fonts.collection.family_names().count());
+        let second = collection.use_fonts(|fonts| fonts.collection.family_names().count());
+
+        assert_eq!(first, second);
+    }
+
+    /// The message a component panics with has to say whose job the collection
+    /// is, since the view that noticed could never have supplied it.
+    #[test]
+    fn the_panic_names_the_hosts_responsibility() {
+        assert!(NOT_INSTALLED.contains("the host must install"));
+    }
+
+    /// A host with no font stack of its own gets one from the installer.
+    #[test]
+    fn the_installer_gives_a_bare_host_a_collection() {
+        let mut env = Environment::new();
+        crate::install_system_font_collection(&mut env);
+
+        let installed = FontCollection::from_env(&env).identity();
+        assert_eq!(FontCollection::from_env(&env).identity(), installed);
+    }
+
+    /// A host that owns its own font stack installs that one, and the installer
+    /// leaves it alone rather than enumerating the system's fonts over the top.
+    #[test]
+    fn the_installer_yields_to_a_collection_the_host_already_owns() {
+        let mut env = Environment::new();
+        let owned = empty();
+        let identity = owned.identity();
+        owned.install(&mut env);
+
+        crate::install_system_font_collection(&mut env);
+
+        assert_eq!(FontCollection::from_env(&env).identity(), identity);
+    }
+}

--- a/components/foundation/text/src/lib.rs
+++ b/components/foundation/text/src/lib.rs
@@ -12,6 +12,9 @@ extern crate alloc;
 
 #[cfg(feature = "highlight")]
 pub mod code;
+/// The one font collection an application shapes and typesets with.
+#[cfg(feature = "font-collection")]
+pub mod collection;
 /// Font utilities and definitions.
 pub mod font;
 /// Syntax highlighting support.
@@ -23,5 +26,37 @@ pub mod styled;
 pub mod text;
 #[cfg(feature = "highlight")]
 pub use code::{Code, CodeConfig, OnCopied, code};
+#[cfg(feature = "font-collection")]
+pub use collection::FontCollection;
 pub use styled::StyledStr;
 pub use text::{Formatter, IntoText, Text, TextConfig, text};
+
+/// Installs the system's fonts as the application's font collection, for a host
+/// that owns no font stack of its own.
+///
+/// The native backends — Apple, Android, GTK — draw text with the platform's
+/// own text engine and never build a `parley` collection, so a component that
+/// typesets text itself (a formula, a canvas, a vector map) has no host
+/// collection to share. This gives them one, discovered once for the
+/// application rather than once per view.
+///
+/// It installs nothing at all when this build has no collection to install,
+/// which is exactly when nothing in the dependency graph could read one: the
+/// `system-fonts` feature is turned on by the components that shape text
+/// themselves, so a build without them carries neither the collection type nor
+/// the font stack behind it.
+///
+/// A collection already installed is left alone, so a host that owns its own
+/// font stack may install that one and call this too, in either order.
+#[allow(
+    clippy::missing_const_for_fn,
+    reason = "the body is empty only in the feature configuration being linted; a build that can consume a font collection installs one here"
+)]
+pub fn install_system_font_collection(env: &mut waterui_core::Environment) {
+    #[cfg(feature = "system-fonts")]
+    if env.get::<collection::FontCollection>().is_none() {
+        collection::FontCollection::system().install(env);
+    }
+    #[cfg(not(feature = "system-fonts"))]
+    let _ = env;
+}

--- a/components/visual/math/Cargo.toml
+++ b/components/visual/math/Cargo.toml
@@ -16,8 +16,15 @@ waterui-graphics.workspace = true
 waterui-layout.workspace = true
 waterui-str.workspace = true
 nami.workspace = true
-# `system` brings in the font collection the math family is looked up through.
-parley = { workspace = true, features = ["system"] }
+# The math family is looked up in the application's shared font collection,
+# which the host installs and this crate only reads: `parley` is here for the
+# `FontContext` that collection hands out, not to discover fonts.
+parley = { workspace = true, features = ["std"] }
+# `system-fonts` is what lets a host with no font stack of its own — the native
+# Apple, Android and GTK backends — install a collection at all. A formula is
+# typeset from real faces, so a build carrying this component must be able to
+# reach them.
+waterui-text = { workspace = true, features = ["system-fonts"] }
 kurbo.workspace = true
 peniko.workspace = true
 ttf-parser.workspace = true

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -13,6 +13,7 @@ use waterui_graphics::color::{Color, ForegroundColor, ResolvedColor};
 use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, invalidate_on_change};
 use waterui_layout::frame::Frame;
 use waterui_str::Str;
+use waterui_text::FontCollection;
 
 use crate::ast::{MathItem, MathStyle};
 use crate::font::MathFont;
@@ -203,6 +204,10 @@ pub fn resolve_font(fonts: &mut FontContext, family: &str) -> Result<FontData, M
 /// [`Math`] wraps this, and a backend that wants to draw a formula into a scene
 /// it already owns can use it directly rather than going through a view.
 pub struct MathContent {
+    /// The application's font collection, installed by the host and shared with
+    /// every other component that shapes or typesets text. The math family is
+    /// looked up in it; this content never builds one of its own.
+    fonts: FontCollection,
     source: Computed<Str>,
     style: MathStyle,
     font_size: f32,
@@ -216,7 +221,7 @@ pub struct MathContent {
     source_guard: Option<BoxWatcherGuard>,
 }
 
-/// The font collection and the last measurement, shared by drawing and layout.
+/// The resolved face and the last measurement, shared by drawing and layout.
 ///
 /// Measuring a formula *is* laying it out, and a container probes a child
 /// several times in one pass, so the answer is kept. A plain `RefCell` is the
@@ -224,7 +229,6 @@ pub struct MathContent {
 /// thread that draws.
 #[derive(Default)]
 struct MathCache {
-    fonts: Option<FontContext>,
     font: Option<FontData>,
     /// The formula last measured and the box it occupies.
     measured: Option<(Str, Size)>,
@@ -234,9 +238,13 @@ impl MathContent {
     /// Scene content drawing `source` at `font_size` in `style`.
     ///
     /// The family must carry an OpenType `MATH` table;
-    /// [`DEFAULT_MATH_FAMILY`] is the one this crate asks for by default.
+    /// [`DEFAULT_MATH_FAMILY`] is the one this crate asks for by default. It is
+    /// looked up in `fonts`, the collection the host installed for the whole
+    /// application — read it out of the environment with
+    /// [`FontCollection::from_env`] rather than building one here.
     #[must_use]
     pub fn new(
+        fonts: FontCollection,
         source: impl IntoComputed<Str>,
         font_size: f32,
         style: MathStyle,
@@ -244,6 +252,7 @@ impl MathContent {
         brush: Brush,
     ) -> Self {
         Self {
+            fonts,
             source: source.into_computed(),
             style,
             font_size,
@@ -263,9 +272,10 @@ impl MathContent {
     fn font(&self) -> Option<FontData> {
         let mut cache = self.cache.borrow_mut();
         if cache.font.is_none() {
-            let cache = &mut *cache;
-            let fonts = cache.fonts.get_or_insert_with(FontContext::new);
-            match resolve_font(fonts, self.family.as_str()) {
+            match self
+                .fonts
+                .use_fonts(|fonts| resolve_font(fonts, self.family.as_str()))
+            {
                 Ok(font) => cache.font = Some(font),
                 Err(error) => {
                     tracing::error!(%error, "math formula has no usable font");
@@ -294,8 +304,8 @@ impl SceneContent for MathContent {
             return false;
         }
 
-        // The font collection is discovered once and kept for the life of this
-        // surface, which is where per-surface resources belong.
+        // The face is resolved out of the application's collection once and
+        // kept for the life of this surface.
         let Some(font) = self.font() else {
             return false;
         };
@@ -388,6 +398,12 @@ impl SceneContent for MathContent {
 }
 
 impl View for Math {
+    /// # Panics
+    ///
+    /// Panics when the host installed no [`FontCollection`] in the environment.
+    /// A formula cannot be typeset without one, and building a second
+    /// collection here is the per-view font enumeration this component was
+    /// changed to stop doing.
     fn body(self, env: &Environment) -> impl View {
         let color = self
             .color
@@ -403,7 +419,14 @@ impl View for Math {
             |signal| Brush::Solid(to_peniko(&signal.get())),
         );
 
-        let content = MathContent::new(self.source, self.font_size, self.style, self.family, brush);
+        let content = MathContent::new(
+            FontCollection::from_env(env),
+            self.source,
+            self.font_size,
+            self.style,
+            self.family,
+            brush,
+        );
 
         // The formula's accessibility node is the leaf's own: `MathContent`
         // answers `SceneContent::accessibility_label` with the markup, which
@@ -462,10 +485,12 @@ mod tests {
 
     use nami::Binding;
     use peniko::{Brush, Color as PenikoColor};
+    use waterui_core::{Environment, View};
     use waterui_graphics::{SceneContent, SceneInvalidator};
     use waterui_str::Str;
+    use waterui_text::FontCollection;
 
-    use super::{DEFAULT_MATH_FAMILY, MathContent, accessibility_markup};
+    use super::{DEFAULT_MATH_FAMILY, Math, MathContent, accessibility_markup};
     use crate::ast::MathStyle;
     use crate::{latex, mathml};
 
@@ -479,12 +504,22 @@ mod tests {
 
     fn content(source: &Binding<Str>) -> MathContent {
         MathContent::new(
+            FontCollection::system(),
             source.clone(),
             18.0,
             MathStyle::Text,
             DEFAULT_MATH_FAMILY,
             Brush::Solid(PenikoColor::BLACK),
         )
+    }
+
+    /// A formula built where no host installed a collection says so, instead of
+    /// enumerating the system's fonts on its own — which is what it used to do,
+    /// once per view.
+    #[test]
+    #[should_panic(expected = "no font collection is installed in the environment")]
+    fn a_formula_without_a_font_collection_names_the_host() {
+        let _ = Math::new(Str::from_static("x")).body(&Environment::new());
     }
 
     /// The accessibility payload is the converter's markup, never a blank.

--- a/components/visual/math/tests/gallery.rs
+++ b/components/visual/math/tests/gallery.rs
@@ -27,6 +27,7 @@ use waterui_graphics::{
 };
 use waterui_math::ast::MathStyle;
 use waterui_math::view::{DEFAULT_MATH_FAMILY, MathContent};
+use waterui_text::FontCollection;
 
 /// Paints an opaque ground under the formula.
 ///
@@ -100,6 +101,12 @@ fn renders_the_formula_gallery_on_both_scene_engines() {
         .expect("the formula gallery requires a working GPU runtime");
     let size = OffscreenSize::try_from_pixels(560, 200).expect("gallery size must be valid");
 
+    // The one collection the gallery typesets against, standing in for the one
+    // a host installs. Discovering the system's fonts is the expensive part, so
+    // it happens here rather than per formula — which is the whole point of the
+    // collection being shared.
+    let fonts = FontCollection::system();
+
     let mut written = Vec::new();
     for (name, source) in GALLERY {
         for (engine, engine_name) in [
@@ -107,6 +114,7 @@ fn renders_the_formula_gallery_on_both_scene_engines() {
             (SceneEngine::Hybrid, "hybrid"),
         ] {
             let content = MathContent::new(
+                fonts.clone(),
                 waterui_str::Str::from(*source),
                 48.0,
                 MathStyle::Display,

--- a/ffi/src/lib.rs
+++ b/ffi/src/lib.rs
@@ -102,6 +102,7 @@ macro_rules! export {
                 let inspector = unsafe { $crate::__init() };
                 let mut env = waterui::configure_environment!(waterui::Environment::new());
                 waterui::inspector::install(&mut env, inspector);
+                $crate::__install_font_collection(&mut env);
                 $crate::__configure_native_realizations(&mut env);
                 $crate::IntoFFI::into_ffi(env)
             }
@@ -158,6 +159,22 @@ macro_rules! export {
             }
         };
     };
+}
+
+/// Installs the application's font collection, for the native backends.
+///
+/// Apple, Android and GTK draw text with the platform's own engine and own no
+/// `parley` collection, so a component that typesets text itself — a formula, a
+/// canvas, a vector map — has no host font stack to share. This gives them one,
+/// discovered once here rather than once per view.
+///
+/// It installs nothing when the application links no such component, because
+/// nothing in that build could read the collection and nothing in it carries
+/// the font stack behind one.
+#[doc(hidden)]
+#[inline]
+pub fn __install_font_collection(env: &mut waterui::Environment) {
+    waterui_text::install_system_font_collection(env);
 }
 
 /// Declares, in the environment a native backend is about to hand the app, the


### PR DESCRIPTION
Refs #230

`parley::FontContext::new()` discovers every font the process can reach.
`MathContent::build_scene` built one per `Math` view, so a page with a dozen
formulas ran a dozen independent system-font scans and held a dozen collections
alive.

## The facility

`waterui-text` gains `FontCollection` (new module `collection`, behind the
default-off `font-collection` feature): one `parley::FontContext` shared as
`Rc<RefCell<_>>` — WaterUI is a main-thread framework and parley's contexts are
not `Sync` — handed out mutably for the duration of one shaping call through
`use_fonts`. The host installs exactly one into the root `Environment`; a
component reads it back with `FontCollection::from_env`, which panics naming the
host's responsibility when none is installed, exactly as the `Body` font token
does today. There is deliberately no per-component fallback construction,
because that is the defect being removed.

The feature is default-off and turned on by the components that shape text
themselves, so an application whose text is drawn by the platform's own engine
carries neither the type nor the parley font stack behind it.

## The hosts

- **hydrolysis** built its resource-font collection per *window*, rescanning the
  resource directories and re-enumerating the system's fonts for each one. It
  now builds the collection once per application (`fonts::native_resource_fonts`
  / `deterministic_test_fonts` return a `FontContext` instead of mutating a
  renderer), installs it, and seeds every window's renderer from it with
  `fonts::seed_renderer`. The renderer keeps its own copy because it shapes
  across worker threads. That per-window duplication was pre-existing; removing
  it is what leaves one collection for the environment to carry. Covers the
  winit runner, the offscreen runner, `HeadlessRuntime` (main window and popups)
  and the web runner.
- **dew** — `DewState` now holds the `FontCollection` it shapes with, and
  `DewRuntime::new` installs that very instance, so a formula on dew typesets
  against the faces the board supplied.
- **FFI (`waterui_init`) and GTK** draw text with the platform's own text engine
  and own no parley collection, so they call
  `waterui_text::install_system_font_collection`, which discovers the system's
  fonts once per application rather than once per view. It installs nothing in a
  build whose graph contains no component that could read a collection, and
  leaves an already-installed collection alone.

## The consumer

`waterui-math` drops its own `FontContext` and its `MathCache::fonts` field, and
takes the collection through `MathContent::new`; `Math::body` reads it out of
the environment. `waterui-math` no longer asks for `parley/system` itself — it
looks a family up in the collection the host built rather than discovering
fonts — but it does enable `waterui-text/system-fonts`, which is what lets a
native host install a collection at all.

## Not in this PR

`waterui-canvas` and `waterui-map-gpu`, the other two components named in the
issue, are published crates in their own repositories now (they are consumed
here from crates.io). They cannot be migrated until a `waterui-text` carrying
`FontCollection` is released, so their move is a follow-up gated on that
release. `waterui-mermaid` holds a fourth `FontContext`, but `merman-render`
requires `Arc<dyn TextMeasurer + Send + Sync>`, which a single-threaded
collection cannot satisfy; that one needs its own design.

## Tests

- `waterui-text`: two components reading the environment get the same collection
  (pointer identity), a child scope keeps it, two collections are told apart,
  reading an uninstalled collection panics naming the host, and the system
  installer both supplies a bare host and yields to a collection the host
  already owns.
- `waterui-math`: building a formula where no collection is installed panics
  with the documented message.

## Verified

`cargo check` + `cargo clippy --all-targets -D warnings` + `cargo nextest run`
for `waterui-text`, `waterui-math`, `hydrolysis`, `waterui-dew` (plus
`--no-default-features`); clippy for `waterui-gtk` and `waterui-ffi`;
`cargo check -p waterui-ffi --features cbindgen`; `cargo test --doc` for
`waterui-text` and `waterui-math`; `cargo check --workspace --all-targets`
clean. rustfmt (edition 2024) on every changed file.

The web runner's edit could not be compiled: hydrolysis does not build for
`wasm32-unknown-unknown` on `dev` for three unrelated pre-existing reasons
(`waterkit-dialog`'s web backend calls a field as a method, `waterui-media`'s
wasm path imports `waterkit_fs` without depending on it, and
`waterui-internal`'s inspector module does not compile for wasm). The edit
mirrors the three runners that are compiled and tested.