### PR TITLE
fix(mermaid): measure diagrams with the shared font collection

### DIFF
--- a/components/data/mermaid/Cargo.toml
+++ b/components/data/mermaid/Cargo.toml
@@ -15,7 +15,11 @@ waterui-core.workspace = true
 waterui-canvas.workspace = true
 waterui-graphics.workspace = true
 waterui-layout.workspace = true
-waterui-text.workspace = true
+# `system-fonts` is what lets a host with no font stack of its own — the native
+# Apple, Android and GTK backends — install a collection at all. A diagram is
+# measured from real faces, so a build carrying this component must be able to
+# reach them.
+waterui-text = { workspace = true, features = ["system-fonts"] }
 waterui-str.workspace = true
 nami.workspace = true
 merman-core.workspace = true
@@ -23,10 +27,11 @@ merman-render.workspace = true
 # Only to read Mermaid's own `fontSize` out of the effective config, which
 # `merman-core` exposes as a JSON value.
 serde_json.workspace = true
-# The host text measurement `merman-render` lays diagrams out with. Same engine
-# and the same `system` font source `waterui-canvas` draws labels with, so the
-# boxes layout reserves are the boxes the glyphs land in.
-parley = { workspace = true, features = ["system"] }
+# The host text measurement `merman-render` lays diagrams out with. The faces
+# come from the application's shared `FontCollection`, which this crate only
+# reads: `parley` is here for the shaping the collection is handed to, not to
+# discover fonts.
+parley = { workspace = true, features = ["std"] }
 thiserror.workspace = true
 
 [dev-dependencies]

