### PR TITLE
fix(workspace): check canonical submodule lineage before blaming the workspace

### DIFF
--- a/.claude/skills/waterui-agent-workspace/scripts/common.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/common.sh
@@ -414,6 +414,42 @@ merge_branch_ff_only() {
   run_quietly git -C "$destination_repo" merge --ff-only FETCH_HEAD || die "failed to fast-forward merge ${label} from ${source_repo}; update or rebase the workspace first"
 }
 
+# Canonical's own submodule branches must sit on the same lineage as the commits
+# the canonical superproject pins. They drift apart in one routine way: a
+# finished workspace fast-forwards a canonical submodule branch to the commit
+# its pull request carried, and that pull request is then rebuilt on a moved
+# integration branch because another one bumped the same submodule first. The
+# abandoned lineage is left on the branch, `git submodule update` does not
+# notice (it detaches at the pin without touching the branch), and every
+# workspace afterwards fails its `--ff-only` merge with an error that reads as
+# though the workspace were at fault. Check canonical before touching a slot,
+# and name the repair.
+ensure_canonical_submodule_lineage() {
+  local source_root="$1"
+  local name
+  local submodule_relpath
+  local canonical_submodule
+  local target_branch
+  local pinned_commit
+  local branch_commit
+
+  while IFS=$'\t' read -r name submodule_relpath; do
+    [[ -n "${name:-}" ]] || continue
+    canonical_submodule="${source_root}/${submodule_relpath}"
+    target_branch="$(configured_submodule_branch "$source_root" "$name")"
+    [[ -n "$target_branch" ]] || die "submodule ${submodule_relpath} has no configured integration branch in .gitmodules"
+
+    git -C "$canonical_submodule" show-ref --verify --quiet "refs/heads/${target_branch}" || die "canonical submodule ${submodule_relpath} has no ${target_branch} branch"
+    branch_commit="$(git -C "$canonical_submodule" rev-parse "refs/heads/${target_branch}")" || die "failed to resolve ${target_branch} in $canonical_submodule"
+    pinned_commit="$(submodule_gitlink_commit "$source_root" "$submodule_relpath")"
+
+    git -C "$canonical_submodule" merge-base --is-ancestor "$pinned_commit" "$branch_commit" >/dev/null 2>&1 && continue
+    git -C "$canonical_submodule" merge-base --is-ancestor "$branch_commit" "$pinned_commit" >/dev/null 2>&1 && continue
+
+    die "canonical submodule ${submodule_relpath} has drifted: its ${target_branch} is at ${branch_commit} while the superproject pins ${pinned_commit}, and neither contains the other. The workspace is fine; canonical is wrong. Repair with: git -C ${canonical_submodule} branch -f ${target_branch} ${pinned_commit}"
+  done < <(submodule_records "$source_root")
+}
+
 ensure_fast_forward_possible() {
   local destination_repo="$1"
   local source_repo="$2"

--- a/.claude/skills/waterui-agent-workspace/scripts/create_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/create_workspace.sh
@@ -66,6 +66,7 @@ main() {
   source_root="$(canonical_dir "$SOURCE_REPO")"
   integration_branch="$(current_branch "$source_root")"
   ensure_source_submodules_ready "$source_root"
+  ensure_canonical_submodule_lineage "$source_root"
 
   # A workspace is built from committed state — `git clone` copies refs, and each
   # submodule is checked out at the gitlink recorded in HEAD — so whatever is

--- a/.claude/skills/waterui-agent-workspace/scripts/finish_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/finish_workspace.sh
@@ -178,6 +178,7 @@ main() {
   workspace_root="$(ensure_workspace_context)"
   workspace_contains_source_layout "$workspace_root"
   ensure_source_submodules_ready "$source_root"
+  ensure_canonical_submodule_lineage "$source_root"
   activate_all_submodules "$source_root"
   activate_all_submodules "$workspace_root"
 

--- a/.claude/skills/waterui-agent-workspace/scripts/sync_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/sync_workspace.sh
@@ -116,6 +116,7 @@ main() {
   workspace_root="$(ensure_workspace_context)"
   workspace_contains_source_layout "$workspace_root"
   ensure_source_submodules_ready "$source_root"
+  ensure_canonical_submodule_lineage "$source_root"
   activate_all_submodules "$source_root"
   activate_all_submodules "$workspace_root"
   ensure_no_integration_lock "$source_root"


### PR DESCRIPTION
`finish_workspace.sh` refused a workspace whose only change was one line of `AGENTS.md`:

```
error: failed to fast-forward merge submodule backends/android from /Users/lexoliu/Coding/waterui/backends/android; update or rebase the workspace first
```

The workspace was correct. Canonical's `backends/android` had its `dev` at the commit an earlier pull request carried, while the superproject pinned the commit that pull request was rebuilt as after another one bumped the same submodule first — two lineages, neither containing the other. `merge_branch_ff_only` fetches canonical's submodule branch into the workspace and merges `--ff-only`, so the drift blocked every workspace in the session, and the message sent the agent to rebase a workspace that was already right. `git submodule update` does not repair it either: it detaches at the pin and leaves the branch where it was.

This adds `ensure_canonical_submodule_lineage`, called from `create_workspace.sh`, `sync_workspace.sh` and `finish_workspace.sh` before any slot work: each submodule's integration branch and the commit the superproject pins must lie on one lineage. When they do not, the error names the repository at fault, prints both commits, and gives the repair:

```
error: canonical submodule backends/android has drifted: its dev is at e2e6acf3… while the
superproject pins e4786d52…, and neither contains the other. The workspace is fine; canonical
is wrong. Repair with: git -C …/backends/android branch -f dev e4786d52…
```

Verified both ways against the real drift: reproduced on the canonical checkout, saw exactly that message, restored the branch, and confirmed the guard passes on healthy state. The canonical checkout that hit this has been repaired.

Fixes #422