### PR TITLE
fix(web): restore the wasm32 build of the hydrolysis web runner and check it in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -151,6 +151,53 @@ jobs:
       - name: Skill snippet compile gate
         run: cargo check -p skill_snippets --all-targets --features compile-gate-tests
 
+  # The web runner, compiled for the target it actually runs on.
+  #
+  # Every other leg builds `hydrolysis --features web` for the host, where the
+  # runner and everything else under `cfg(target_arch = "wasm32")` is compiled
+  # out — so the browser build rotted through three unrelated breakages before
+  # anyone pointed a compiler at it (#408). This is the cheapest statement that
+  # it still builds: a `cargo check` of the web runner plus the two crates whose
+  # wasm-only paths it reaches (`waterui-media` reads local photos through the
+  # kit file system there, and the kit dialog has a whole browser backend).
+  #
+  # It runs in both tiers rather than only in the nightly: a pull request
+  # touching any of those three can break it, and the check is a couple of
+  # minutes even cold, against the 90-120 minute legs beside it.
+  wasm:
+    name: wasm32
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    env:
+      # Cargo caps lints for registry dependencies, so this holds the workspace
+      # crates — and only them — to the same "no new warnings" bar as the host
+      # lint pass. `cargo check` takes no trailing rustc arguments.
+      RUSTFLAGS: -D warnings
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      # Build scripts and proc macros still compile for the host even when
+      # every library target is wasm, and this graph reaches the ones that need
+      # native headers.
+      - name: Install native dependencies
+        uses: ./.github/actions/setup-linux-deps
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: false
+          cache-on-failure: true
+      - name: Check the web runner for wasm32
+        run: |
+          cargo check --target wasm32-unknown-unknown \
+            -p hydrolysis --features hydrolysis/web \
+            -p waterui-media \
+            -p waterkit-dialog
+
   # The workspace test run, per platform. On Linux it also carries the
   # doctests, which share its build; on macOS those go to `macos-suites`, so
   # that this job is the workspace run alone — the single longest step in CI —

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13167,6 +13167,7 @@ dependencies = [
  "tracing",
  "waterkit-codec 0.1.1",
  "waterkit-dialog",
+ "waterkit-fs 0.1.1",
  "waterui",
  "waterui-controls",
  "waterui-core",

--- a/backends/hydrolysis/src/renderer/accessibility/accessibility_impl.rs
+++ b/backends/hydrolysis/src/renderer/accessibility/accessibility_impl.rs
@@ -213,6 +213,10 @@ impl AccessibilityBuilder {
     /// Nodes are registered as the tree is walked, so a child is always pushed
     /// after the parent that contains it and the last match is the innermost
     /// one — the element a user pointing at that spot means.
+    ///
+    /// Only "inspect this element" asks, and a browser page hosts no inspector
+    /// endpoint to reveal the answer in.
+    #[cfg(any(not(target_arch = "wasm32"), test))]
     pub(crate) fn node_at_point(&self, point: vello::kurbo::Point) -> Option<AccessibilityNodeId> {
         self.nodes
             .iter()

--- a/backends/hydrolysis/src/renderer/input/popup_menu.rs
+++ b/backends/hydrolysis/src/renderer/input/popup_menu.rs
@@ -659,7 +659,7 @@ impl HydrolysisRenderer {
     /// does, so an application does not have to opt in to being inspectable.
     /// A release build appends nothing, and a secondary click on something with
     /// no menu of its own goes on doing nothing.
-    #[cfg(feature = "accessibility")]
+    #[cfg(all(feature = "accessibility", not(target_arch = "wasm32")))]
     pub(crate) fn append_inspect_element_item(
         &self,
         items: &mut Vec<PopupMenuNode>,
@@ -693,8 +693,9 @@ impl HydrolysisRenderer {
     }
 
     /// Inspecting an element means naming it in the accessibility tree, so a
-    /// build without that tree has no name to send.
-    #[cfg(not(feature = "accessibility"))]
+    /// build without that tree has no name to send — and a browser page has no
+    /// inspector endpoint to send it to.
+    #[cfg(any(not(feature = "accessibility"), target_arch = "wasm32"))]
     pub(crate) fn append_inspect_element_item(
         &self,
         _items: &mut Vec<PopupMenuNode>,

--- a/backends/hydrolysis/src/runner/mod.rs
+++ b/backends/hydrolysis/src/runner/mod.rs
@@ -68,6 +68,9 @@ use fonts::*;
 #[cfg(not(target_arch = "wasm32"))]
 pub use headless::{HeadlessPumpResult, HeadlessRuntime};
 use window::*;
+// Frame and tree profiles are published to the inspector endpoint, which exists
+// only where `waterui::inspector` does.
+#[cfg(not(target_arch = "wasm32"))]
 mod inspector;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -84,8 +87,18 @@ use crate::renderer::{HydrolysisRenderer, HydrolysisWindowOrigin, KeyDelivery};
 use crate::renderer::{HydrolysisTextContextMenuMode, PopupWindowManager};
 use crate::time::Instant;
 
-fn init_main_thread_executors() -> Option<waterui::inspector::InspectorRuntime> {
+/// The global executor every runner installs before anything can spawn.
+fn init_global_executor() {
     let _ = executor_core::try_init_global_executor(native_executor::NativeExecutor::new());
+}
+
+/// Installs the global executor and prepares inspection.
+///
+/// A browser page has no transport for the inspector endpoint, so the wasm
+/// runner installs the executor alone.
+#[cfg(not(target_arch = "wasm32"))]
+fn init_main_thread_executors() -> Option<waterui::inspector::InspectorRuntime> {
+    init_global_executor();
     waterui::inspector::maybe_init_from_env("hydrolysis")
 }
 
@@ -208,7 +221,8 @@ pub fn run(app: App) {
 
 #[cfg(all(target_arch = "wasm32", feature = "web"))]
 pub fn run(app: App) {
-    web_runner::run(app, init_main_thread_executors());
+    init_global_executor();
+    web_runner::run(app);
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "winit"))]

--- a/backends/hydrolysis/src/runner/web_runner.rs
+++ b/backends/hydrolysis/src/runner/web_runner.rs
@@ -240,7 +240,7 @@ impl BrowserRunnerHandle {
     }
 }
 
-pub fn run(app: App, inspector: Option<waterui::inspector::InspectorRuntime>) {
+pub fn run(app: App) {
     wasm_bindgen_futures::spawn_local(async move {
         let schedule_frame_ref: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
         let browser_schedule = {
@@ -259,18 +259,12 @@ pub fn run(app: App, inspector: Option<waterui::inspector::InspectorRuntime>) {
             runnable_queue: runnable_queue.clone(),
             schedule_frame: browser_schedule.clone(),
         };
+        // Nothing probes the browser executor: the inspector endpoint is a TCP
+        // server the page cannot host, so no probe exists to hand it.
         let _ = try_init_local_executor(waterui::task::monitored_local_executor_with_probes(
             local_executor,
-            inspector
-                .as_ref()
-                .map(waterui::inspector::InspectorRuntime::runtime_probe),
+            None,
         ));
-        // The reactive graph is thread-confined, so its observer is installed
-        // here, on the thread that owns the loop, and lives as long as it does.
-        #[cfg(feature = "inspector-signals")]
-        let _signal_scope = inspector
-            .as_ref()
-            .map(waterui::inspector::InspectorRuntime::observe_signals);
 
         let (windows, _menu_bar, env) = app.into_parts();
         let mut windows = windows.into_iter();

--- a/backends/hydrolysis/src/runner/window.rs
+++ b/backends/hydrolysis/src/runner/window.rs
@@ -656,9 +656,13 @@ pub(super) fn render_window_with_capture<P: PlatformWindow>(
     let mut snapshot = None;
     let mut rebuilt = false;
     let profile;
-    // The scheduled mode is cleared while the scene is pumped, so record what
-    // this frame was asked to do before that happens.
+    // What the inspector is told about this frame, captured before the pump:
+    // the scheduled mode is cleared while the scene is pumped, and the elapsed
+    // total has to start before any of it runs. A browser page hosts no
+    // inspector endpoint, so neither is measured there.
+    #[cfg(not(target_arch = "wasm32"))]
     let frame_mode = runtime.mode;
+    #[cfg(not(target_arch = "wasm32"))]
     let frame_pump_started_at = Instant::now();
     {
         let diagnostics_enabled = runtime.render_diagnostics.enabled();
@@ -901,10 +905,13 @@ pub(super) fn render_window_with_capture<P: PlatformWindow>(
         runtime.platform.request_redraw();
     }
 
-    super::inspector::publish_frame(env, frame_mode, &profile, frame_pump_started_at.elapsed());
-    #[cfg(feature = "accessibility")]
-    if let Some(update) = runtime.renderer.peek_accessibility_tree_update() {
-        super::inspector::publish_tree(env, update);
+    #[cfg(not(target_arch = "wasm32"))]
+    {
+        super::inspector::publish_frame(env, frame_mode, &profile, frame_pump_started_at.elapsed());
+        #[cfg(feature = "accessibility")]
+        if let Some(update) = runtime.renderer.peek_accessibility_tree_update() {
+            super::inspector::publish_tree(env, update);
+        }
     }
 
     RenderWindowResult {

--- a/components/multimedia/media/Cargo.toml
+++ b/components/multimedia/media/Cargo.toml
@@ -38,6 +38,9 @@ zenwave = { workspace = true, features = ["rustls"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 zenwave.workspace = true
+# The browser has no `std::fs`, so a local photo URL is read back through the
+# kit's IndexedDB-backed file system instead of `blocking::unblock`.
+waterkit-fs.workspace = true
 
 [features]
 default = ["std"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@ pub mod component;
 mod interaction_support;
 pub use interaction_support::{cursor, drag_drop, gesture, interaction};
 mod runtime;
-#[cfg(feature = "inspector")]
+#[cfg(all(feature = "inspector", not(target_arch = "wasm32")))]
 pub use runtime::inspector;
 #[cfg(feature = "snackbar")]
 pub use runtime::snackbar;

--- a/src/runtime/inspector/hub.rs
+++ b/src/runtime/inspector/hub.rs
@@ -20,23 +20,9 @@ use waterui_inspector_protocol::{Channel, ChannelSet, InspectorEvent, InspectorE
 ///
 /// Deep enough to absorb a burst between dispatcher wake-ups, shallow enough
 /// that a wedged client is noticed rather than silently buffering forever.
-#[cfg_attr(
-    target_arch = "wasm32",
-    expect(
-        dead_code,
-        reason = "browsers cannot host the TCP inspector dispatcher"
-    )
-)]
 const PUBLISH_CAPACITY: usize = 8192;
 
 /// What the dispatcher thread consumes.
-#[cfg_attr(
-    target_arch = "wasm32",
-    expect(
-        dead_code,
-        reason = "browsers cannot host the TCP inspector dispatcher"
-    )
-)]
 pub(super) enum Dispatch {
     /// An event to fan out to subscribed clients.
     Event(InspectorEventEnvelope),
@@ -81,10 +67,6 @@ pub(super) struct ClientId(pub(super) u64);
 #[derive(Debug)]
 pub struct EventHub {
     seq: AtomicU64,
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(dead_code, reason = "browsers cannot accept TCP inspector clients")
-    )]
     next_client: AtomicU64,
     /// Union of every connected client's subscription.
     ///
@@ -102,13 +84,6 @@ pub struct EventHub {
 
 impl EventHub {
     /// Creates a hub and the receiver its dispatcher thread will drain.
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(
-            dead_code,
-            reason = "browser inspector initialization returns Unsupported"
-        )
-    )]
     pub(super) fn new() -> (Arc<Self>, async_channel::Receiver<Dispatch>) {
         let (sender, receiver) = async_channel::bounded(PUBLISH_CAPACITY);
         let hub = Arc::new(Self {
@@ -157,13 +132,6 @@ impl EventHub {
     }
 
     /// Takes the number of events dropped on `channel` since the last call.
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(
-            dead_code,
-            reason = "browsers cannot dispatch inspector events over TCP"
-        )
-    )]
     pub(super) fn take_dropped(&self, channel: Channel) -> u64 {
         self.dropped[channel as usize].swap(0, Ordering::Relaxed)
     }
@@ -182,7 +150,6 @@ impl EventHub {
     ///
     /// Does nothing when none is attached: inspecting an element is a request
     /// to an inspector, not something the application does by itself.
-    #[cfg(not(target_arch = "wasm32"))]
     pub fn select_node(&self, node: waterui_inspector_protocol::NodeId) {
         self.send_control(Dispatch::Select { node });
     }
@@ -191,7 +158,6 @@ impl EventHub {
     ///
     /// Control messages are rare, so losing one would be a correctness bug
     /// rather than backpressure; this blocks instead of dropping.
-    #[cfg(not(target_arch = "wasm32"))]
     pub(super) fn send_control(&self, dispatch: Dispatch) {
         // A closed channel means the dispatcher is gone and the process is
         // shutting down; there is nothing useful to do about it here.
@@ -199,22 +165,11 @@ impl EventHub {
     }
 
     /// Allocates the next client identifier.
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(dead_code, reason = "browsers cannot accept TCP inspector clients")
-    )]
     pub(super) fn next_client_id(&self) -> ClientId {
         ClientId(self.next_client.fetch_add(1, Ordering::Relaxed))
     }
 
     /// Replaces the union of client subscriptions.
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(
-            dead_code,
-            reason = "browsers cannot negotiate TCP inspector subscriptions"
-        )
-    )]
     pub(super) fn set_subscribed(&self, channels: ChannelSet) {
         self.subscribed.store(channels.bits(), Ordering::Relaxed);
     }

--- a/src/runtime/inspector/mod.rs
+++ b/src/runtime/inspector/mod.rs
@@ -24,18 +24,14 @@
 //! ```
 
 use std::io;
-#[cfg(not(target_arch = "wasm32"))]
 use std::net::TcpListener;
 use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::sync::Arc;
-#[cfg(not(target_arch = "wasm32"))]
 use std::thread;
 use std::time::Duration;
 
 use waterui_core::Environment;
-#[cfg(not(target_arch = "wasm32"))]
 use waterui_inspector_protocol::discovery::Advertisement;
-#[cfg(not(target_arch = "wasm32"))]
 use waterui_inspector_protocol::{ChannelSet, TargetInfo};
 
 use crate::task::RuntimeProbe;
@@ -43,7 +39,6 @@ use crate::task::RuntimeProbe;
 mod hub;
 mod logs;
 mod recorder;
-#[cfg(not(target_arch = "wasm32"))]
 mod server;
 /// The reactive-graph bridge only exists when `nami` is built with graph
 /// observability; without it there is no observer trait to implement.
@@ -63,7 +58,6 @@ pub use logs::InspectorLayer;
 pub use recorder::{FrameRecorder, TreeRecorder};
 
 /// How long a connecting peer has to complete the handshake.
-#[cfg(not(target_arch = "wasm32"))]
 const HANDSHAKE_TIMEOUT: Duration = Duration::from_secs(5);
 
 const DEFAULT_HOST: IpAddr = IpAddr::V4(Ipv4Addr::LOCALHOST);
@@ -223,28 +217,23 @@ where
 pub struct InspectorRuntime {
     hub: Arc<EventHub>,
     task_probe: Arc<tasks::TaskProbe>,
-    #[cfg(not(target_arch = "wasm32"))]
     listening: std::sync::OnceLock<ListeningEndpoint>,
-    #[cfg(not(target_arch = "wasm32"))]
     pending: std::sync::Mutex<Option<PendingEndpoint>>,
 }
 
 /// What a bound endpoint owns once it is listening.
-#[cfg(not(target_arch = "wasm32"))]
 struct ListeningEndpoint {
     endpoint: InspectorEndpointInfo,
     advertisement: Advertisement,
 }
 
 /// Everything needed to bind, held until somebody asks.
-#[cfg(not(target_arch = "wasm32"))]
 struct PendingEndpoint {
     config: InspectorServerConfig,
     backend: &'static str,
     receiver: async_channel::Receiver<hub::Dispatch>,
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl Drop for InspectorRuntime {
     fn drop(&mut self) {
         // A file naming an endpoint that no longer exists sends the next reader
@@ -275,14 +264,7 @@ impl InspectorRuntime {
     /// Where this endpoint is listening, if it has been asked to.
     #[must_use]
     pub fn bound_endpoint(&self) -> Option<&InspectorEndpointInfo> {
-        #[cfg(target_arch = "wasm32")]
-        {
-            None
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            self.listening.get().map(|listening| &listening.endpoint)
-        }
+        self.listening.get().map(|listening| &listening.endpoint)
     }
 
     /// Where this endpoint is listening, binding the socket if it is not yet.
@@ -292,17 +274,7 @@ impl InspectorRuntime {
     /// Returns an I/O error when the socket cannot be bound or a thread cannot
     /// be spawned.
     pub fn endpoint(&self) -> io::Result<&InspectorEndpointInfo> {
-        #[cfg(target_arch = "wasm32")]
-        {
-            Err(io::Error::new(
-                io::ErrorKind::Unsupported,
-                "the TCP inspector endpoint is unavailable in browsers",
-            ))
-        }
-        #[cfg(not(target_arch = "wasm32"))]
-        {
-            self.ensure_listening().map(|listening| &listening.endpoint)
-        }
+        self.ensure_listening().map(|listening| &listening.endpoint)
     }
 
     /// The probe that reports main-thread occupancy.
@@ -528,7 +500,6 @@ pub fn install(environment: &mut Environment, inspector: Option<InspectorRuntime
 /// application rather than only from one started in a terminal.
 ///
 /// `WATERUI_CLI` overrides the search.
-#[cfg(not(target_arch = "wasm32"))]
 fn water_cli_path() -> Option<std::path::PathBuf> {
     use std::path::PathBuf;
 
@@ -564,7 +535,6 @@ fn water_cli_path() -> Option<std::path::PathBuf> {
 ///
 /// Advertised in the handshake so an inspector can grey out what it will never
 /// receive instead of waiting forever for it.
-#[cfg(not(target_arch = "wasm32"))]
 fn available_channels() -> ChannelSet {
     let mut available =
         ChannelSet::FRAMES | ChannelSet::TREE | ChannelSet::TASKS | ChannelSet::LOGS;
@@ -630,21 +600,9 @@ pub fn init_with_config(
     config: InspectorServerConfig,
     backend: &'static str,
 ) -> io::Result<InspectorRuntime> {
-    #[cfg(target_arch = "wasm32")]
-    {
-        let _ = config;
-        return Err(io::Error::new(
-            io::ErrorKind::Unsupported,
-            "the TCP inspector endpoint is unavailable in browsers",
-        ));
-    }
-
-    #[cfg(not(target_arch = "wasm32"))]
-    {
-        let runtime = InspectorRuntime::prepared(config, backend);
-        runtime.ensure_listening()?;
-        Ok(runtime)
-    }
+    let runtime = InspectorRuntime::prepared(config, backend);
+    runtime.ensure_listening()?;
+    Ok(runtime)
 }
 
 /// Builds a runtime whose socket is not bound yet.
@@ -660,7 +618,6 @@ pub fn prepare_with_config(
     InspectorRuntime::prepared(config, backend)
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 impl InspectorRuntime {
     fn prepared(config: InspectorServerConfig, backend: &'static str) -> Self {
         let (hub, receiver) = EventHub::new();
@@ -765,7 +722,6 @@ impl InspectorRuntime {
     }
 }
 
-#[cfg(not(target_arch = "wasm32"))]
 fn spawn(name: &str, body: impl FnOnce() + Send + 'static) -> io::Result<()> {
     thread::Builder::new()
         .name(name.to_string())

--- a/src/runtime/inspector/tasks.rs
+++ b/src/runtime/inspector/tasks.rs
@@ -67,25 +67,11 @@ struct Totals {
 
 impl TaskProbe {
     /// Creates a probe publishing to `hub` once per `window`.
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(
-            dead_code,
-            reason = "browser inspector initialization returns Unsupported"
-        )
-    )]
     pub(super) fn new(hub: Arc<EventHub>, window: Duration, stall_ratio: f64) -> Self {
         Self::with_clock(hub, window, stall_ratio, Arc::new(Instant::now))
     }
 
     /// Creates a probe reading time from `clock`.
-    #[cfg_attr(
-        target_arch = "wasm32",
-        expect(
-            dead_code,
-            reason = "browser inspector initialization returns Unsupported"
-        )
-    )]
     fn with_clock(hub: Arc<EventHub>, window: Duration, stall_ratio: f64, clock: Clock) -> Self {
         let started = clock();
         Self {

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -2,7 +2,10 @@ pub mod app;
 mod entry;
 pub mod error;
 pub mod fullscreen;
-#[cfg(feature = "inspector")]
+// Inspection is a TCP endpoint that also launches the inspector application on
+// the developer's machine; a browser page can do neither, so on wasm the
+// endpoint is absent rather than present and permanently unable to work.
+#[cfg(all(feature = "inspector", not(target_arch = "wasm32")))]
 pub mod inspector;
 pub mod metadata;
 pub mod realization;


### PR DESCRIPTION
`cargo check -p hydrolysis --target wasm32-unknown-unknown --features web` failed on `dev` for three unrelated reasons, and no lane could see any of them: every CI leg builds `hydrolysis --features web` for the **host**, where the web runner and everything else under `cfg(target_arch = "wasm32")` is compiled out.

## The three breakages

**1. The kit sharing dialog called a field as a method.** `load_photo_media` reached for `import_to_cache_subdir`, which is the field behind `FileDialog::with_import_to_cache`. Fixed in the `kit` submodule (`water-rs/kit@d43ed13`, branch `agent/wasm-web-runner-408/20260907-064005`) and pinned here.

**2. `waterui-media` imported `waterkit_fs` with no dependency declared for that target.** The import is live, not vestigial: a browser has no `std::fs`, so a local photo URL is read back through the kit's IndexedDB-backed file system while every other target uses `blocking::unblock(std::fs::read)`. The dependency is now declared under `[target.'cfg(target_arch = "wasm32")'.dependencies]`.

**3. The inspector did not compile for wasm at all.** It is a TCP endpoint that also launches the inspector application on the developer's machine, and a browser page can do neither. The module was already carrying an attempt at wasm support — branches returning `io::ErrorKind::Unsupported`, `#[cfg]`-erased struct fields, and `expect(dead_code, reason = "browsers cannot ...")` scaffolding on a hub and probe that could never publish anything. That is a stub of a subsystem that has no wasm transport, so it is deleted rather than repaired: `waterui::inspector` is gated once, at its declaration, and simply does not exist on wasm.

The four places hydrolysis reaches for it are gated at that same boundary rather than stubbed: the frame/tree publisher (`runner/inspector.rs`), the frame profile `render_window` captures to feed it, the "Inspect element" context-menu entry, and the runner's main-thread probe.

## Follow-on breakages, all fixed here

Clearing the three above exposed three more:

- `web_runner::run` still took an `Option<InspectorRuntime>` it can never be handed; it now installs the browser executor with no probe.
- `AccessibilityBuilder::node_at_point` became dead code — only "Inspect element" asks.
- The dialog's `finalize_selected_file`/`finalize_selected_files` became dead code. They turn a picked *path* into an imported one, and a browser hands back file contents rather than a path, so the web backend imports the bytes it was given instead. Both are now compiled where they apply.

## The CI lane

A `wasm32` job in `test.yml` — the body **both** tiers call, so it runs in the nightly full matrix and in the pull-request gate under the existing `code` path filter, from one job definition rather than two copies. It is a `cargo check` of the web runner plus the two crates whose wasm-only paths it reaches, with `RUSTFLAGS: -D warnings`; cargo caps lints for registry dependencies, so that holds the workspace crates — and only them — to the same bar the host lint pass does (`cargo check` takes no trailing rustc arguments).

**Measured**, on an M-series machine, `cargo check -p hydrolysis --target wasm32-unknown-unknown --features web` after a first warming build:

| state | wall |
|---|---|
| warm, no source change | **1.3 s** |
| warm, after touching the three crates | ~5 s |
| whole wasm graph rebuilt from an empty `target/wasm32-unknown-unknown` | 32 s |

Far inside the "couple of minutes" bar, so it belongs in the gate and not only in the nightly.

## Verified

- `cargo check --target wasm32-unknown-unknown -p hydrolysis --features hydrolysis/web -p waterui-media -p waterkit-dialog` with `RUSTFLAGS=-D warnings`: clean, zero warnings.
- `cargo check -p hydrolysis`, `cargo clippy -p hydrolysis --all-targets -- -D warnings`, `cargo clippy -p waterui-media --all-targets -- -D warnings`, `cargo clippy -p waterkit-dialog --all-targets -- -D warnings` (in the kit workspace): all clean, re-run after rebasing onto current `dev`.
- `cargo nextest run -p waterkit-dialog` (11 passed) and the inspector's own tests (10 passed).
- `rustfmt --edition 2024 --check` on every changed file; `actionlint` on `test.yml`, `ci.yml`, `nightly.yml`.
- `cli/Cargo.toml` names no `kit` pin, so no scaffold pin test applies.

Fixes #408
