### PR TITLE
feat(codes): draw QR codes as a self-drawn scene component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4004,6 +4004,34 @@ dependencies = [
 ]
 
 [[package]]
+name = "g2gen"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7e0eb46f83a20260b850117d204366674e85d3a908d90865c78df9a6b1dfc"
+dependencies = [
+ "g2poly",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "g2p"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "539e2644c030d3bf4cd208cb842d2ce2f80e82e6e8472390bcef83ceba0d80ad"
+dependencies = [
+ "g2gen",
+ "g2poly",
+]
+
+[[package]]
+name = "g2poly"
+version = "1.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312d2295c7302019c395cfb90dacd00a82a2eabd700429bba9c7a3f38dbbe11b"
+
+[[package]]
 name = "gallery-example"
 version = "0.1.0"
 dependencies = [
@@ -4886,7 +4914,7 @@ dependencies = [
  "jiff",
  "js-sys",
  "keyboard-types",
- "lru",
+ "lru 0.16.4",
  "nami",
  "native-executor",
  "objc2 0.6.4",
@@ -6441,6 +6469,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f66e8d5d03f609abc3a39e6f08e4164ebf1447a732906d39eb9b99b7919ef39"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "lru"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
+dependencies = [
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -8831,6 +8868,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
+name = "qrcode"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d68782463e408eb1e668cf6152704bd856c78c5b6417adaee3203d8f4c1fc9ec"
+
+[[package]]
 name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9363,6 +9406,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f1964b10c76125c36f8afe190065a4bf9a87bf324842c05701330bba9f1cacbb"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "rqrr"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d084c50c5cfa397a081850da329566c8667b0b6c4e81da16abff1fef27de93b"
+dependencies = [
+ "g2p",
+ "image",
+ "lru 0.18.4",
 ]
 
 [[package]]
@@ -13105,7 +13159,7 @@ dependencies = [
  "getrandom 0.2.17",
  "image",
  "kurbo 0.13.1",
- "lru",
+ "lru 0.16.4",
  "maplibre-expr",
  "mvt-reader",
  "nami",
@@ -13270,6 +13324,27 @@ dependencies = [
  "serde",
  "serde_json",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "waterui-qr"
+version = "0.1.0"
+dependencies = [
+ "hydrolysis-m3",
+ "image",
+ "kurbo 0.13.1",
+ "nami",
+ "peniko",
+ "qrcode",
+ "rqrr",
+ "thiserror 2.0.20",
+ "tracing",
+ "waterui",
+ "waterui-core",
+ "waterui-graphics",
+ "waterui-layout",
+ "waterui-str",
+ "waterui-testing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,6 +3,7 @@
 members = [
     "core",
     "components/assets/*",
+    "components/codes/*",
     "components/data/*",
     "components/devtools/*/*",
     "components/foundation/*",
@@ -140,6 +141,7 @@ merman-render = { git = "https://github.com/water-rs/merman", rev = "a6f41d47b49
 waterui-shape = { version = "0.1.0", path = "components/foundation/shape", default-features = false }
 waterui-svg = { version = "0.1.0", path = "components/visual/svg" }
 waterui-math = { version = "0.1.0", path = "components/visual/math" }
+waterui-qr = { version = "0.1.0", path = "components/codes/qr" }
 waterui-ffi = { version = "0.3.0", path = "ffi" }
 waterui-layout = { version = "0.3.0", path = "components/foundation/layout" }
 waterui-navigation = { version = "0.3.0", path = "components/foundation/navigation" }
@@ -220,6 +222,15 @@ parley = { version = "0.11", default-features = false }
 # workspace renders one with `vello_svg`, so the parser is depended on directly
 # rather than through a Vello-only renderer.
 usvg = "0.46.0"
+# QR symbol encoder. Only the module matrix is taken from it — the component
+# draws the modules itself through `Scene2D` — so its image, SVG and PIC
+# renderers, and the `image` crate behind the first of them, stay out of the
+# graph via `default-features = false`.
+qrcode = { version = "0.14.1", default-features = false }
+# QR decoder. Test-only: the round-trip check reads the drawn pixels back and
+# asserts they decode to the payload, which is the only assertion that can tell
+# whether a code actually scans.
+rqrr = "0.11.0"
 kurbo = "0.13"
 peniko = "0.6"
 skrifa = "0.42.1"

--- a/components/codes/qr/Cargo.toml
+++ b/components/codes/qr/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "waterui-qr"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+readme = "README.md"
+repository.workspace = true
+description = "QR code rendering for WaterUI, drawn as a scene rather than as an image"
+keywords = ["qrcode", "barcode", "waterui", "gui"]
+categories = ["gui"]
+
+[dependencies]
+waterui-core.workspace = true
+waterui-graphics.workspace = true
+waterui-layout.workspace = true
+waterui-str.workspace = true
+nami.workspace = true
+kurbo.workspace = true
+peniko.workspace = true
+# The symbol encoder. Only its module matrix is used; the modules are drawn
+# through `Scene2D` here, so none of its renderers are reachable.
+qrcode.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
+
+[dev-dependencies]
+# The round-trip test renders the component offscreen, which is the only thing
+# in this crate that touches the GPU stack.
+waterui-graphics = { workspace = true, features = ["gpu"] }
+waterui = { path = "../../.." }
+waterui-testing = { path = "../../../testing" }
+# Reads the rendered pixels back. A code that does not decode is not a code,
+# and no assertion about geometry says that.
+rqrr.workspace = true
+image = { version = "0.25", default-features = false }
+# The dark-theme round trip needs a dark palette installed over the default
+# test theme, which is the theme package's own job.
+hydrolysis-m3 = { path = "../../../backends/hydrolysis_m3" }
+
+[lints]
+workspace = true

--- a/components/codes/qr/README.md
+++ b/components/codes/qr/README.md
@@ -1,0 +1,102 @@
+# waterui-qr
+
+QR code rendering for WaterUI, drawn as a scene rather than as an image.
+
+```rust
+use waterui_qr::{ErrorCorrection, qr_code};
+
+qr_code("https://waterui.dev").correction(ErrorCorrection::High)
+```
+
+## How it works
+
+```
+payload ──(qrcode)──► QrMatrix ──► snapped grid ──► Scene2D rects
+   │                                                     │
+   └──► a11y label                                       └──► any backend
+```
+
+No platform ships a QR primitive — a code is a picture everywhere — so this is a
+self-drawn component, exactly as `AGENTS.md` prescribes for a semantic component
+with no native counterpart. Encoding is `qrcode`'s: the bit stream, the
+error-correction blocks, the mask selection and the placement rules of ISO/IEC
+18004 are a specification with a maintained implementation, and only its module
+grid is taken. The grid is drawn through the engine-independent `Scene2D`
+contract, so a code renders on the classic compute pipeline, on the CPU/GPU
+split engine that adapters without compute shaders fall to, and on dew's CPU
+scene, and stays vector sharp at any size instead of being rasterized once.
+
+## Snapping
+
+One module is a whole number of units on a side, and the block is placed at a
+whole-unit origin, so every module boundary is exact. This is what keeps a code
+scannable rather than merely tidy: a boundary that falls inside a pixel is
+antialiased into a grey seam, and a decoder's binarizer then has to guess which
+side that seam belongs to. At small sizes it guesses wrong on most rows, which
+is more damage than the error correction was sized for.
+
+The space being snapped to is the one the scene is built in — the surface's own
+pixel grid where the scene owns a `GpuSurface`, and the window's logical grid
+(the device pixel grid at every integer scale factor) where a self-drawn backend
+merges the scene into its own. Whatever the box does not divide evenly is left
+around the symbol as extra clear space, which is the one thing around a code
+that may grow freely.
+
+## The quiet zone
+
+Four modules on every side, per the specification, drawn as part of the code
+rather than left to the caller: a required margin that has to be remembered is a
+margin that gets forgotten, and a code pressed against neighbouring content is
+one a detector finds late or not at all. `quiet_zone(n)` changes it for a code
+that sits on a ground that is already clear.
+
+## Colours
+
+A QR code is a machine-readable target, so its two colours are functional rather
+than decorative. The defaults come from the theme — `Foreground` and `Surface`,
+so a themed application gets its own near-black and near-white rather than a
+hardcoded `#000` on `#fff` — but the *darker* of the two always draws the
+modules.
+
+That ordering is the whole point. A decoder looks for dark modules on a light
+ground, and the detectors in wide use (`quirc`, ZXing, and the `rqrr` this
+crate's tests decode with) do not search for the reflectance-reversed form at
+all, so `Foreground` on `Surface` taken verbatim would hand a dark-mode
+application a code that looks right and does not scan. `tests/round_trip.rs`
+pins both halves: a code under the dark theme decodes, and a deliberately
+inverted one is not found.
+
+`module_color(…)` and `background_color(…)` take the judgement back; both accept
+signals, so a code follows a colour that changes without its subtree being
+rebuilt.
+
+## Reactivity
+
+The payload and both colours are signals. A change to any of them invalidates
+the scene rather than rebuilding the subtree, so the content instance and its
+cached grid survive it and only the frame is redrawn.
+
+## Accessibility
+
+A code reaches the screen as an anonymous field of squares, and unlike a
+decorative drawing it *is* content: the whole point of the picture is a string
+that only a camera can get at. The drawing answers
+`SceneContent::accessibility_label` with the payload and the backend names the
+node with it, so anyone who cannot point a camera at the screen still gets what
+the code says. `.a11y_label("Boarding pass")` wins wherever the application
+names the code itself — the payload is what the node says when nobody did.
+
+## Failure
+
+A payload past the largest symbol at the chosen level is a `QrError`. There is
+no truncation and no drop to a weaker correction level: a code that says less
+than the payload is a code that sends whoever scans it somewhere else.
+
+## Tests
+
+`tests/round_trip.rs` renders the component offscreen and decodes the pixels
+back with `rqrr`, at two module sizes and under two themes. It is the only
+assertion that says what matters — every way a drawn code stops being readable
+leaves a picture that still looks like a QR code — and it writes the frames into
+WaterUI's canonical artifact layout, so the same run that proves a code decodes
+also leaves the image to look at.

--- a/components/codes/qr/src/lib.rs
+++ b/components/codes/qr/src/lib.rs
@@ -1,0 +1,70 @@
+//! QR code rendering for `WaterUI`.
+//!
+//! No platform ships a QR primitive — a code is a picture everywhere — so this
+//! is a self-drawn component: the payload is encoded into a module grid, and
+//! the grid is drawn through the engine-independent `Scene2D` contract, which
+//! means it renders on whichever engine the backend supplies and stays vector
+//! sharp at any size instead of being rasterized once into a bitmap.
+//!
+//! Two things separate this from drawing squares. Module edges are snapped to
+//! whole units of the box the code is drawn in, because a boundary that falls
+//! inside a pixel is antialiased into a seam a decoder's binarizer has to guess
+//! at; and the default colours preserve a code's polarity across the colour
+//! scheme, because a light-on-dark code is one most detectors will not find at
+//! all. Both are explained where they happen, in [`view`].
+//!
+//! # Showing a code
+//!
+//! ```
+//! use waterui_qr::qr_code;
+//!
+//! let ticket = qr_code("https://waterui.dev");
+//! ```
+//!
+//! The payload takes a signal, so a code bound to state re-encodes and redraws
+//! without its subtree being rebuilt:
+//!
+//! ```
+//! use nami::Binding;
+//! use waterui_qr::qr_code;
+//! use waterui_str::Str;
+//!
+//! let link = Binding::container(Str::from_static("https://waterui.dev"));
+//! let code = qr_code(link.clone());
+//!
+//! link.set(Str::from_static("https://waterui.dev/docs"));
+//! ```
+//!
+//! Style is an attribute rather than another type — the correction level, the
+//! quiet zone and the two colours are set on the code:
+//!
+//! ```
+//! use waterui_graphics::color::Color;
+//! use waterui_qr::{ErrorCorrection, qr_code};
+//!
+//! let code = qr_code("https://waterui.dev")
+//!     .correction(ErrorCorrection::High)
+//!     .module_size(6.0)
+//!     .module_color(Color::srgb(13, 26, 51));
+//! ```
+//!
+//! # Encoding without drawing
+//!
+//! Encoding needs no GPU and no environment, which is what makes it usable from
+//! a test or a server:
+//!
+//! ```
+//! use waterui_qr::{ErrorCorrection, QrMatrix};
+//!
+//! let matrix = QrMatrix::encode("https://waterui.dev", ErrorCorrection::Medium)?;
+//! assert!(matrix.is_dark(0, 0), "every symbol opens with a finder pattern");
+//! # Ok::<(), waterui_qr::QrError>(())
+//! ```
+
+extern crate alloc;
+
+pub mod matrix;
+pub mod view;
+
+pub use matrix::{ErrorCorrection, QrError, QrMatrix};
+pub use view::{DEFAULT_MODULE_SIZE, DEFAULT_QUIET_ZONE, QrCode, QrContent, qr_code};

--- a/components/codes/qr/src/matrix.rs
+++ b/components/codes/qr/src/matrix.rs
@@ -1,0 +1,278 @@
+//! The module grid a QR symbol is drawn from.
+//!
+//! Encoding is [`qrcode`]'s: bit stream, error-correction blocks, mask
+//! selection and the placement rules of ISO/IEC 18004 are a specification this
+//! crate has no business re-implementing. What comes back out of it here is
+//! only the grid — [`QrMatrix`] — because everything downstream draws the
+//! modules itself.
+
+use alloc::vec::Vec;
+use core::fmt;
+
+use qrcode::types::QrError as SymbolError;
+use qrcode::{Color as ModuleColor, EcLevel, QrCode as Symbol};
+
+/// How much of a symbol may be obscured or damaged and still decode.
+///
+/// Higher levels spend more of the symbol on recovery data, so the same payload
+/// needs a larger grid: the choice is between a small code and a robust one,
+/// and it depends on where the code ends up rather than on what it says.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub enum ErrorCorrection {
+    /// Recovers roughly 7% of the symbol. The smallest grid a payload fits in.
+    Low,
+    /// Recovers roughly 15%. The level a code is drawn at when nothing else is
+    /// asked for, and the one most published codes use.
+    #[default]
+    Medium,
+    /// Recovers roughly 25%.
+    Quartile,
+    /// Recovers roughly 30%. What a code printed on something that gets
+    /// handled — or drawn over with a logo — needs.
+    High,
+}
+
+impl ErrorCorrection {
+    /// The encoder's spelling of this level.
+    const fn level(self) -> EcLevel {
+        match self {
+            Self::Low => EcLevel::L,
+            Self::Medium => EcLevel::M,
+            Self::Quartile => EcLevel::Q,
+            Self::High => EcLevel::H,
+        }
+    }
+}
+
+impl fmt::Display for ErrorCorrection {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        formatter.write_str(match self {
+            Self::Low => "low",
+            Self::Medium => "medium",
+            Self::Quartile => "quartile",
+            Self::High => "high",
+        })
+    }
+}
+
+/// Why a payload could not be turned into a symbol.
+///
+/// There is no lower level to fall back to and nothing to truncate: a code that
+/// says less than the payload is a code that sends whoever scans it somewhere
+/// else, so encoding either produces the payload or fails.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum QrError {
+    /// The payload is longer than the largest symbol holds at this level.
+    ///
+    /// The ceiling is roughly 2 953 bytes at [`ErrorCorrection::Low`] and 1 273
+    /// at [`ErrorCorrection::High`], so a payload that overflows one level may
+    /// well fit a lower one — but which trade to make is the caller's, not this
+    /// crate's.
+    #[error(
+        "a payload of {length} bytes does not fit any QR symbol at {correction} error correction"
+    )]
+    PayloadTooLong {
+        /// Length of the payload in bytes.
+        length: usize,
+        /// The level it was encoded at.
+        correction: ErrorCorrection,
+    },
+    /// The encoder refused the payload for a reason other than its length.
+    #[error("the payload could not be encoded as a QR symbol: {reason}")]
+    Unencodable {
+        /// What the encoder objected to.
+        reason: &'static str,
+    },
+}
+
+/// The square grid of a QR symbol, one `bool` per module, dark being `true`.
+///
+/// This is the symbol proper: it carries no quiet zone, because the quiet zone
+/// is a property of how the symbol is placed rather than of the symbol itself.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct QrMatrix {
+    dark: Vec<bool>,
+    width: usize,
+}
+
+impl QrMatrix {
+    /// Encodes `payload` at `correction`, choosing the smallest symbol version
+    /// that holds it.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`QrError::PayloadTooLong`] when the payload exceeds the largest
+    /// symbol at this level, and [`QrError::Unencodable`] when the encoder
+    /// refuses it for any other reason.
+    ///
+    /// ```
+    /// use waterui_qr::{ErrorCorrection, QrMatrix};
+    ///
+    /// let matrix = QrMatrix::encode("https://waterui.dev", ErrorCorrection::Medium)?;
+    /// // The smallest symbol is 21 modules on a side, and every symbol is square.
+    /// assert!(matrix.width() >= 21);
+    /// # Ok::<(), waterui_qr::QrError>(())
+    /// ```
+    pub fn encode(payload: &str, correction: ErrorCorrection) -> Result<Self, QrError> {
+        let symbol =
+            Symbol::with_error_correction_level(payload, correction.level()).map_err(|error| {
+                match error {
+                    SymbolError::DataTooLong => QrError::PayloadTooLong {
+                        length: payload.len(),
+                        correction,
+                    },
+                    SymbolError::InvalidVersion => QrError::Unencodable {
+                        reason: "the encoder picked a symbol version the payload does not fit",
+                    },
+                    SymbolError::UnsupportedCharacterSet | SymbolError::InvalidCharacter => {
+                        QrError::Unencodable {
+                            reason: "the payload contains bytes the encoder cannot place",
+                        }
+                    }
+                    SymbolError::InvalidEciDesignator => QrError::Unencodable {
+                        reason: "the payload names an invalid ECI designator",
+                    },
+                }
+            })?;
+
+        let width = symbol.width();
+        let dark = symbol
+            .into_colors()
+            .into_iter()
+            .map(|module| module == ModuleColor::Dark)
+            .collect();
+        Ok(Self { dark, width })
+    }
+
+    /// The number of modules along one side, quiet zone excluded.
+    #[must_use]
+    pub const fn width(&self) -> usize {
+        self.width
+    }
+
+    /// Whether the module at `(x, y)` is dark, counting from the top left.
+    ///
+    /// # Panics
+    ///
+    /// Panics when either coordinate is outside the grid.
+    #[must_use]
+    pub fn is_dark(&self, x: usize, y: usize) -> bool {
+        assert!(
+            x < self.width && y < self.width,
+            "module ({x}, {y}) is outside a {}x{} symbol",
+            self.width,
+            self.width
+        );
+        self.dark[y * self.width + x]
+    }
+
+    /// The grid a row at a time, top to bottom.
+    #[must_use]
+    pub fn rows(&self) -> impl ExactSizeIterator<Item = &[bool]> {
+        self.dark.chunks_exact(self.width)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::format;
+    use alloc::string::String;
+
+    use super::{ErrorCorrection, QrError, QrMatrix};
+
+    /// The payload every test in this crate encodes unless it needs another.
+    const PAYLOAD: &str = "https://waterui.dev";
+
+    #[test]
+    fn a_symbol_is_square_and_carries_its_finder_patterns() {
+        let matrix = QrMatrix::encode(PAYLOAD, ErrorCorrection::Medium).expect("the payload fits");
+
+        assert!(
+            matrix.width() >= 21 && matrix.width() % 4 == 1,
+            "a QR symbol is 21 + 4n modules on a side, got {}",
+            matrix.width()
+        );
+        assert_eq!(matrix.rows().len(), matrix.width(), "the grid is square");
+
+        // The three finder patterns are the one part of a symbol whose contents
+        // the specification fixes, so they are what tells us the grid is the
+        // right way up and indexed the way `is_dark` claims.
+        let last = matrix.width() - 7;
+        for (corner_x, corner_y) in [(0, 0), (last, 0), (0, last)] {
+            for (x, y) in [(0, 0), (6, 0), (0, 6), (6, 6), (3, 3)] {
+                assert!(
+                    matrix.is_dark(corner_x + x, corner_y + y),
+                    "the finder pattern at ({corner_x}, {corner_y}) is missing its frame"
+                );
+            }
+            for (x, y) in [(1, 1), (5, 1), (1, 5), (5, 5)] {
+                assert!(
+                    !matrix.is_dark(corner_x + x, corner_y + y),
+                    "the finder pattern at ({corner_x}, {corner_y}) has no light ring"
+                );
+            }
+        }
+    }
+
+    /// A stronger level spends more of the symbol on recovery, so the same
+    /// payload needs at least as large a grid.
+    #[test]
+    fn stronger_correction_never_shrinks_the_symbol() {
+        let mut previous = 0;
+        for correction in [
+            ErrorCorrection::Low,
+            ErrorCorrection::Medium,
+            ErrorCorrection::Quartile,
+            ErrorCorrection::High,
+        ] {
+            let width = QrMatrix::encode(PAYLOAD, correction)
+                .unwrap_or_else(|error| panic!("{correction}: {error}"))
+                .width();
+            assert!(
+                width >= previous,
+                "{correction} produced a {width}-module symbol, smaller than the {previous}-module one before it"
+            );
+            previous = width;
+        }
+    }
+
+    /// A payload past the largest symbol is an error, not a smaller code: there
+    /// is nothing to truncate and nothing to fall back to.
+    #[test]
+    fn an_over_long_payload_is_an_error() {
+        // Comfortably past the ~1 273-byte ceiling at High, and past the
+        // ~2 953-byte one at Low.
+        let payload = String::from_iter(core::iter::repeat_n('W', 4096));
+
+        let error = QrMatrix::encode(&payload, ErrorCorrection::High)
+            .expect_err("4096 bytes does not fit any symbol");
+        assert_eq!(
+            error,
+            QrError::PayloadTooLong {
+                length: 4096,
+                correction: ErrorCorrection::High,
+            }
+        );
+        assert_eq!(
+            format!("{error}"),
+            "a payload of 4096 bytes does not fit any QR symbol at high error correction"
+        );
+    }
+
+    /// Encoding is deterministic, which is what lets a cached matrix be reused
+    /// for an unchanged payload.
+    #[test]
+    fn the_same_payload_encodes_the_same_way_every_time() {
+        assert_eq!(
+            QrMatrix::encode(PAYLOAD, ErrorCorrection::Medium),
+            QrMatrix::encode(PAYLOAD, ErrorCorrection::Medium)
+        );
+    }
+
+    #[test]
+    #[should_panic(expected = "is outside a")]
+    fn a_module_outside_the_grid_is_a_caller_bug() {
+        let matrix = QrMatrix::encode(PAYLOAD, ErrorCorrection::Low).expect("the payload fits");
+        let _ = matrix.is_dark(matrix.width(), 0);
+    }
+}

--- a/components/codes/qr/src/view.rs
+++ b/components/codes/qr/src/view.rs
@@ -1,0 +1,701 @@
+//! The [`QrCode`] view and the scene content behind it.
+
+use alloc::rc::Rc;
+use alloc::string::{String, ToString as _};
+
+use kurbo::{Affine, BezPath, Rect, Shape as _};
+use nami::SignalExt as _;
+use nami::signal::IntoComputed;
+use nami::watcher::BoxWatcherGuard;
+use peniko::{Brush, Fill};
+use waterui_core::layout::Size;
+use waterui_core::resolve::Resolvable as _;
+use waterui_core::{Computed, Environment, Signal as _, View};
+use waterui_graphics::color::{Color, ForegroundColor, ResolvedColor, SurfaceColor, signal_color};
+use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, invalidate_on_change};
+use waterui_layout::frame::Frame;
+use waterui_str::Str;
+
+use crate::matrix::{ErrorCorrection, QrMatrix};
+
+/// The quiet zone ISO/IEC 18004 requires around a symbol, in modules.
+///
+/// Four modules of clear space on every side is what tells a decoder where the
+/// symbol ends; a code pressed against neighbouring content is a code that is
+/// found late or not at all. It is drawn as part of the code rather than left
+/// to the caller for exactly that reason — a required margin that has to be
+/// remembered is a margin that gets forgotten.
+pub const DEFAULT_QUIET_ZONE: u8 = 4;
+
+/// The natural edge of one module, in points.
+///
+/// A QR code has no resolution of its own: it is a grid of squares that can be
+/// drawn at any size, so what settles its natural size is the smallest size it
+/// can still be read at. A camera needs several device pixels per module to
+/// resolve one, and four points a module is the smallest edge that leaves that
+/// margin on a non-HiDPI display. A layout that names a size wins over this,
+/// exactly as it does over an image's pixel dimensions.
+pub const DEFAULT_MODULE_SIZE: f32 = 4.0;
+
+/// A QR code drawn from its module grid.
+///
+/// The payload is a signal, so a code bound to state re-encodes and redraws
+/// without its subtree being rebuilt. The two colours default to the theme's
+/// (see [`Self::module_color`]), and the quiet zone is part of the drawing.
+///
+/// ```
+/// use waterui_qr::{ErrorCorrection, QrCode};
+///
+/// let ticket = QrCode::new("https://waterui.dev")
+///     .correction(ErrorCorrection::High)
+///     .module_size(6.0);
+/// ```
+#[derive(Debug, Clone)]
+pub struct QrCode {
+    payload: Computed<Str>,
+    correction: ErrorCorrection,
+    quiet_zone: u8,
+    module_size: f32,
+    module_color: Option<Color>,
+    background_color: Option<Color>,
+}
+
+impl QrCode {
+    /// A code encoding `payload`.
+    ///
+    /// The payload takes a signal, so a code bound to state follows it.
+    #[must_use]
+    pub fn new(payload: impl IntoComputed<Str>) -> Self {
+        Self {
+            payload: payload.into_computed(),
+            correction: ErrorCorrection::default(),
+            quiet_zone: DEFAULT_QUIET_ZONE,
+            module_size: DEFAULT_MODULE_SIZE,
+            module_color: None,
+            background_color: None,
+        }
+    }
+
+    /// Sets how much of the symbol may be lost and still decode.
+    ///
+    /// A stronger level needs a larger grid for the same payload, so this
+    /// changes the code's natural size.
+    #[must_use]
+    pub const fn correction(mut self, correction: ErrorCorrection) -> Self {
+        self.correction = correction;
+        self
+    }
+
+    /// Sets the clear space around the symbol, in modules.
+    ///
+    /// [`DEFAULT_QUIET_ZONE`] is what the specification requires and what a
+    /// code is drawn with unless it sits on a ground that is already clear for
+    /// some other reason.
+    #[must_use]
+    pub const fn quiet_zone(mut self, modules: u8) -> Self {
+        self.quiet_zone = modules;
+        self
+    }
+
+    /// Sets the edge of one module in points, which is what the code's natural
+    /// size is made of.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `points` is not finite and positive, which is a caller bug
+    /// rather than bad input.
+    #[must_use]
+    pub fn module_size(mut self, points: f32) -> Self {
+        assert!(
+            points.is_finite() && points > 0.0,
+            "QR module size must be finite and positive, got {points}"
+        );
+        self.module_size = points;
+        self
+    }
+
+    /// Overrides the colour the dark modules are drawn in.
+    ///
+    /// Left alone, the two colours come from the theme — but not verbatim. A QR
+    /// code is a machine-readable target, so its colours are functional rather
+    /// than decorative: a decoder looks for dark modules on a light ground, and
+    /// the detectors in wide use (`quirc`, `ZXing`, and the `rqrr` this crate's
+    /// round-trip test decodes with) do not search for the reflectance-reversed
+    /// form at all. Drawing `Foreground` on `Surface` verbatim would therefore
+    /// hand a dark-mode application a code that looks right and does not scan.
+    /// So the default pair is the theme's `Foreground` and `Surface` with the
+    /// *darker* of the two always drawing the modules: a themed application
+    /// still gets its own near-black and near-white rather than a hardcoded
+    /// `#000` on `#fff`, and the polarity a decoder needs survives the colour
+    /// scheme.
+    ///
+    /// Naming either colour hands that judgement back to the caller: the
+    /// colours are then used exactly as given, in the order given.
+    #[must_use]
+    pub fn module_color(mut self, color: impl IntoComputed<Color>) -> Self {
+        self.module_color = Some(signal_color(color));
+        self
+    }
+
+    /// Overrides the colour behind the modules, quiet zone included.
+    ///
+    /// See [`Self::module_color`] for what the colours default to and why
+    /// naming one changes it.
+    #[must_use]
+    pub fn background_color(mut self, color: impl IntoComputed<Color>) -> Self {
+        self.background_color = Some(signal_color(color));
+        self
+    }
+
+    /// The colours this code draws with, resolved against `env`.
+    fn colors(&self, env: &Environment) -> (Computed<ResolvedColor>, Computed<ResolvedColor>) {
+        match (&self.module_color, &self.background_color) {
+            (Some(modules), Some(background)) => (modules.resolve(env), background.resolve(env)),
+            (Some(modules), None) => (modules.resolve(env), SurfaceColor.resolve(env).computed()),
+            (None, Some(background)) => (
+                ForegroundColor.resolve(env).computed(),
+                background.resolve(env),
+            ),
+            (None, None) => {
+                let pair = ForegroundColor
+                    .resolve(env)
+                    .zip(&SurfaceColor.resolve(env).computed());
+                (
+                    pair.map(|(foreground, surface)| darker(foreground, surface))
+                        .computed(),
+                    pair.map(|(foreground, surface)| lighter(foreground, surface))
+                        .computed(),
+                )
+            }
+        }
+    }
+}
+
+/// A QR code encoding `payload`.
+///
+/// The ergonomic entry point; [`QrCode::new`] is the same constructor and
+/// carries the attributes that shape the code.
+///
+/// ```
+/// use waterui_qr::qr_code;
+///
+/// let code = qr_code("https://waterui.dev");
+/// ```
+#[must_use]
+pub fn qr_code(payload: impl IntoComputed<Str>) -> QrCode {
+    QrCode::new(payload)
+}
+
+/// The darker of two colours, compared by perceptual lightness.
+fn darker(first: ResolvedColor, second: ResolvedColor) -> ResolvedColor {
+    if first.to_oklch().lightness <= second.to_oklch().lightness {
+        first
+    } else {
+        second
+    }
+}
+
+/// The lighter of two colours, compared by perceptual lightness.
+fn lighter(first: ResolvedColor, second: ResolvedColor) -> ResolvedColor {
+    if first.to_oklch().lightness <= second.to_oklch().lightness {
+        second
+    } else {
+        first
+    }
+}
+
+/// Scene content that draws one QR code.
+///
+/// [`QrCode`] wraps this. A backend that already owns a scene can draw a code
+/// into it directly rather than going through a view.
+pub struct QrContent {
+    payload: Computed<Str>,
+    correction: ErrorCorrection,
+    quiet_zone: u8,
+    module_size: f32,
+    modules: Computed<ResolvedColor>,
+    background: Computed<ResolvedColor>,
+    /// The payload last encoded and what it encoded to, `None` when it did not
+    /// encode. Measuring and drawing both need the grid, and a container probes
+    /// a child several times in one pass, so the answer is kept. A plain
+    /// `RefCell` is the right cell for it: layout is single-threaded by
+    /// contract and runs on the thread that draws.
+    encoded: core::cell::RefCell<Option<(Str, Option<Rc<QrMatrix>>)>>,
+    invalidator: Option<SceneInvalidator>,
+    /// Keeps the watchers installed by [`SceneContent::set_invalidator`] alive.
+    /// Dropping them stops asking for redraws, which is what clearing the
+    /// invalidator means.
+    guards: alloc::vec::Vec<BoxWatcherGuard>,
+}
+
+impl QrContent {
+    /// Scene content drawing `payload` at `correction`.
+    ///
+    /// `module_size` is only the natural size the content reports; the code is
+    /// drawn to fill whatever box layout hands it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `module_size` is not finite and positive.
+    #[must_use]
+    pub fn new(
+        payload: impl IntoComputed<Str>,
+        correction: ErrorCorrection,
+        quiet_zone: u8,
+        module_size: f32,
+        modules: impl IntoComputed<ResolvedColor>,
+        background: impl IntoComputed<ResolvedColor>,
+    ) -> Self {
+        assert!(
+            module_size.is_finite() && module_size > 0.0,
+            "QR module size must be finite and positive, got {module_size}"
+        );
+        Self {
+            payload: payload.into_computed(),
+            correction,
+            quiet_zone,
+            module_size,
+            modules: modules.into_computed(),
+            background: background.into_computed(),
+            encoded: core::cell::RefCell::new(None),
+            invalidator: None,
+            guards: alloc::vec::Vec::new(),
+        }
+    }
+
+    /// The grid `payload` encodes to, encoded once and kept.
+    ///
+    /// `None` means the payload does not fit a symbol at this correction level.
+    /// There is deliberately nothing to fall back to: a code drawn from a
+    /// truncated payload sends whoever scans it somewhere else.
+    fn matrix(&self, payload: &Str) -> Option<Rc<QrMatrix>> {
+        let mut encoded = self.encoded.borrow_mut();
+        if let Some((cached, matrix)) = encoded.as_ref()
+            && cached == payload
+        {
+            return matrix.clone();
+        }
+
+        let matrix = match QrMatrix::encode(payload.as_str(), self.correction) {
+            Ok(matrix) => Some(Rc::new(matrix)),
+            Err(error) => {
+                tracing::error!(%error, %payload, "could not encode QR code");
+                None
+            }
+        };
+        *encoded = Some((payload.clone(), matrix.clone()));
+        matrix
+    }
+
+    /// The whole grid, symbol plus quiet zone on both sides, in modules.
+    fn side_in_modules(&self, matrix: &QrMatrix) -> usize {
+        matrix.width() + 2 * usize::from(self.quiet_zone)
+    }
+}
+
+impl core::fmt::Debug for QrContent {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("QrContent")
+            .field("correction", &self.correction)
+            .field("quiet_zone", &self.quiet_zone)
+            .field("module_size", &self.module_size)
+            .finish_non_exhaustive()
+    }
+}
+
+impl SceneContent for QrContent {
+    fn build_scene(&mut self, scene: &mut dyn Scene2D, width: f32, height: f32) -> bool {
+        if !(width.is_finite() && height.is_finite()) || width <= 0.0 || height <= 0.0 {
+            return false;
+        }
+
+        // The ground covers the whole box rather than just the symbol's own
+        // quiet zone: the code is opaque by definition — a decoder reads
+        // reflectance, and whatever shows through modules that are supposed to
+        // be light is damage — and any box larger than the snapped grid below
+        // leaves its remainder as extra clear space, which is the one thing
+        // around a symbol that may grow freely.
+        let box_rect = Rect::new(0.0, 0.0, f64::from(width), f64::from(height));
+        scene.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            &Brush::Solid(self.background.get().to_peniko()),
+            None,
+            &box_rect.to_path(0.0),
+        );
+
+        let payload = self.payload.get();
+        let Some(matrix) = self.matrix(&payload) else {
+            return false;
+        };
+        let side = self.side_in_modules(&matrix);
+        let Some(grid) = Grid::fit(width, height, side) else {
+            tracing::error!(
+                width,
+                height,
+                side,
+                "a {side}-module QR grid does not fit a {width}x{height} box at one unit a module"
+            );
+            return false;
+        };
+
+        let mut path = BezPath::new();
+        let quiet = grid.module * f64::from(self.quiet_zone);
+        let mut top = grid.y + quiet;
+        for row in matrix.rows() {
+            let bottom = top + grid.module;
+            // Each row is walked as runs of dark modules so a run becomes one
+            // rectangle instead of one per module: a version-40 symbol is
+            // 31 329 modules, and a fill of that many separate squares is a
+            // scene nobody needs to build. Coordinates advance by whole
+            // multiples of an integer module edge from an integer origin, so
+            // every rectangle in the path is exactly aligned with its
+            // neighbours and adjacent runs share an edge instead of leaving a
+            // hairline of ground between them.
+            let mut x = grid.x + quiet;
+            let mut run: Option<f64> = None;
+            for &dark in row {
+                if dark {
+                    run = run.or(Some(x));
+                } else if let Some(left) = run.take() {
+                    path.extend(Rect::new(left, top, x, bottom).path_elements(0.0));
+                }
+                x += grid.module;
+            }
+            if let Some(left) = run.take() {
+                path.extend(Rect::new(left, top, x, bottom).path_elements(0.0));
+            }
+            top = bottom;
+        }
+
+        scene.fill(
+            Fill::NonZero,
+            Affine::IDENTITY,
+            &Brush::Solid(self.modules.get().to_peniko()),
+            None,
+            &path,
+        );
+        false
+    }
+
+    /// The whole grid — symbol plus quiet zone — at this content's module size.
+    ///
+    /// Square, because a symbol is, so a container that names one axis derives
+    /// the other from it instead of stretching the code into something no
+    /// decoder will look at. `None` when the payload does not encode, which is
+    /// not a size.
+    fn intrinsic_size(&self) -> Option<Size> {
+        let matrix = self.matrix(&self.payload.get())?;
+        // A symbol is at most 177 modules on a side and the quiet zone at most
+        // 255 on each, so the total is well inside `u16` and exact in `f32`.
+        let side = u16::try_from(self.side_in_modules(&matrix)).ok()?;
+        let points = f32::from(side) * self.module_size;
+        Some(Size::new(points, points))
+    }
+
+    /// What the code encodes.
+    ///
+    /// A QR code reaches the screen as an anonymous field of squares, so this
+    /// node is the only place its content can be announced at all — and unlike
+    /// a decorative drawing, a code that cannot be read by anything but a
+    /// camera is a dead end for whoever cannot point one at it. It is read
+    /// fresh on every emission, and the payload watcher installed by
+    /// [`Self::set_invalidator`] is what schedules the frame that re-emits it.
+    fn accessibility_label(&self) -> Option<String> {
+        Some(self.payload.get().to_string())
+    }
+
+    fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
+        // The code is drawn from three signals read in `build_scene`, so a
+        // surface that is never told one of them changed keeps presenting the
+        // code it drew last — a stale payload, or a code that stayed light-on-
+        // dark through a switch to the light theme. Watching them schedules the
+        // frame that redraws; this is scene invalidation, not a subtree
+        // rebuild, so the content instance and its cached grid survive it.
+        self.guards = invalidator
+            .as_ref()
+            .map_or_else(alloc::vec::Vec::new, |invalidator| {
+                alloc::vec![
+                    invalidate_on_change(invalidator, &self.payload),
+                    invalidate_on_change(invalidator, &self.modules),
+                    invalidate_on_change(invalidator, &self.background),
+                ]
+            });
+        self.invalidator = invalidator;
+    }
+}
+
+/// Where the symbol sits inside the box layout handed the code, snapped so
+/// every module edge lands on a whole unit of that box's coordinate space.
+///
+/// Snapping is what keeps a code scannable rather than merely tidy. A module
+/// boundary that falls mid-pixel is antialiased into a grey seam, and a
+/// binarizer then has to guess which side of the boundary that seam belongs to;
+/// guess wrong often enough — and at small sizes it is wrong on most rows — and
+/// the symbol carries more damage than its error correction was sized for. With
+/// an integer module edge and an integer origin, every boundary is exact and
+/// nothing is antialiased at all.
+///
+/// The space being snapped to is the one `build_scene` is handed: the surface's
+/// own pixel grid where the scene owns a `GpuSurface`, and the window's logical
+/// grid — which is the device pixel grid at every integer scale factor — where
+/// a self-drawn backend merges the scene into its own.
+#[derive(Debug, Clone, Copy, PartialEq)]
+struct Grid {
+    /// Left edge of the drawn block, on a whole unit.
+    x: f64,
+    /// Top edge of the drawn block, on a whole unit.
+    y: f64,
+    /// One module's edge: a whole number of units, at least one.
+    module: f64,
+}
+
+impl Grid {
+    /// The largest snapped grid of `side` modules that fits `width` by
+    /// `height`, centred in it.
+    ///
+    /// `None` when the box does not hold one unit per module, which is a code
+    /// that could only be drawn by putting module boundaries inside pixels —
+    /// exactly the drawing this type exists to avoid.
+    fn fit(width: f32, height: f32, side: usize) -> Option<Self> {
+        let modules = f64::from(u32::try_from(side).ok()?);
+        let module = (f64::from(width.min(height)) / modules).floor();
+        if module < 1.0 {
+            return None;
+        }
+        let drawn = module * modules;
+        Some(Self {
+            x: ((f64::from(width) - drawn) / 2.0).floor(),
+            y: ((f64::from(height) - drawn) / 2.0).floor(),
+            module,
+        })
+    }
+}
+
+impl View for QrCode {
+    /// # Panics
+    ///
+    /// Panics when the environment carries no theme, since the code's default
+    /// colours are the theme's `Foreground` and `Surface`. Every backend
+    /// installs them; a bare [`Environment`] does not.
+    fn body(self, env: &Environment) -> impl View {
+        let (modules, background) = self.colors(env);
+        let content = QrContent::new(
+            self.payload,
+            self.correction,
+            self.quiet_zone,
+            self.module_size,
+            modules,
+            background,
+        );
+
+        // The code's accessibility node is the leaf's own: `QrContent` answers
+        // `SceneContent::accessibility_label` with the payload, which the
+        // backend offers as the node's name when the application named nothing
+        // itself. It cannot be attached here as `.a11y_label(…)` metadata —
+        // that is nearest-consumer and would beat the application's own label
+        // instead of yielding to it.
+        Frame::new(SceneView::new(content))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloc::rc::Rc;
+    use alloc::vec::Vec;
+    use core::cell::Cell;
+
+    use nami::Binding;
+    use waterui_core::layout::Size;
+    use waterui_graphics::color::{ResolvedColor, Srgb};
+    use waterui_graphics::{SceneContent as _, SceneInvalidator};
+    use waterui_str::Str;
+
+    use super::{DEFAULT_MODULE_SIZE, DEFAULT_QUIET_ZONE, Grid, QrContent, darker, lighter};
+    use crate::matrix::{ErrorCorrection, QrMatrix};
+
+    const PAYLOAD: &str = "https://waterui.dev";
+
+    fn content(payload: &Binding<Str>) -> QrContent {
+        QrContent::new(
+            payload.clone(),
+            ErrorCorrection::Medium,
+            DEFAULT_QUIET_ZONE,
+            DEFAULT_MODULE_SIZE,
+            ResolvedColor::from_srgb(Srgb::BLACK),
+            ResolvedColor::from_srgb(Srgb::WHITE),
+        )
+    }
+
+    /// A [`SceneInvalidator`] that counts the frames it was asked for.
+    fn counting_invalidator() -> (SceneInvalidator, Rc<Cell<usize>>) {
+        let redraws = Rc::new(Cell::new(0_usize));
+        let counted = Rc::clone(&redraws);
+        let invalidator: SceneInvalidator = Rc::new(move || counted.set(counted.get() + 1));
+        (invalidator, redraws)
+    }
+
+    #[test]
+    fn the_natural_size_is_the_grid_and_its_quiet_zone() {
+        let content = content(&Binding::container(Str::from_static(PAYLOAD)));
+        let width = QrMatrix::encode(PAYLOAD, ErrorCorrection::Medium)
+            .expect("the payload fits")
+            .width();
+
+        let modules = u16::try_from(width + 2 * usize::from(DEFAULT_QUIET_ZONE))
+            .expect("a symbol and its quiet zone are far inside u16");
+        let side = f32::from(modules) * DEFAULT_MODULE_SIZE;
+        assert_eq!(content.intrinsic_size(), Some(Size::new(side, side)));
+    }
+
+    /// A payload no symbol holds has no grid, and therefore no size — rather
+    /// than a size for a code that cannot be drawn.
+    #[test]
+    fn a_payload_that_does_not_encode_has_no_natural_size() {
+        let payload = Str::from(alloc::string::String::from_iter(core::iter::repeat_n(
+            'W', 4096,
+        )));
+        let content = content(&Binding::container(payload));
+        assert_eq!(content.intrinsic_size(), None);
+    }
+
+    #[test]
+    fn the_accessibility_node_carries_the_payload() {
+        let payload = Binding::container(Str::from_static(PAYLOAD));
+        let content = content(&payload);
+        assert_eq!(content.accessibility_label().as_deref(), Some(PAYLOAD));
+
+        payload.set(Str::from_static("https://example.invalid"));
+        assert_eq!(
+            content.accessibility_label().as_deref(),
+            Some("https://example.invalid"),
+            "the node must follow the payload signal, not freeze at what it was built with"
+        );
+    }
+
+    #[test]
+    fn changing_the_payload_asks_for_a_frame() {
+        let payload = Binding::container(Str::from_static(PAYLOAD));
+        let mut content = content(&payload);
+        let (invalidator, redraws) = counting_invalidator();
+
+        content.set_invalidator(Some(invalidator));
+        let installed = redraws.get();
+
+        payload.set(Str::from_static("https://example.invalid"));
+
+        assert!(
+            redraws.get() > installed,
+            "a code bound to state must schedule a frame when its payload changes"
+        );
+    }
+
+    /// A theme switch changes only the colours, and a surface that is not told
+    /// about it keeps presenting a code in the old scheme's polarity.
+    #[test]
+    fn changing_a_colour_asks_for_a_frame() {
+        let modules = Binding::container(ResolvedColor::from_srgb(Srgb::BLACK));
+        let mut content = QrContent::new(
+            Str::from_static(PAYLOAD),
+            ErrorCorrection::Medium,
+            DEFAULT_QUIET_ZONE,
+            DEFAULT_MODULE_SIZE,
+            modules.clone(),
+            ResolvedColor::from_srgb(Srgb::WHITE),
+        );
+        let (invalidator, redraws) = counting_invalidator();
+
+        content.set_invalidator(Some(invalidator));
+        let installed = redraws.get();
+
+        modules.set(ResolvedColor::from_srgb(Srgb::new(0.1, 0.1, 0.1)));
+
+        assert!(redraws.get() > installed);
+    }
+
+    #[test]
+    fn clearing_the_invalidator_stops_the_frames() {
+        let payload = Binding::container(Str::from_static(PAYLOAD));
+        let mut content = content(&payload);
+        let (invalidator, redraws) = counting_invalidator();
+
+        content.set_invalidator(Some(invalidator));
+        content.set_invalidator(None);
+        let cleared = redraws.get();
+
+        payload.set(Str::from_static("https://example.invalid"));
+
+        assert_eq!(
+            redraws.get(),
+            cleared,
+            "a surface that took its invalidator back must stop being asked for frames"
+        );
+    }
+
+    /// The grid's whole promise is that its coordinates are exact whole
+    /// numbers, so exact comparison is the assertion; an epsilon would pass on
+    /// precisely the drawing this type exists to rule out.
+    #[expect(
+        clippy::float_cmp,
+        reason = "a snapped grid's coordinates are exact integers by construction"
+    )]
+    #[test]
+    fn every_module_edge_lands_on_a_whole_unit() {
+        // 29 modules (a version-1 symbol with its quiet zone) in a box that is
+        // not a multiple of it: 200 / 29 is 6.89, so the grid must take 6.
+        let grid = Grid::fit(200.0, 200.0, 29).expect("29 modules fit 200 units");
+        assert_eq!(grid.module, 6.0);
+        assert_eq!(grid.x, 13.0, "the 26 leftover units are split evenly");
+        assert_eq!(grid.y, 13.0);
+
+        let edges: Vec<f64> = (0..=29)
+            .map(|index| grid.module.mul_add(f64::from(index), grid.x))
+            .collect();
+        assert!(
+            edges.iter().all(|edge| edge.fract() == 0.0),
+            "a module edge inside a pixel is a grey seam a binarizer has to guess at"
+        );
+        assert_eq!(
+            *edges.last().expect("the grid has edges"),
+            grid.x + 174.0,
+            "the drawn block is the module edge times the module count, exactly"
+        );
+    }
+
+    /// The box is the code's, not the symbol's: a non-square box centres the
+    /// grid on both axes and leaves the rest as clear space.
+    #[expect(
+        clippy::float_cmp,
+        reason = "a snapped grid's coordinates are exact integers by construction"
+    )]
+    #[test]
+    fn a_non_square_box_is_sized_by_its_shorter_side() {
+        let grid = Grid::fit(300.0, 200.0, 29).expect("29 modules fit the shorter side");
+        assert_eq!(grid.module, 6.0);
+        assert_eq!(grid.x, 63.0);
+        assert_eq!(grid.y, 13.0);
+    }
+
+    /// Below one unit a module there is no drawing that is not a guess, so
+    /// there is no grid.
+    #[test]
+    fn a_box_too_small_for_one_unit_a_module_has_no_grid() {
+        assert_eq!(Grid::fit(28.0, 28.0, 29), None);
+        assert!(Grid::fit(29.0, 29.0, 29).is_some());
+    }
+
+    #[test]
+    fn the_darker_colour_is_picked_by_perceptual_lightness() {
+        let black = ResolvedColor::from_srgb(Srgb::BLACK);
+        let white = ResolvedColor::from_srgb(Srgb::WHITE);
+
+        // Compared as the paint each resolves to, which is what the drawing
+        // actually uses and what makes the two colours distinguishable without
+        // comparing floats.
+        assert_eq!(darker(black, white).to_peniko(), black.to_peniko());
+        assert_eq!(darker(white, black).to_peniko(), black.to_peniko());
+        assert_eq!(lighter(black, white).to_peniko(), white.to_peniko());
+        assert_eq!(lighter(white, black).to_peniko(), white.to_peniko());
+    }
+}

