### PR TITLE
fix(android): publish slider and progress accessibility nodes

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
 apple-backend-commit = "180dfaa559eea9ef6434c1c23d7d7c4b8c07cc7e"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
-android-backend-commit = "91ef771aadea21de11cc53ce5f42f3a63f53638f"
+android-backend-commit = "e4786d52a3ed7ce969311ac437725ad93040adfa"
 
 [[bin]]
 name = "water"


### PR DESCRIPTION
Sliders and progress indicators reached no screen reader and no accessibility-driven
test on Android. A `uiautomator dump` of `examples/form` on the Pixel 9 Pro contained
the sliders' label `TextView`s and nothing else — no node of any class for the control
itself.

## What was wrong

Two causes stacked on the slider.

Material's `BaseSlider` puts the control on the virtual thumb nodes its own
`ExploreByTouchHelper` serves, so `BaseSlider.onInitializeAccessibilityNodeInfo` ends
with an unconditional `info.setVisibleToUser(false)` to keep the view's own node from
answering as well. `uiautomator` (and TalkBack) never descend into a child that is not
visible to the user, so the host node *and* the virtual thumb underneath it both
disappeared — which is why the sliders had no node at all, not merely a wrongly
classed one.

WaterUI publishes one node for the whole slider, so both halves had to change. The
delegate installed here replaces the helper, and `SeekBarSlider` restores the
visibility the superclass discards — using the value the platform itself computed on
the way past, recorded by the delegate, rather than a guess. A delegate alone cannot
do it: the superclass clobbers the node *after* the delegate has run.

## What it publishes now

- Slider: an `android.widget.SeekBar` node with the label from the WaterUI
  accessibility metadata, a `RangeInfo` carrying the live value and the config's
  bounds, and `ACTION_SET_PROGRESS` / `ACTION_SCROLL_FORWARD` / `ACTION_SCROLL_BACKWARD`
  wired to the `Binding`. A scroll action steps one percent of the range, matching the
  hydrolysis renderer's `slider_step_for_range`, and reports "not performed" at a bound
  the way a platform `SeekBar` does. A disabled slider offers no adjustment actions.
- Progress: an `android.widget.ProgressBar` node with the reading normalized to 0…1
  and no actions. An indeterminate indicator carries no range rather than inventing a
  reading, and the platform widget's own track-unit range is cleared.

No FFI change was needed: `SliderConfig` already carries its range and accessibility
label across the C ABI. `ProgressConfig` has no accessibility label, so the indicator
takes its text from its own label view, the way hydrolysis' `default_label` does; the
label and value-label views are folded into that one node instead of standing beside it.

## Verified on the Pixel 9 Pro

`water run --platform android` on the device, then `uiautomator dump`:

```
class=android.widget.SeekBar     content-desc=Volume       bounds=[32,1322][929,1430]
class=android.widget.SeekBar     content-desc=Brightness   bounds=[32,712][929,820]
class=android.widget.SeekBar     content-desc=Font Scale   bounds=[32,1025][929,1133]
class=android.widget.SeekBar     content-desc=Progress     bounds=[32,1294][929,1402]
class=android.widget.ProgressBar content-desc=Please wait... bounds=[32,1477][929,1486]
```

Dragging the Volume slider by touch still updates the binding (`Volume: 0.7747…`),
so replacing Material's accessibility helper cost no interaction behaviour.

## Tests

Robolectric (`:runtime:testDebugUnitTest`, which CI already runs) covers the published
nodes on the JVM: the `SeekBar` class name, the range, the action set, that performing
`ACTION_SET_PROGRESS` and the scroll actions writes the binding and stops at the
bounds, that a disabled slider refuses them, the `ProgressBar` node and its label, and
the visibility regression that made the whole control disappear.

## Pre-existing defect fixed alongside

`:runtime:lintDebug` — a required check on the android-backend repository — was already
failing on its `dev` with three errors in `PictureComponent`, which blocked verifying
this change through the same gate. The custom view now extends `AppCompatImageView`,
declares why it has no XML constructor, and uses the KTX `createBitmap`. That defect was
pre-existing and not introduced here.

Submodule: water-rs/android-backend@e4786d52a3ed7ce969311ac437725ad93040adfa

Fixes #401
