### PR TITLE
fix(ci): report outdated dependencies with cargo upgrade --dry-run

### DIFF
--- a/.github/workflows/dep-check.yml
+++ b/.github/workflows/dep-check.yml
@@ -38,21 +38,30 @@ jobs:
         if: steps.detect.outputs.type == 'rust'
         uses: Swatinem/rust-cache@v2
 
+      - name: Install cargo-edit
+        if: steps.detect.outputs.type == 'rust'
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-edit
+
       - name: Check Rust dependencies
         if: steps.detect.outputs.type == 'rust'
         run: |
-          cargo install cargo-outdated --locked
-          # Exit code 1 means "something is outdated"; anything else is a
-          # tooling failure and must fail the job instead of being filed as
-          # the outdated list.
-          set +e
-          cargo outdated -R --exit-code 1 > outdated.txt 2>&1
-          rc=$?
-          set -e
+          # `cargo upgrade --dry-run` resolves the workspace in place, so it
+          # follows workspace inheritance and the submodule path dependencies
+          # that `cargo outdated`'s temporary copy could not. It prints one
+          # table per crate with something to bump and nothing otherwise; the
+          # per-crate progress lines and its dry-run notes are not findings.
+          cargo upgrade --dry-run --incompatible 2>&1 | tee upgrade.log \
+            | grep -vE '^\s+Checking |^note: |^warning: aborting upgrade|^\s+(git|latest|local|pinned): ' \
+            > outdated.txt || true
           cat outdated.txt
-          if [ "$rc" -gt 1 ]; then
-            echo "cargo outdated failed with exit code $rc" >&2
-            exit "$rc"
+          # The command exits 0 in a dry run whether or not anything is outdated;
+          # a resolver failure surfaces as `error:` text, which must fail the job
+          # instead of being filed as the outdated list.
+          if grep -q '^error' upgrade.log; then
+            echo "cargo upgrade failed" >&2
+            exit 1
           fi
 
       - name: Setup Node


### PR DESCRIPTION
Refs #405

cargo-outdated copies the workspace to a temp dir before resolving; there the `kit` submodule crates cannot inherit `edition` from the workspace root, so the weekly check filed a resolver error as the report even after #400 added the submodule checkout (see #405). `cargo upgrade --dry-run --incompatible` (cargo-edit, installed with taiki-e/install-action) resolves in place and prints one table per crate with something to bump; verified locally on this workspace (accesskit 0.24 → 0.25, base64 0.22 → 0.23, cookie 0.18.2). Progress lines and dry-run notes are stripped; an `error:` line fails the job. actionlint clean.