--- a/components/codes/qr/tests/e2e_semantics.rs
+++ b/components/codes/qr/tests/e2e_semantics.rs
@@ -1,0 +1,110 @@
+//! End-to-end accessibility-semantics tests for the `qr` component.
+//!
+//! A QR code reaches the screen as an anonymous field of squares, and unlike a
+//! decorative drawing it is content: the whole point of the picture is a string
+//! that only a camera can get at. The node the leaf publishes is where anyone
+//! who cannot point a camera at it reads that string, so these tests pin what
+//! it carries.
+
+use core::time::Duration;
+
+use nami::Binding;
+use waterui::ViewExt as _;
+use waterui::component::vstack;
+use waterui::text::text;
+use waterui_qr::qr_code;
+use waterui_str::Str;
+use waterui_testing::{Role, SemanticApp, UiBuilder};
+
+const PAYLOAD: &str = "https://waterui.dev";
+const OTHER_PAYLOAD: &str = "https://waterui.dev/docs/qr";
+
+fn unlabelled_code() -> impl waterui::View {
+    qr_code(PAYLOAD)
+}
+
+fn labelled_code() -> impl waterui::View {
+    qr_code(PAYLOAD).a11y_label("Ticket")
+}
+
+/// A code in a stack, which proposes its own width to every child.
+fn code_in_a_stack() -> impl waterui::View {
+    vstack((qr_code(PAYLOAD), text("Scan to open")))
+}
+
+/// The code reaches the tree as an image node carrying what it encodes.
+#[waterui::test(unlabelled_code)]
+fn an_unnamed_code_publishes_its_payload(app: &mut SemanticApp) {
+    let node = app.query().role(Role::IMAGE).label(PAYLOAD).single();
+
+    let bounds = node.bounds();
+    assert!(
+        bounds.width() > 0.0 && bounds.height() > 0.0,
+        "the code's node must occupy the box it draws into, got {}x{}",
+        bounds.width(),
+        bounds.height()
+    );
+}
+
+/// What the application named the code wins: it knows what the code is for, and
+/// the payload is only the announcement of last resort.
+#[waterui::test(labelled_code)]
+fn an_application_label_wins_over_the_payload(app: &mut SemanticApp) {
+    app.query()
+        .role(Role::IMAGE)
+        .label("Ticket")
+        .assert_exists();
+
+    assert!(
+        !app.query().role(Role::IMAGE).label(PAYLOAD).exists(),
+        "a code the application named must not also be announced as its raw payload"
+    );
+}
+
+/// A code stays square wherever it is placed.
+///
+/// A stack names its children's cross axis, and scene content given one axis
+/// derives the other from its natural size — so what has to hold here is the
+/// ratio, not the extent: a QR code stretched into a rectangle is a code no
+/// decoder will look at twice, whatever size it is.
+#[waterui::test(code_in_a_stack)]
+fn a_code_placed_in_a_stack_stays_square(app: &mut SemanticApp) {
+    let bounds = app
+        .query()
+        .role(Role::IMAGE)
+        .label(PAYLOAD)
+        .single()
+        .bounds();
+
+    assert!(
+        (bounds.width() - bounds.height()).abs() < 1.0,
+        "the code must keep the square aspect of its module grid, got {}x{}",
+        bounds.width(),
+        bounds.height()
+    );
+    assert!(
+        bounds.width() > 0.0,
+        "the code must occupy the box it draws into"
+    );
+}
+
+/// The payload follows the signal, so a code bound to state does not announce
+/// what it encoded when its subtree was built.
+#[waterui::test]
+fn the_published_payload_follows_the_signal(ui: UiBuilder) {
+    let payload = Binding::container(Str::from_static(PAYLOAD));
+    let shown = payload.clone();
+    let mut app = ui.mount(move || qr_code(shown.clone()));
+
+    app.query().role(Role::IMAGE).label(PAYLOAD).assert_exists();
+
+    payload.set(Str::from_static(OTHER_PAYLOAD));
+
+    assert!(
+        app.query()
+            .role(Role::IMAGE)
+            .label(OTHER_PAYLOAD)
+            .wait_for_existence(Duration::from_secs(2)),
+        "the published payload must follow the code's signal"
+    );
+}

