### PR TITLE
fix(android): keep a gesture with the view that took its touch-down

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
 apple-backend-commit = "5bb1cc890acf802c6e4e2e6130b1c91531743af7"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
-android-backend-commit = "438c232d5cbf61f35795b6faf715f45c80094da7"
+android-backend-commit = "36a83f93240a32d61eb571392cb8cc0bd4e8e44b"
 
 [[bin]]
 name = "water"


### PR DESCRIPTION
Dragging the Font Scale slider in `examples/form` and letting go left its dark value
bubble ("0.18") painted over the "Font Scale" label indefinitely — still there after 31
unrelated taps and several seconds.

## Root cause

The label is Material's and it is transient by design: `BaseSlider.onTouchEvent` calls
`setPressed(false)` on `ACTION_UP`, and the resulting `drawableStateChanged` is what
runs `ensureLabelsRemoved()`. The slider was simply never seeing the release.

`PassThroughFrameLayout` and `RustLayoutViewGroup` hit-test the way UIKit does, so a
touch landing on nothing interactive passes through to whatever is behind. Both asked
that question again **for every event of a gesture**, not once at its start. Android
does the opposite on purpose: a gesture belongs to whoever accepted its `ACTION_DOWN`
and is delivered there however far the finger then wanders. Re-deciding per event means
that the moment a drag drifts off the control it began on — a finger sliding up out of
a slider's row into the label above it is enough — dispatch stops. No release, no
cancel, and the slider stays pressed with its label up forever.

So this was never a slider bug. It was WaterUI's touch dispatch dropping the tail of
any gesture that wanders, and the stuck label is what made it visible. `labelBehavior`
is untouched (the default `LABEL_FLOATING` is correct), and nothing hides the label by
hand or on a timer.

## The fix

Both containers now route through one `GestureRouter`: it hit-tests the touch-down,
remembers whichever target accepted it, and hands that target the rest of the gesture
until the release or cancel that ends it. The pass-through and z-order fall-through
behaviour is unchanged, because the same hit-test still runs — once, where it belongs.
A target removed by a reactive rebuild mid-gesture is dropped rather than dispatched to
after it has left the hierarchy.

## Tests

`:runtime:testDebugUnitTest` (Robolectric) covers the release and the cancel arriving
after the finger has left the control, a real Material `Slider` ending unpressed after
such a drag, pass-through for a touch that starts on nothing interactive, and the target
being released so the next gesture hit-tests afresh. The three regression tests were run
against the previous dispatch and all three fail there.

## Verified on the Pixel 9 Pro

Same drag before and after, with the release drifting up out of the slider's row, then
two unrelated taps and a wait:

- Before: a dark "0.12" bubble sits over the "Font Scale" label, and the thumb is still
  drawn in its enlarged pressed form.
- After: the "Font Scale" label is fully readable, the thumb is back to its normal
  unpressed bar, and the drag was still applied (track filled to roughly 60%).

Screenshots: `scratchpad/form_402/before_fix_after_release.png` and
`after_fix_after_release.png`.

## Notes for review

- `:runtime:lintDebug` is red on android-backend `dev` for a pre-existing
  `PictureComponent` defect that this PR does not touch; it is fixed in #414, so it is
  not duplicated here.
- The Robolectric test dependency added to `runtime/build.gradle.kts` is the same
  addition #414 makes. Whichever of the two lands second needs that one hunk resolved
  by keeping a single copy.

Submodule: water-rs/android-backend@e2e6acf394b5212bdad8a79ee38eb699f7087704

Fixes #402