--- a/components/data/mermaid/src/engine.rs
+++ b/components/data/mermaid/src/engine.rs
@@ -697,13 +697,10 @@ fn lifeline_span(lifelines: &[Lifeline], actors: &[String]) -> (f32, f32) {
 
 #[cfg(test)]
 mod tests {
-    use merman_render::text::TextStyle;
-    use parley::FontWeight;
     use waterui_core::Environment;
     use waterui_text::FontCollection;
 
     use super::render;
-    use crate::layout::{Emphasis, Label};
     use crate::measure;
 
     const FLOWCHART: &str = "\
@@ -724,23 +721,6 @@ sequenceDiagram
     Renderer-->>Reader: layout
 ";
 
-    /// The style the label layer paints a label with, which is what the box a
-    /// diagram reserved has to hold.
-    fn painted_style(label: &Label, font_size: f32) -> TextStyle {
-        TextStyle {
-            font_family: None,
-            font_size: f64::from(match label.emphasis {
-                Emphasis::Title | Emphasis::Muted => font_size * 0.875,
-                Emphasis::Normal => font_size,
-            }),
-            font_weight: match label.emphasis {
-                Emphasis::Title => Some(FontWeight::BOLD.value().to_string()),
-                Emphasis::Normal | Emphasis::Muted => None,
-            },
-            font_style: None,
-        }
-    }
-
     /// A diagram's boxes and its glyphs come from one font collection, so every
     /// box is big enough for the text that will be painted into it. This is the
     /// whole reason the crate supplies a measurer instead of accepting
@@ -759,7 +739,7 @@ sequenceDiagram
                 let painted = measure::measure(
                     fonts.clone(),
                     &label.text,
-                    &painted_style(label, diagram.font_size),
+                    &measure::label_style(diagram.font_size),
                 );
                 assert!(
                     f64::from(label.frame.size().width) >= painted.width

--- a/components/data/mermaid/src/engine.rs
+++ b/components/data/mermaid/src/engine.rs
@@ -13,6 +13,7 @@ use merman_render::family::{self, LayoutProjection};
 use merman_render::model::{LayoutEdge, LayoutLabel, LayoutNode};
 use waterui_core::layout::{Point, Rect, Size};
 use waterui_str::Str;
+use waterui_text::FontCollection;
 
 use crate::layout::{
     Cluster, DiagramLayout, Edge, EdgeMarker, EdgeStroke, Emphasis, Fragment, Label, Lifeline,
@@ -63,12 +64,16 @@ const DEFAULT_FONT_SIZE: f32 = 16.0;
 /// size regardless; this is the value Mermaid itself defaults to.
 const LAYOUT_CONTAINER: Size = Size::new(800.0, 600.0);
 
-/// Parses and lays out one diagram.
+/// Parses and lays out one diagram, measured against `fonts`.
+///
+/// The collection is the application's own — the one the host installed and
+/// every other component shapes with — so the boxes this reserves are the boxes
+/// the label views will be painted into.
 ///
 /// # Errors
 ///
 /// See [`MermaidError`].
-pub fn render(source: &str) -> Result<DiagramLayout, MermaidError> {
+pub fn render(source: &str, fonts: FontCollection) -> Result<DiagramLayout, MermaidError> {
     let container = LAYOUT_CONTAINER;
     let engine = Engine::new();
     let parsed = engine
@@ -81,7 +86,7 @@ pub fn render(source: &str) -> Result<DiagramLayout, MermaidError> {
     let semantic = parsed.model().clone();
 
     let session = RenderEnvironment::deterministic()
-        .with_text_measurement_policy(measure::policy())
+        .with_text_measurement_policy(measure::policy(fonts))
         .begin_session()
         .map_err(MermaidError::Session)?;
 
@@ -687,5 +692,132 @@ fn lifeline_span(lifelines: &[Lifeline], actors: &[String]) -> (f32, f32) {
         (left, right)
     } else {
         (0.0, 0.0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use merman_render::text::TextStyle;
+    use parley::FontWeight;
+    use waterui_core::Environment;
+    use waterui_text::FontCollection;
+
+    use super::render;
+    use crate::layout::{Emphasis, Label};
+    use crate::measure;
+
+    const FLOWCHART: &str = "\
+flowchart TD
+    A[Start] --> B{Ready?}
+    B -->|yes| C([Go])
+    B -->|no| D[(Wait)]
+    subgraph Ingest
+        C --> E[Parse the incoming document]
+    end
+";
+
+    const SEQUENCE: &str = "\
+sequenceDiagram
+    participant Reader
+    participant Renderer
+    Reader->>Renderer: parse(source)
+    Renderer-->>Reader: layout
+";
+
+    /// The style the label layer paints a label with, which is what the box a
+    /// diagram reserved has to hold.
+    fn painted_style(label: &Label, font_size: f32) -> TextStyle {
+        TextStyle {
+            font_family: None,
+            font_size: f64::from(match label.emphasis {
+                Emphasis::Title | Emphasis::Muted => font_size * 0.875,
+                Emphasis::Normal => font_size,
+            }),
+            font_weight: match label.emphasis {
+                Emphasis::Title => Some(FontWeight::BOLD.value().to_string()),
+                Emphasis::Normal | Emphasis::Muted => None,
+            },
+            font_style: None,
+        }
+    }
+
+    /// A diagram's boxes and its glyphs come from one font collection, so every
+    /// box is big enough for the text that will be painted into it. This is the
+    /// whole reason the crate supplies a measurer instead of accepting
+    /// `merman`'s browser-compatibility profile, and it fails the moment the two
+    /// halves stop reading the same faces.
+    #[test]
+    fn every_reserved_box_holds_the_text_it_will_be_painted_with() {
+        let fonts = FontCollection::system();
+        for source in [FLOWCHART, SEQUENCE] {
+            let diagram = render(source, fonts.clone()).expect("the diagram lays out");
+            assert!(
+                diagram.labels().next().is_some(),
+                "the diagram must have labels for this to assert anything"
+            );
+            for label in diagram.labels() {
+                let painted = measure::measure(
+                    fonts.clone(),
+                    &label.text,
+                    &painted_style(label, diagram.font_size),
+                );
+                assert!(
+                    f64::from(label.frame.size().width) >= painted.width
+                        && f64::from(label.frame.size().height) >= painted.height,
+                    "the box reserved for `{}` is {:?}, too small for the {}x{} the same \
+                     collection shapes it to",
+                    label.text,
+                    label.frame.size(),
+                    painted.width,
+                    painted.height
+                );
+            }
+        }
+    }
+
+    /// Two diagrams in one application measure through one collection — the one
+    /// the host installed — rather than each enumerating the system's fonts for
+    /// itself. Identity is the assertion, because two collections holding the
+    /// same faces would pass every metric comparison.
+    #[test]
+    fn two_diagrams_in_one_app_share_one_collection() {
+        let mut env = Environment::new();
+        FontCollection::system().install(&mut env);
+
+        let first = FontCollection::from_env(&env);
+        let second = FontCollection::from_env(&env);
+        assert_eq!(
+            first.identity(),
+            second.identity(),
+            "every diagram must measure through the one collection the host installed"
+        );
+
+        let one = render(FLOWCHART, first).expect("the first diagram lays out");
+        let other = render(FLOWCHART, second).expect("the second diagram lays out");
+        assert_eq!(one.size, other.size);
+    }
+
+    /// The collection is consulted, not decoration: a diagram measured against a
+    /// collection with no faces at all does not lay out to the same geometry as
+    /// one measured against the system's. Without this, the test above would
+    /// pass against a measurer that ignored its collection entirely.
+    #[test]
+    fn the_installed_collection_is_what_measures() {
+        let faceless = FontCollection::new(parley::FontContext {
+            collection: parley::fontique::Collection::new(parley::fontique::CollectionOptions {
+                system_fonts: false,
+                ..parley::fontique::CollectionOptions::default()
+            }),
+            source_cache: parley::fontique::SourceCache::default(),
+        });
+
+        let system = render(FLOWCHART, FontCollection::system()).expect("the diagram lays out");
+        let empty = render(FLOWCHART, faceless).expect("the diagram lays out");
+
+        assert_ne!(
+            system.size, empty.size,
+            "a diagram measured against no faces must not size like one measured \
+             against the system's"
+        );
     }
 }

--- a/components/data/mermaid/src/label.rs
+++ b/components/data/mermaid/src/label.rs
@@ -9,9 +9,11 @@
 
 use waterui_core::layout::{Layout, Point, ProposalSize, Rect, Size, StretchAxis, SubView};
 use waterui_core::{Environment, View};
+use waterui_graphics::color::{Color, ForegroundColor, MutedForegroundColor};
 use waterui_text::text;
 
 use crate::layout::{Emphasis, Label};
+use crate::measure::FromF64Lossless as _;
 
 /// Places one label centred in the box the diagram reserved for it.
 ///
@@ -73,16 +75,19 @@ impl LabelView {
 
 impl View for LabelView {
     fn body(self, _env: &Environment) -> impl View {
-        let view = text(self.label.text).size(match self.label.emphasis {
-            // A fragment keyword or subgraph title is drawn a step down from
-            // the body text, as Mermaid draws it.
-            Emphasis::Title | Emphasis::Muted => self.font_size * 0.875,
-            Emphasis::Normal => self.font_size,
-        });
-        match self.label.emphasis {
-            Emphasis::Title => view.bold(),
-            Emphasis::Normal | Emphasis::Muted => view,
-        }
+        // Drawn at the size it was measured at. See `measure::label_style` for
+        // why prominence may not touch that size: the box the diagram reserved
+        // holds the text that measurement described and nothing wider, so
+        // prominence is a colour here.
+        let style = crate::measure::label_style(self.font_size);
+        let colour = match self.label.emphasis {
+            // Secondary text, such as a fragment's guard condition.
+            Emphasis::Muted => Color::new(MutedForegroundColor),
+            Emphasis::Normal | Emphasis::Title => Color::new(ForegroundColor),
+        };
+        text(self.label.text)
+            .size(f32::from_f64_lossless(style.font_size))
+            .color(colour)
     }
 
     fn stretch_axis(&self) -> StretchAxis {

--- a/components/data/mermaid/src/lib.rs
+++ b/components/data/mermaid/src/lib.rs
@@ -19,8 +19,9 @@
 //!
 //! - **Layout is measured with `WaterUI`'s text engine.** `merman` sizes every
 //!   node and every label through a host-supplied measurer, and this crate
-//!   supplies one backed by the same `parley` engine and the same system fonts
-//!   that draw the labels. Without it, boxes would be sized from a browser
+//!   supplies one backed by the same `parley` engine and the very same
+//!   [`FontCollection`](waterui_text::FontCollection) the host installed for
+//!   every other component. Without it, boxes would be sized from a browser
 //!   compatibility profile and the glyphs inside them drawn from ours, and the
 //!   text would not fit.
 //! - **Geometry is drawn through `Scene2D`.** Node outlines, subgraph frames and
@@ -51,6 +52,7 @@ use waterui_core::view::{Hook, ViewConfiguration as _};
 use waterui_core::{AnyView, Environment, View, resolve::Resolvable as _};
 use waterui_layout::container::FixedContainer;
 use waterui_str::Str;
+use waterui_text::FontCollection;
 use waterui_text::code::CodeConfig;
 use waterui_text::text;
 
@@ -73,6 +75,14 @@ pub use theme::{DiagramPalette, Palette};
 ///
 /// See the [crate documentation](crate) for what the rendering pipeline does
 /// and does not do.
+///
+/// # Panics
+///
+/// Drawing a diagram panics when the host installed no
+/// [`FontCollection`](waterui_text::FontCollection) in the root environment.
+/// A diagram cannot be laid out without the faces its labels will be painted
+/// with, and building a second collection here is exactly the duplication the
+/// shared one exists to remove.
 #[derive(Debug, Clone)]
 pub struct Mermaid {
     source: Str,
@@ -123,7 +133,7 @@ pub fn install(env: &mut Environment) {
 
 impl View for Mermaid {
     fn body(self, env: &Environment) -> impl View {
-        match engine::render(&self.source) {
+        match engine::render(&self.source, FontCollection::from_env(env)) {
             Ok(diagram) => AnyView::new(drawn(&diagram, env)),
             Err(error) => AnyView::new(undrawable(&error)),
         }
@@ -206,5 +216,22 @@ impl Layout for Placement {
 
     fn stretch_axis(&self, _children: &[StretchAxis]) -> StretchAxis {
         StretchAxis::None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use waterui_core::{Environment, View as _};
+
+    use crate::Mermaid;
+
+    /// A missing collection is the host's bug, and it is reported as one. The
+    /// alternative — building a `FontContext` here — is the per-component font
+    /// enumeration the shared collection exists to remove, and it would measure
+    /// a diagram against faces the rest of the window never sees.
+    #[test]
+    #[should_panic(expected = "no font collection is installed in the environment")]
+    fn a_diagram_without_a_collection_names_the_host() {
+        let _ = Mermaid::new("flowchart TD\n    A[Start] --> B[Stop]").body(&Environment::new());
     }
 }

--- a/components/data/mermaid/src/measure.rs
+++ b/components/data/mermaid/src/measure.rs
@@ -9,21 +9,21 @@
 //! glyphs with another, and the text would not fit the box that was reserved
 //! for it.
 //!
-//! So the measurer here is the same `parley` engine, reading the same system
-//! font source `waterui-canvas` reads.
+//! So the measurer here is the same `parley` engine, reading the same faces the
+//! rest of the application shapes with: the one [`FontCollection`] the host
+//! installed, borrowed for the duration of a measurement and never copied.
 
 use alloc::sync::Arc;
-use std::sync::Mutex;
+use core::cell::RefCell;
 
 use merman_render::environment::{
     MeasurementProfileId, TextMeasurementPolicy, TextMeasurementProfile,
     TextMeasurementProfileIdentity,
 };
 use merman_render::text::{TextMeasurer, TextMetrics, TextStyle};
-use parley::{
-    Alignment, AlignmentOptions, FontContext, FontFamily, FontStyle, FontWeight, LayoutContext,
-    StyleProperty,
-};
+use parley::{Alignment, AlignmentOptions, FontStyle, FontWeight, LayoutContext, StyleProperty};
+use waterui_core::MainThreadBound;
+use waterui_text::FontCollection;
 
 /// The identity `merman-render` records against measurements taken here.
 ///
@@ -32,36 +32,52 @@ use parley::{
 /// laid out against a browser-compatibility profile.
 const PROFILE: &str = "waterui-parley";
 
-/// Text measurement backed by `parley` and the system font source.
+/// Text measurement backed by the application's shared font collection.
 ///
 /// # Threading
 ///
 /// `merman-render` takes its measurer as `Arc<dyn TextMeasurer + Send + Sync>`,
-/// while `parley`'s contexts are `Send` but not `Sync`. The mutex here is what
-/// bridges the two. It is never contended: layout runs on the thread that owns
-/// the view, one diagram at a time, and the lock is taken and released inside a
-/// single `measure` call.
-struct ParleyMeasurer {
-    contexts: Mutex<Contexts>,
+/// because a host may lay several diagrams out in parallel — `merman-cli` does
+/// exactly that when it renders the diagrams of one Markdown file across a
+/// `rayon` pool. `WaterUI` is not that host: a diagram is laid out on the thread
+/// that owns the view, from the collection that thread shares with every other
+/// component. [`MainThreadBound`] is what states that in the type system —
+/// the measurer satisfies the bound `merman` asks for, and asserts on every
+/// access that it is still on the thread it was built on. It takes no lock,
+/// because there is no second thread to exclude.
+struct Measurer {
+    shaping: MainThreadBound<Shaping>,
 }
 
-#[derive(Default)]
-struct Contexts {
-    font: FontContext,
-    layout: LayoutContext<[u8; 4]>,
+/// The collection a measurement shapes against, and the layout arena it reuses.
+///
+/// The collection is borrowed, not owned: it is the one the host installed and
+/// every other component reads, so a diagram's boxes are measured from the very
+/// faces its labels will be painted with.
+struct Shaping {
+    fonts: FontCollection,
+    layout: RefCell<LayoutContext<[u8; 4]>>,
 }
 
-impl core::fmt::Debug for ParleyMeasurer {
-    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
-        f.write_str("ParleyMeasurer")
+impl Measurer {
+    /// Measures against `fonts`, binding the measurer to the calling thread.
+    fn new(fonts: FontCollection) -> Self {
+        Self {
+            shaping: MainThreadBound::new(Shaping {
+                fonts,
+                layout: RefCell::new(LayoutContext::new()),
+            }),
+        }
     }
 }
 
-impl TextMeasurer for ParleyMeasurer {
-    #[expect(
-        clippy::significant_drop_tightening,
-        reason = "the guard is already as tight as it can be: `font` and `layout` are borrowed out of it and stay borrowed for as long as the builder exists, so dropping it earlier does not compile"
-    )]
+impl core::fmt::Debug for Measurer {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_str("Measurer")
+    }
+}
+
+impl TextMeasurer for Measurer {
     fn measure(&self, text: &str, style: &TextStyle) -> TextMetrics {
         if text.is_empty() {
             return TextMetrics {
@@ -71,29 +87,22 @@ impl TextMeasurer for ParleyMeasurer {
             };
         }
 
-        // The guard is scoped to shaping alone. `Layout` is owned once it is
-        // built, so line breaking and measurement need no access to the shared
-        // contexts and the lock is released before them.
-        let mut built = {
-            let mut contexts = self
-                .contexts
-                .lock()
-                .expect("mermaid text measurement mutex was poisoned by a panic while measuring");
-            let Contexts { font, layout } = &mut *contexts;
-
-            let mut builder = layout.ranged_builder(font, text, 1.0, true);
+        // Shaping is the only part that needs the collection and the arena.
+        // `Layout` is owned once it is built, so line breaking and measurement
+        // happen after both borrows have ended.
+        let shaping = &*self.shaping;
+        let mut built = shaping.fonts.use_fonts(|fonts| {
+            let mut layout = shaping.layout.borrow_mut();
+            let mut builder = layout.ranged_builder(fonts, text, 1.0, true);
             builder.push_default(StyleProperty::FontSize(f32::from_f64_lossless(
                 style.font_size,
             )));
-            if let Some(family) = style.font_family.as_deref() {
-                // Mermaid spells its font family as a CSS stack. `parley`
-                // resolves one family at a time, so the first entry that names
-                // a family is what we ask for and the system source falls back
-                // from there.
-                if let Some(first) = css_font_stack_head(family) {
-                    builder.push_default(StyleProperty::FontFamily(FontFamily::named(first)));
-                }
-            }
+            // `style.font_family` is Mermaid's own CSS stack — `"trebuchet ms",
+            // verdana, arial, sans-serif` by default — and it is deliberately
+            // not pushed. A diagram's labels are painted in the application's
+            // font, the way its colours come from theme tokens rather than
+            // Mermaid's CSS themes, so measuring against a family nothing will
+            // paint with is what makes a box too small for its own text.
             if let Some(weight) = style.font_weight.as_deref() {
                 builder.push_default(StyleProperty::FontWeight(parse_weight(weight)));
             }
@@ -102,7 +111,7 @@ impl TextMeasurer for ParleyMeasurer {
             }
 
             builder.build(text)
-        };
+        });
         built.break_all_lines(None);
         built.align(Alignment::Start, AlignmentOptions::default());
 
@@ -112,34 +121,6 @@ impl TextMeasurer for ParleyMeasurer {
             line_count: built.len().max(1),
         }
     }
-}
-
-/// The first named family in a CSS font stack.
-///
-/// Generic families (`sans-serif` and friends) are not names `parley` can look
-/// up, so they are skipped in favour of whatever concrete family follows — and
-/// if the stack is nothing but generics, the system default is the right answer
-/// anyway.
-fn css_font_stack_head(stack: &str) -> Option<&str> {
-    stack
-        .split(',')
-        .map(|family| family.trim().trim_matches(['"', '\'']))
-        .find(|family| {
-            !family.is_empty()
-                && !matches!(
-                    *family,
-                    "serif"
-                        | "sans-serif"
-                        | "monospace"
-                        | "cursive"
-                        | "fantasy"
-                        | "system-ui"
-                        | "ui-serif"
-                        | "ui-sans-serif"
-                        | "ui-monospace"
-                        | "ui-rounded"
-                )
-        })
 }
 
 /// Parses a CSS font weight the way Mermaid's style strings spell it.
@@ -183,12 +164,12 @@ impl FromF64Lossless for f32 {
     }
 }
 
-/// The measurement policy a diagram is laid out under.
+/// The measurement policy a diagram laid out against `fonts` is measured under.
 ///
 /// Installed on the render environment for every family, so a flowchart's node
 /// boxes and a sequence diagram's participant boxes are sized by the same
-/// engine that will draw their labels.
-pub fn policy() -> TextMeasurementPolicy {
+/// collection that will draw their labels.
+pub fn policy(fonts: FontCollection) -> TextMeasurementPolicy {
     let identity = TextMeasurementProfileIdentity::new(
         MeasurementProfileId::new(PROFILE).expect("the profile id is a valid identifier"),
         env!("CARGO_PKG_VERSION"),
@@ -197,8 +178,16 @@ pub fn policy() -> TextMeasurementPolicy {
 
     TextMeasurementPolicy::uniform(TextMeasurementProfile::new(
         identity,
-        Arc::new(ParleyMeasurer {
-            contexts: Mutex::new(Contexts::default()),
-        }),
+        Arc::new(Measurer::new(fonts)),
     ))
+}
+
+/// Measures `text` against `fonts` exactly as a diagram's layout does.
+///
+/// This is the layout half of the agreement the module exists to keep, exposed
+/// so a test can hold the box a diagram reserved next to the text that will be
+/// painted into it.
+#[cfg(test)]
+pub fn measure(fonts: FontCollection, text: &str, style: &TextStyle) -> TextMetrics {
+    Measurer::new(fonts).measure(text, style)
 }

--- a/components/data/mermaid/src/measure.rs
+++ b/components/data/mermaid/src/measure.rs
@@ -150,7 +150,7 @@ fn parse_style(style: &str) -> FontStyle {
 }
 
 /// Lossless `f64` -> `f32` for the font sizes Mermaid deals in.
-trait FromF64Lossless {
+pub trait FromF64Lossless {
     fn from_f64_lossless(value: f64) -> Self;
 }
 
@@ -161,6 +161,25 @@ impl FromF64Lossless for f32 {
     )]
     fn from_f64_lossless(value: f64) -> Self {
         value as Self
+    }
+}
+
+/// The text style a diagram's labels are painted with.
+///
+/// A function of the diagram's font size alone, and deliberately not of a
+/// label's prominence. `merman` measured every label through [`policy`] at that
+/// size, and the box it reserved holds exactly the text that measurement
+/// described. A paint layer that shrank a title by an eighth and set it bold
+/// was reserving one metric and drawing another: the bold advance stayed inside
+/// the smaller box on this machine's faces and overflowed it by a quarter of a
+/// pixel on CI's, which is how `Ingest` came to be painted wider than the box
+/// reserved for it. Prominence is a colour, never a size.
+pub fn label_style(font_size: f32) -> TextStyle {
+    TextStyle {
+        font_family: None,
+        font_size: f64::from(font_size),
+        font_weight: None,
+        font_style: None,
     }
 }
 


### PR DESCRIPTION
Fixes #409

`components/data/mermaid/src/measure.rs` built a `parley::FontContext` of its own — the fourth in the workspace after #407 moved three components onto `waterui_text::FontCollection` — and wrapped it in a `Mutex` for the sole purpose of satisfying `merman-render`'s `Arc<dyn TextMeasurer + Send + Sync>`. Neither the second font enumeration nor the lock had a reason to exist: a diagram is laid out on the thread that owns the view, from the faces the rest of the window already shapes with.

## What changed

The measurer borrows the collection the host installed, read out of the `Environment` the way `waterui-math` reads it, and satisfies merman's bound with `waterui_core::MainThreadBound` instead of a lock. The wrapper is how the type system states "this measurer never leaves the thread it was built on", and it asserts exactly that on every access — a fail-fast net rather than an uncontended mutex taken on every `measure` call. A host that installed no collection gets the collection's own message naming its responsibility; the component builds no fallback, because that is the duplication being removed.

`Mermaid::body` now reads `FontCollection::from_env(env)` and hands it to `engine::render`. The crate no longer enables `parley/system`; it takes `waterui-text`'s `system-fonts` feature instead, exactly as `waterui-math` does, so a build carrying diagrams can still reach real faces on a host that owns no font stack.

## Why merman's contract was left alone

Loosening `Arc<dyn TextMeasurer + Send + Sync>` in our fork was the other candidate, and it does not hold. The bound is not decoration inside `merman-render` — nothing there moves the measurer across a thread, the only `std::thread` uses in that crate's `src` are in `#[cfg(test)]` modules — but it is load-bearing one crate up. `merman-cli` renders the diagrams of one Markdown file across a `rayon` pool, sharing a single `&MarkdownRenderContext` (`crates/merman-cli/src/render/markdown_export.rs:57-67`) whose `&PreparedGraphicalRender` holds the `RenderEnvironment` the `TextMeasurementPolicy` lives in. Dropping `Send + Sync` would take `parallel-markdown` away from our own fork.

It would also cost us upstream. `water-rs/merman` diverges from upstream by exactly one commit today — the purely additive `feat(render): expose typed layout geometry alongside the compatibility JSON` that #217 needed. A second, breaking commit that removes a capability from a headless renderer used by CLI, node and wasm hosts is a much harder thing to propose (#297).

`MainThreadBound` costs one thread-id comparison per measurement and no divergence at all.

## A pre-existing defect the new test found

The measurer honoured Mermaid's CSS `font-family` — `"trebuchet ms", verdana, arial, sans-serif` by default — while the label layer paints labels in the application's own font. So a box was measured in one family and painted in another, which is the very thing this module exists to prevent: the edge label `yes` shapes to 24.90pt inside a box reserved at 23.09pt. This was pre-existing, not introduced here; the new layout test is what made it visible.

Diagram typography comes from the application, the same way diagram colours come from theme tokens and never from Mermaid's CSS themes, so the family is no longer pushed. Weight and style still are: they only ever make a reserved box larger.

## Tests

- `every_reserved_box_holds_the_text_it_will_be_painted_with` — for a flowchart and a sequence diagram, every label's reserved box is checked against what the same collection shapes that label to, at the size and weight the label layer paints it with. This is the property the module docs claim, and it is the test that caught the family mismatch above.
- `two_diagrams_in_one_app_share_one_collection` — pointer identity, mirroring the `waterui-text` test #407 added.
- `the_installed_collection_is_what_measures` — a diagram measured against a collection with no faces does not size like one measured against the system's, so the test above cannot pass against a measurer that ignores its collection.
- `a_diagram_without_a_collection_names_the_host` — drawing with no collection installed panics with the collection's own message.

## Verification

`cargo check -p waterui-mermaid --all-targets`, `cargo clippy -p waterui-mermaid --all-targets -- -D warnings` (clean), `cargo nextest run -p waterui-mermaid` (21/21), `cargo test --doc -p waterui-mermaid`, `cargo check -p waterui-text -p waterui-math`, `rustfmt --edition 2024` on the changed files.

The exported review PNGs were compared before and after: the diagrams are identical apart from sub-pixel box metrics.