--- a/components/codes/qr/tests/round_trip.rs
+++ b/components/codes/qr/tests/round_trip.rs
@@ -1,0 +1,169 @@
+//! Renders the component offscreen and decodes the pixels back.
+//!
+//! This is the only assertion that says what matters about a QR code. Geometry
+//! tests say the modules are where the encoder put them; nothing but a decoder
+//! says whether a camera pointed at the screen would read the payload — and the
+//! ways a drawn code stops being readable (module edges antialiased into grey
+//! seams, a quiet zone that is not there, a light-on-dark polarity most
+//! detectors do not look for) all leave a picture that still looks like a QR
+//! code.
+//!
+//! The PNGs land in `WaterUI`'s canonical artifact layout, so the same run that
+//! asserts a code decodes also leaves the image to look at.
+
+use core::time::Duration;
+
+use image::GrayImage;
+use nami::Binding;
+use waterui::Environment;
+use waterui_graphics::color::Color;
+use waterui_qr::{ErrorCorrection, qr_code};
+use waterui_str::Str;
+use waterui_testing::{OffscreenApp, Snapshot, install_default_theme, ui};
+
+const PAYLOAD: &str = "https://waterui.dev";
+const OTHER_PAYLOAD: &str = "https://waterui.dev/docs/qr";
+
+/// Every payload the frame currently shows, as a decoder reads it.
+///
+/// The snapshot is the whole window rather than the code alone, which is what a
+/// camera sees too: the detector has to find the symbol before it can read it,
+/// and that is exactly what the quiet zone is for.
+fn decode(snapshot: &Snapshot) -> Vec<String> {
+    let luma = GrayImage::from_fn(snapshot.width, snapshot.height, |x, y| {
+        let index = ((y * snapshot.width + x) * 4) as usize;
+        let [red, green, blue, alpha] = [
+            f32::from(snapshot.rgba8[index]),
+            f32::from(snapshot.rgba8[index + 1]),
+            f32::from(snapshot.rgba8[index + 2]),
+            f32::from(snapshot.rgba8[index + 3]) / 255.0,
+        ];
+        // Composited over white, because that is what an uncomposited frame
+        // reaches a viewer's eye over and the alternative is reading a
+        // transparent pixel as black.
+        let over_white = |channel: f32| 255.0f32.mul_add(1.0 - alpha, channel * alpha);
+        let value = 0.2126f32.mul_add(
+            over_white(red),
+            0.7152f32.mul_add(over_white(green), 0.0722 * over_white(blue)),
+        );
+        #[expect(
+            clippy::cast_possible_truncation,
+            clippy::cast_sign_loss,
+            reason = "clamped to 0..=255 before the cast"
+        )]
+        let level = value.round().clamp(0.0, 255.0) as u8;
+        image::Luma([level])
+    });
+
+    rqrr::PreparedImage::prepare(luma)
+        .detect_grids()
+        .into_iter()
+        .filter_map(|grid| grid.decode().ok())
+        .map(|(_meta, content)| content)
+        .collect()
+}
+
+/// Asserts the frame decodes to exactly `expected`, and leaves the PNG behind.
+fn assert_decodes(app: &mut OffscreenApp, case: &str, stage: &str, expected: &str) {
+    let captured = app.capture_snapshot("waterui-qr", case, stage);
+    let decoded = decode(captured.snapshot());
+    assert_eq!(
+        decoded,
+        vec![String::from(expected)],
+        "{case}/{stage}: the rendered code must decode to its payload; \
+         the frame is at {}",
+        captured.path().display()
+    );
+}
+
+/// Two pixels a module — small enough that a module edge landing inside a pixel
+/// would put a grey seam on most rows of the symbol, which is the case snapping
+/// exists for.
+///
+/// The root view is offered the whole window, so the viewport is what sets the
+/// module size in these tests: this payload encodes to a 25-module symbol at the
+/// default correction, 33 modules with its quiet zone, and 80 units across 33
+/// modules snaps to 2.
+#[test]
+fn a_code_drawn_two_pixels_to_the_module_decodes() {
+    let mut app = ui().viewport(80, 80).mount_offscreen(|| qr_code(PAYLOAD));
+
+    assert_decodes(&mut app, "small", "00_two_pixels_a_module", PAYLOAD);
+}
+
+/// The same payload with room to spare, at the correction level that makes the
+/// largest symbol: 29 modules, 37 with the quiet zone, snapping to 11 units a
+/// module in a 420-unit window.
+#[test]
+fn a_large_code_decodes() {
+    let mut app = ui()
+        .viewport(420, 420)
+        .mount_offscreen(|| qr_code(PAYLOAD).correction(ErrorCorrection::High));
+
+    assert_decodes(&mut app, "large", "00_eleven_pixels_a_module", PAYLOAD);
+}
+
+/// The payload is a signal, so changing it re-encodes and redraws the existing
+/// surface. What is asserted is not that some pixels moved but that the *new*
+/// payload comes back out of the frame.
+#[test]
+fn the_drawn_code_follows_its_payload_signal() {
+    let payload = Binding::container(Str::from_static(PAYLOAD));
+    let shown = payload.clone();
+    let mut app = ui()
+        .viewport(320, 320)
+        .mount_offscreen(move || qr_code(shown.clone()));
+
+    assert_decodes(&mut app, "reactive", "00_initial", PAYLOAD);
+
+    payload.set(Str::from_static(OTHER_PAYLOAD));
+    // The change reaches the surface as a scene invalidation, so let the frames
+    // it schedules run before reading the pixels back.
+    app.pump_for(Duration::from_millis(64));
+
+    assert_decodes(&mut app, "reactive", "01_after_change", OTHER_PAYLOAD);
+}
+
+/// A dark theme must not invert the code.
+///
+/// `Foreground` on `Surface` taken verbatim would draw light modules on a dark
+/// ground under this theme, and `rqrr` — like `quirc` and `ZXing`, which is what
+/// the phone pointed at the screen is running — does not look for the
+/// reflectance-reversed form at all. This test is the reason the default pair
+/// is ordered by lightness rather than by role.
+#[test]
+fn a_dark_theme_keeps_the_code_scannable() {
+    let mut app = ui()
+        .theme(|env: &mut Environment| {
+            install_default_theme(env);
+            hydrolysis_m3::install_dark(env);
+        })
+        .viewport(320, 320)
+        .mount_offscreen(|| qr_code(PAYLOAD));
+
+    assert_decodes(&mut app, "dark", "00_dark_theme", PAYLOAD);
+}
+
+/// Why the default pair is ordered by lightness rather than by role.
+///
+/// Drawn deliberately reflectance-reversed — light modules on a dark ground,
+/// which is exactly what the theme's `Foreground` on `Surface` produces under a
+/// dark scheme — the code the tests above read back is not found at all. This
+/// is the evidence behind [`a_dark_theme_keeps_the_code_scannable`]: without
+/// the ordering, that test would be reading this frame.
+#[test]
+fn a_reflectance_reversed_code_is_not_found_by_a_decoder() {
+    let mut app = ui().viewport(320, 320).mount_offscreen(|| {
+        qr_code(PAYLOAD)
+            .module_color(Color::srgb(255, 255, 255))
+            .background_color(Color::srgb(0, 0, 0))
+    });
+
+    let captured = app.capture_snapshot("waterui-qr", "inverted", "00_light_on_dark");
+    assert!(
+        decode(captured.snapshot()).is_empty(),
+        "a light-on-dark code decoding would mean this crate's colour ordering \
+         guards against nothing; the frame is at {}",
+        captured.path().display()
+    );
+}

--- a/components/visual/graphics/src/color/mod.rs
+++ b/components/visual/graphics/src/color/mod.rs
@@ -254,6 +254,34 @@ impl ResolvedColor {
         linear_srgb_to_oklch(self.red, self.green, self.blue)
     }
 
+    /// Converts this resolved color into the paint a scene is drawn with.
+    ///
+    /// Everything that records into a [`Scene2D`](crate::scene2d::Scene2D)
+    /// needs its colours as `peniko`'s, so this is the one place the
+    /// conversion lives rather than a private copy per drawing component.
+    /// Components are gamma-encoded 8-bit sRGB, which is what `peniko`'s
+    /// `AlphaColor<Srgb>` stores; a P3 or HDR colour is therefore clamped into
+    /// the sRGB gamut here, the same way it is on its way to any 8-bit target.
+    #[must_use]
+    pub fn to_peniko(&self) -> peniko::Color {
+        let srgb = self.to_srgb();
+        let channel = |value: f32| {
+            #[expect(
+                clippy::cast_possible_truncation,
+                clippy::cast_sign_loss,
+                reason = "clamped to 0..=255 before the cast"
+            )]
+            let byte = (value * 255.0).clamp(0.0, 255.0).round() as u8;
+            byte
+        };
+        peniko::Color::from_rgba8(
+            channel(srgb.red),
+            channel(srgb.green),
+            channel(srgb.blue),
+            channel(self.opacity),
+        )
+    }
+
     /// Returns linear RGB components with HDR headroom applied.
     #[must_use]
     pub fn linear_with_headroom(&self) -> [f32; 3] {

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -416,7 +416,7 @@ impl View for Math {
 
         let brush = color.map_or_else(
             || Brush::Solid(PenikoColor::BLACK),
-            |signal| Brush::Solid(to_peniko(&signal.get())),
+            |signal| Brush::Solid(signal.get().to_peniko()),
         );
 
         let content = MathContent::new(
@@ -457,25 +457,6 @@ fn accessibility_markup(source: &Str, style: MathStyle) -> String {
             String::from(source.as_str())
         }
     }
-}
-
-fn to_peniko(color: &ResolvedColor) -> PenikoColor {
-    let srgb = color.to_srgb();
-    let channel = |value: f32| {
-        #[expect(
-            clippy::cast_possible_truncation,
-            clippy::cast_sign_loss,
-            reason = "clamped to 0..=255 before the cast"
-        )]
-        let byte = (value * 255.0).clamp(0.0, 255.0).round() as u8;
-        byte
-    };
-    PenikoColor::from_rgba8(
-        channel(srgb.red),
-        channel(srgb.green),
-        channel(srgb.blue),
-        channel(color.opacity),
-    )
 }
 
 #[cfg(test)]


### PR DESCRIPTION
No platform ships a QR primitive — a code is a picture everywhere — so `AGENTS.md` Principle 4 settles the architecture, and `waterui-qr` is a Rust-side self-drawn component with **zero new FFI types**. `qrcode` supplies the module grid and the grid is drawn through `Scene2D`, so a code renders on whichever engine the backend supplies (classic compute, the CPU/GPU split engine, dew's CPU scene) and stays vector sharp instead of being rasterized once into a bitmap.

## Encoder

`qrcode` 0.14.1 over `fast_qr` 0.14, `default-features = false`:

- **Licence.** MIT OR Apache-2.0, matching the workspace's own dual licence. `fast_qr` is MIT only, which narrows what WaterUI can offer downstream.
- **Exactly the API needed.** `QrCode::with_error_correction_level(…)` then `into_colors()` is the module matrix and nothing else; with default features off, the image, SVG and PIC renderers (and the `image` crate behind the first) are unreachable, leaving zero transitive dependencies. `fast_qr` is equally clean on that axis but stores every symbol as an inline 177×177 array, so the smallest code carries the largest symbol's storage.
- **Typed failure.** `QrError` is a real enum, so a payload past the largest symbol is a typed error rather than a panic or a silently smaller code.

## Snapping

One module is a whole number of units on a side and the block sits at a whole-unit origin, so every module boundary is exact. A boundary that falls inside a pixel is antialiased into a grey seam, and a decoder's binarizer then has to guess which side that seam belongs to — at small sizes it guesses wrong on most rows, which is more damage than the error correction was sized for. The space snapped to is the one `build_scene` is handed: the surface's own pixel grid under `GpuSurface`, the window's logical grid (the device pixel grid at every integer scale factor) where a backend merges the scene into its own. Whatever the box does not divide evenly is left as extra quiet zone, the one thing around a symbol that may grow freely.

The quiet zone itself — four modules, per ISO/IEC 18004 — is part of the drawing rather than something a caller must remember.

## Colours, and why the pair is ordered

Style is an attribute (Principle 1): correction level, quiet zone, module size and both colours are methods on the view, and the colours take `impl IntoComputed<Color>`.

The defaults are the theme's `Foreground` and `Surface` (Principle 6), but the **darker of the two always draws the modules**. A decoder looks for dark modules on a light ground, and the detectors in wide use — `quirc`, ZXing, and `rqrr`, which this PR's tests decode with — do not search for the reflectance-reversed form at all, so taking the pair verbatim would hand a dark-mode application a code that looks right and does not scan. Ordering by perceptual lightness keeps a themed application's own near-black and near-white rather than a hardcoded `#000` on `#fff`, and keeps the polarity a decoder needs across a colour-scheme switch. Naming either colour hands the judgement back to the caller.

## Tests

The round trip is the load-bearing one: the component is rendered offscreen through `waterui-testing`'s existing GPU-backed session and the pixels are decoded back with `rqrr`. Every way a drawn code stops being readable leaves a picture that still looks like a QR code, so nothing short of a decoder is evidence.

- two pixels a module and eleven pixels a module, both decode;
- a payload change through a `Binding` — the *new* payload comes back out of the frame;
- the dark theme decodes, and a deliberately inverted code is **not found**, which is the evidence behind the colour ordering rather than a claim about it;
- `tests/e2e_semantics.rs` asserts the accessibility node carries the payload, that an application label wins over it, that it follows the signal, and that the code stays square in a stack;
- an over-long payload is a `QrError::PayloadTooLong`, and finder-pattern geometry pins that the grid is indexed the way `is_dark` claims.

Frames land in WaterUI's canonical artifact layout, so the run that proves a code decodes also leaves the image to look at. Both were read directly: quiet zone present, finder patterns square with clean light rings, hard module edges with no bleeding even at two pixels a module.

## Also in this diff

`ResolvedColor::to_peniko` moves into `waterui-graphics`, where the conversion every scene-drawing component needs belongs. `waterui-math` carried a private copy — pre-existing duplication, not a defect — and now uses the shared one instead of this PR adding a third.

Fixes #113
