### PR TITLE
feat(controls): add the Avatar component

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12360,6 +12360,7 @@ name = "waterui"
 version = "0.3.0"
 dependencies = [
  "hydrolysis-m3",
+ "image",
  "waterui-dylib",
  "waterui-internal",
  "waterui-testing",
@@ -12992,6 +12993,7 @@ dependencies = [
  "tracing-subscriber",
  "tree-sitter",
  "tree-sitter-md",
+ "unicode-segmentation",
  "waterkit-haptic",
  "waterkit-screen",
  "waterui",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -283,6 +283,9 @@ waterui-dylib = { workspace = true, optional = true }
 [dev-dependencies]
 waterui-testing = { path = "testing" }
 hydrolysis-m3 = { path = "backends/hydrolysis_m3" }
+# Writes the test portrait the avatar visual acceptance renders. PNG only:
+# the encoder is all these tests need.
+image = { version = "0.25.10", default-features = false, features = ["png"] }
 
 [features]
 default = [

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -35,6 +35,9 @@ waterkit-screen = { workspace = true, optional = true }
 executor-core.workspace = true
 futures.workspace = true
 tracing.workspace = true
+# Grapheme clusters for the avatar monogram: a name's first "letter" is a
+# cluster, not a `char`, wherever a combining mark or an emoji sequence is one.
+unicode-segmentation = "1.12"
 tracing-subscriber = { workspace = true, optional = true }
 async-channel.workspace = true
 minstant.workspace = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,7 +92,9 @@ pub mod prelude {
     // Drag and drop extension traits
     pub use super::drag_drop::DropDestinationExt;
 
-    pub use super::widget::{Card, CardStyle, CardStyleTokens, CardTheme, Divider, card, suspense};
+    pub use super::widget::{
+        Avatar, Card, CardStyle, CardStyleTokens, CardTheme, Divider, avatar, card, suspense,
+    };
     #[cfg(feature = "flow-markdown")]
     pub use super::widget::{
         FlowAnimationPolicy, FlowAnimationPreset, FlowElementKind, FlowMarkdown, FlowStreamMode,

--- a/src/widget/avatar.rs
+++ b/src/widget/avatar.rs
@@ -1,0 +1,442 @@
+//! A small portrait standing in for a person or an entity.
+//!
+//! An avatar is an image clipped to a shape, with something legible to show
+//! when there is no image: the initials of a name, or a view the caller
+//! supplies. It is a Rust-side composition of primitives that already exist —
+//! a stack, a frame, a clip, theme tokens — and ships no FFI type of its own.
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::metadata::secure::ColorSpace;
+use crate::prelude::*;
+use crate::theme::color::{MutedForeground, SurfaceVariant};
+#[cfg(feature = "media")]
+use nami::signal::IntoComputed;
+use unicode_segmentation::UnicodeSegmentation as _;
+use waterui_controls::{IntoLabel, Label};
+use waterui_core::accessibility::{AccessibilityChildren, AccessibilityRole};
+use waterui_core::handler::{AnyViewBuilder, ViewBuilder};
+use waterui_layout::stack::zstack;
+use waterui_shape::{Circle, PathCommand, Shape, ShapeExt, ShapeKind};
+use waterui_text::Text;
+
+/// The side length an avatar takes when the caller names none, in points.
+///
+/// A list row's leading avatar, which is what most of them are.
+const DEFAULT_SIZE: f32 = 40.0;
+
+/// Initial glyphs are drawn at this fraction of the avatar's inner side.
+///
+/// Two capitals at 40% of a circle's diameter sit inside it with the optical
+/// margin a monogram wants; larger and the letters touch the clip.
+const INITIALS_SCALE: f32 = 0.4;
+
+/// A shape captured by value so an avatar can both clip to it and fill behind
+/// it.
+///
+/// [`Shape`] is a producer of path commands, not a value: `ClipShape::new`
+/// consumes one and `ShapeExt::fill` consumes another, while an avatar needs
+/// the same silhouette for its clip, its container fill, and its ring. Holding
+/// the resolved [`ShapeKind`] and unit-space commands lets one authored shape
+/// answer all three. The kind is what backends act on — a normalized radius
+/// resolved per axis turns a circular corner elliptical — so it is carried
+/// alongside the commands rather than derived from them.
+#[derive(Debug, Clone)]
+struct CapturedShape {
+    kind: ShapeKind,
+    commands: Vec<PathCommand>,
+}
+
+impl CapturedShape {
+    fn new(shape: &impl Shape) -> Self {
+        Self {
+            kind: shape.shape_kind(),
+            commands: shape.path().into_iter().collect(),
+        }
+    }
+
+    /// The corner radius, in points, that a [`Border`] must use to trace this
+    /// shape around a square of `side` points.
+    ///
+    /// An avatar's box is square, so a circle, an ellipse inscribed in it and
+    /// a capsule are the same outline: half the side.
+    fn corner_radius(&self, side: f32) -> f32 {
+        match self.kind {
+            ShapeKind::Rect | ShapeKind::CustomPath => 0.0,
+            ShapeKind::Circle | ShapeKind::Ellipse | ShapeKind::Capsule => side / 2.0,
+            ShapeKind::RoundedRect { corner_radius } => corner_radius * side,
+            ShapeKind::UnevenRoundedRect {
+                top_left,
+                top_right,
+                bottom_left,
+                bottom_right,
+            } => top_left.max(top_right).max(bottom_left).max(bottom_right) * side,
+        }
+    }
+}
+
+impl Shape for CapturedShape {
+    type Iter = Vec<PathCommand>;
+
+    fn path(&self) -> Self::Iter {
+        self.commands.clone()
+    }
+
+    fn shape_kind(&self) -> ShapeKind {
+        self.kind
+    }
+}
+
+impl ShapeExt for CapturedShape {}
+
+/// The outline drawn around an avatar.
+#[derive(Debug)]
+struct Ring {
+    color: Color,
+    width: f32,
+}
+
+/// A small portrait of a person or an entity.
+///
+/// The avatar always carries the name it stands for: assistive technology
+/// announces it, and with no image and no supplied fallback the initials drawn
+/// in the circle are derived from it. Everything else — shape, size, ring — is
+/// an attribute, so there is one `Avatar` type rather than a `CircleAvatar`
+/// and a `SquareAvatar`.
+///
+/// # Examples
+///
+/// ```rust
+/// use waterui::prelude::*;
+///
+/// let author = avatar("Ada Lovelace");
+/// ```
+///
+/// With a picture, a rounded-rectangle silhouette and a ring:
+///
+/// ```rust
+/// use waterui::prelude::*;
+/// use waterui::shape::RoundedRectangle;
+///
+/// # fn profile(photo: waterui::Url) -> impl View {
+/// avatar("Grace Hopper")
+///     .image(photo)
+///     .shape(RoundedRectangle::new(0.25))
+///     .size(64.0)
+///     .ring(Color::new(theme_color::Accent), 2.0)
+/// # }
+/// ```
+#[derive(Debug)]
+pub struct Avatar {
+    label: Label,
+    fallback: Option<AnyViewBuilder<AnyView>>,
+    #[cfg(feature = "media")]
+    image: Option<Computed<Url>>,
+    shape: CapturedShape,
+    size: f32,
+    ring: Option<Ring>,
+    color_space: ColorSpace,
+}
+
+impl Avatar {
+    /// An avatar named `name` that shows `fallback` when it has no image.
+    ///
+    /// This is the general constructor: `fallback` is any view — a monogram of
+    /// your own, an icon, a generated identicon. For the ordinary case, where
+    /// the fallback is the initials of the name, use [`avatar`].
+    ///
+    /// `name` is required, and required at construction, for the same reason
+    /// every `WaterUI` control demands a [`Label`]: a portrait with no name is
+    /// an anonymous image to a screen reader. It is never drawn — only spoken,
+    /// and read for the initials.
+    ///
+    /// ```rust
+    /// use waterui::prelude::*;
+    /// use waterui::widget::avatar::Avatar;
+    ///
+    /// # fn team() -> impl View {
+    /// Avatar::new("Katherine Johnson", || text("KJ").bold())
+    /// # }
+    /// ```
+    #[must_use]
+    pub fn new(name: impl IntoLabel, fallback: impl ViewBuilder) -> Self {
+        Self::with_fallback(
+            name,
+            Some(AnyViewBuilder::new(move || AnyView::new(fallback.build()))),
+        )
+    }
+
+    /// The shared constructor: `None` means "derive a monogram from the name".
+    fn with_fallback(name: impl IntoLabel, fallback: Option<AnyViewBuilder<AnyView>>) -> Self {
+        Self {
+            label: name.into_label(),
+            fallback,
+            #[cfg(feature = "media")]
+            image: None,
+            shape: CapturedShape::new(&Circle),
+            size: DEFAULT_SIZE,
+            ring: None,
+            // The issue this component answers, water-rs/waterui#93, is one
+            // line: ban HDR by default.
+            color_space: ColorSpace::Sdr,
+        }
+    }
+
+    /// Shows `source` inside the avatar's silhouette.
+    ///
+    /// The source is a signal, so pointing an avatar at a different picture
+    /// replaces the decoded frame without rebuilding anything around it. The
+    /// fallback stays behind the picture and shows through until the first
+    /// frame decodes, and again if the load fails.
+    #[cfg(feature = "media")]
+    #[must_use]
+    pub fn image(mut self, source: impl IntoComputed<Url>) -> Self {
+        self.image = Some(source.into_computed());
+        self
+    }
+
+    /// Clips the avatar to `shape` instead of a circle.
+    ///
+    /// ```rust
+    /// use waterui::prelude::*;
+    /// use waterui::shape::RoundedRectangle;
+    ///
+    /// # fn squircle() -> impl View {
+    /// avatar("Radia Perlman").shape(RoundedRectangle::new(0.25))
+    /// # }
+    /// ```
+    #[must_use]
+    #[expect(
+        clippy::needless_pass_by_value,
+        reason = "a shape is authored inline (`.shape(RoundedRectangle::new(0.25))`); taking a reference would force the caller to bind it first, and `ClipShape::new` takes it by value for the same reason"
+    )]
+    pub fn shape(mut self, shape: impl Shape) -> Self {
+        self.shape = CapturedShape::new(&shape);
+        self
+    }
+
+    /// Sets the avatar's side length in points. Avatars are square.
+    #[must_use]
+    pub const fn size(mut self, side: f32) -> Self {
+        self.size = side;
+        self
+    }
+
+    /// Draws a ring of `width` points around the avatar in `color`.
+    ///
+    /// The ring is drawn inside the avatar's own side length, so a ring never
+    /// changes how much room the avatar takes in a row.
+    #[must_use]
+    pub fn ring(mut self, color: impl Into<Color>, width: f32) -> Self {
+        self.ring = Some(Ring {
+            color: color.into(),
+            width,
+        });
+        self
+    }
+
+    /// Chooses the dynamic range the avatar's contents are shown in.
+    ///
+    /// An avatar defaults to [`ColorSpace::Sdr`], against the framework-wide
+    /// default of HDR. A portrait is a thumbnail sitting in a row of chrome: an
+    /// HDR source painted at 40 points has its highlights driven past the
+    /// display's white point, so the small bright disc blooms and glares
+    /// against the text beside it, and a row of avatars flickers as each one
+    /// loads. Opt an individual avatar back in with
+    /// `.dynamic_range(ColorSpace::Hdr)` when its picture is the subject rather
+    /// than a marker — a profile header at full width, say.
+    #[must_use]
+    pub const fn dynamic_range(mut self, space: ColorSpace) -> Self {
+        self.color_space = space;
+        self
+    }
+}
+
+impl View for Avatar {
+    fn body(self, env: &Environment) -> impl View {
+        let Self {
+            label,
+            fallback,
+            #[cfg(feature = "media")]
+            image,
+            shape,
+            size,
+            ring,
+            color_space,
+        } = self;
+
+        // Resolving first is what lets `accessibility_label` read a localized
+        // name: an unresolved environment-dependent `Text` has no content
+        // signal to take.
+        let name = label.resolve(env).accessibility_label();
+        let spoken = name.map(|name| name.to_plain()).computed();
+
+        let ring_width = ring.as_ref().map_or(0.0, |ring| ring.width);
+        let inner = (size - ring_width * 2.0).max(0.0);
+
+        let fallback = fallback.map_or_else(
+            || {
+                AnyView::new(
+                    Text::new(spoken.map(|name| initials(&name)).computed())
+                        .size(f64::from(inner * INITIALS_SCALE))
+                        .color(Color::new(MutedForeground)),
+                )
+            },
+            |fallback| fallback.build(),
+        );
+
+        #[cfg(feature = "media")]
+        let picture = image.map(|source| AnyView::new(Photo::new(source).resizable()));
+        #[cfg(not(feature = "media"))]
+        let picture: Option<AnyView> = None;
+
+        let content = zstack((fallback, picture))
+            .size(inner, inner)
+            .background(shape.clone().fill(Color::new(SurfaceVariant)))
+            .clip(shape.clone());
+
+        let framed = match ring {
+            Some(ring) => AnyView::new(content.padding_with(ring_width).border_with(
+                Border::new(ring.color, ring.width).corner_radius(shape.corner_radius(size)),
+            )),
+            None => AnyView::new(content),
+        };
+
+        framed
+            .a11y_label(spoken)
+            .a11y_role(AccessibilityRole::Image)
+            // The initials and the picture are the avatar's own chrome. Without
+            // this the monogram would announce itself a second time, under the
+            // node that already carries the person's full name.
+            .a11y_children(AccessibilityChildren::ExcludeDescendants)
+            .color_space(color_space)
+    }
+}
+
+/// An avatar named `name`, showing the initials of that name when it has no
+/// image.
+///
+/// The ergonomic counterpart to [`Avatar::new`], which takes an arbitrary
+/// fallback view.
+///
+/// ```rust
+/// use waterui::prelude::*;
+///
+/// # fn row() -> impl View {
+/// hstack((avatar("Ada Lovelace"), text("Ada Lovelace")))
+/// # }
+/// ```
+#[must_use]
+pub fn avatar(name: impl IntoLabel) -> Avatar {
+    Avatar::with_fallback(name, None)
+}
+
+/// The monogram shown for `name` when an avatar has no picture.
+///
+/// One grapheme cluster from the first word, and one from the last when the
+/// name has more than one word: `"Ada Lovelace"` reads `AL`, `"山田 太郎"`
+/// reads `山太`. A single word contributes a single glyph — `"Ada"` is `A`,
+/// not `AD`, because slicing a second letter out of one word produces an
+/// abbreviation nobody wrote, and in an unspaced script such as Chinese it
+/// would cut a name in half. Grapheme clusters rather than `char`s, so a
+/// combining mark or an emoji sequence is not split down the middle.
+/// Uppercasing is Unicode's own and leaves caseless scripts alone.
+fn initials(name: &str) -> Str {
+    let mut monogram = String::new();
+    let mut words = name.split_whitespace();
+    if let Some(first) = words.next() {
+        monogram.push_str(&first_grapheme(first));
+        if let Some(last) = words.last() {
+            monogram.push_str(&first_grapheme(last));
+        }
+    }
+    monogram.into()
+}
+
+fn first_grapheme(word: &str) -> String {
+    word.graphemes(true)
+        .next()
+        .map(str::to_uppercase)
+        .unwrap_or_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{Avatar, CapturedShape, avatar, initials};
+    use crate::metadata::secure::{ColorSpace, HighDynamicRange, StandardDynamicRange};
+    use waterui_core::{Environment, Metadata, View};
+    use waterui_shape::{Circle, RoundedRectangle, ShapeKind};
+
+    /// `AnyView::new` unwraps an `AnyView` rather than nesting one, so this
+    /// hands back exactly the view `Avatar::body` produced.
+    fn realize(avatar: Avatar) -> waterui_core::AnyView {
+        waterui_core::AnyView::new(avatar.body(&Environment::new()))
+    }
+
+    #[test]
+    fn an_avatar_is_standard_dynamic_range_unless_asked_otherwise() {
+        assert!(
+            realize(avatar("Ada Lovelace"))
+                .downcast::<Metadata<StandardDynamicRange>>()
+                .is_ok(),
+            "water-rs/waterui#93: an avatar opts its contents out of HDR"
+        );
+    }
+
+    #[test]
+    fn an_avatar_can_be_opted_back_into_high_dynamic_range() {
+        assert!(
+            realize(avatar("Ada Lovelace").dynamic_range(ColorSpace::Hdr))
+                .downcast::<Metadata<HighDynamicRange>>()
+                .is_ok(),
+            "an avatar whose picture is the subject can ask for the framework default back"
+        );
+    }
+
+    #[test]
+    fn two_word_names_take_the_first_and_last_initial() {
+        assert_eq!(&*initials("Ada Lovelace"), "AL");
+        assert_eq!(&*initials("grace brewster murray hopper"), "GH");
+    }
+
+    #[test]
+    fn one_word_names_take_a_single_glyph() {
+        assert_eq!(&*initials("Ada"), "A");
+        assert_eq!(&*initials("madonna"), "M");
+    }
+
+    #[test]
+    fn caseless_scripts_are_left_alone() {
+        assert_eq!(&*initials("山田 太郎"), "山太");
+        assert_eq!(&*initials("山田太郎"), "山");
+        assert_eq!(&*initials("Ольга Ладыженская"), "ОЛ");
+    }
+
+    #[test]
+    fn a_grapheme_cluster_is_never_split() {
+        // A base letter plus a combining acute; taking one `char` would show
+        // the accent as a lone mark on the next glyph.
+        assert_eq!(&*initials("e\u{301}douard Lucas"), "E\u{301}L");
+        assert_eq!(&*initials("👩‍🚀 Crew"), "👩‍🚀C");
+    }
+
+    #[test]
+    fn an_empty_name_has_no_monogram() {
+        assert_eq!(&*initials("   "), "");
+        assert_eq!(&*initials(""), "");
+    }
+
+    #[test]
+    fn a_ring_traces_the_shape_it_surrounds() {
+        assert!((CapturedShape::new(&Circle).corner_radius(40.0) - 20.0).abs() < f32::EPSILON);
+        assert!(
+            (CapturedShape::new(&RoundedRectangle::new(0.25)).corner_radius(40.0) - 10.0).abs()
+                < f32::EPSILON
+        );
+        assert!(matches!(
+            CapturedShape::new(&Circle).kind,
+            ShapeKind::Circle
+        ));
+    }
+}

--- a/src/widget/mod.rs
+++ b/src/widget/mod.rs
@@ -1,4 +1,5 @@
 pub mod accordion;
+pub mod avatar;
 pub mod card;
 pub mod condition;
 pub mod error;
@@ -6,6 +7,7 @@ pub mod suspense;
 // pub mod tree;
 
 pub use accordion::{Accordion, accordion};
+pub use avatar::{Avatar, avatar};
 pub use card::{Card, CardStyle, CardStyleTokens, CardTheme, card};
 pub use suspense::{Suspense, suspense};
 // pub use tree::{TreeNode, TreeView, tree_view};

--- a/tests/avatar.rs
+++ b/tests/avatar.rs
@@ -1,0 +1,231 @@
+//! Semantic and visual acceptance for the `Avatar` composer.
+//!
+//! Avatar is a Rust-side composition (Framework Design Principle #2) — a
+//! stack, a frame, a clip and theme tokens, with no FFI type of its own — so
+//! its contract is exactly what the accessibility tree exposes plus what the
+//! renderer draws. The PNG-producing test is ignored by default and reviewed
+//! by eye.
+
+use core::cell::Cell;
+use core::time::Duration;
+use std::path::{Path, PathBuf};
+use std::rc::Rc;
+
+use hydrolysis_m3::install as install_m3;
+use waterui::Str;
+use waterui::media::photo::Event as PhotoEvent;
+use waterui::prelude::*;
+use waterui::shape::RoundedRectangle;
+use waterui::widget::avatar::Avatar;
+use waterui_testing::{OffscreenApp, Role, UiBuilder};
+
+/// A 240×240 test portrait: four saturated quadrants.
+///
+/// Every feature is chosen to be read off the rendered avatar directly. The
+/// quadrant boundaries show whether the picture is centred and undistorted,
+/// and the silhouette's edge is the boundary between a saturated colour and
+/// the page — which reads in both colour schemes, unlike a light or dark
+/// border, either of which disappears into one of the two backgrounds and
+/// makes a circular clip look like an octagon.
+fn write_test_portrait(dir: &Path) -> PathBuf {
+    const SIDE: u32 = 240;
+    let path = dir.join("portrait.png");
+    let mut pixels = image::RgbaImage::new(SIDE, SIDE);
+    for (x, y, pixel) in pixels.enumerate_pixels_mut() {
+        *pixel = match (x < SIDE / 2, y < SIDE / 2) {
+            (true, true) => image::Rgba([220, 40, 40, 255]),
+            (false, true) => image::Rgba([40, 160, 60, 255]),
+            (true, false) => image::Rgba([40, 80, 220, 255]),
+            (false, false) => image::Rgba([230, 190, 40, 255]),
+        };
+    }
+    std::fs::create_dir_all(dir).expect("test portrait directory");
+    pixels.save(&path).expect("test portrait should encode");
+    path
+}
+
+fn portrait_url() -> Url {
+    let dir = std::env::temp_dir().join("waterui-avatar-tests");
+    Url::from_file_path_str(write_test_portrait(&dir).to_string_lossy().into_owned())
+}
+
+#[waterui::test(theme = install_m3)]
+fn an_initials_avatar_publishes_one_node_carrying_the_name(ui: UiBuilder) {
+    let mut app = ui.viewport(120, 120).mount(|| avatar("Ada Lovelace"));
+
+    let nodes = app.query().role(Role::IMAGE).all();
+    assert_eq!(
+        nodes.len(),
+        1,
+        "an avatar is one image node, whatever it draws inside itself"
+    );
+    app.query()
+        .role(Role::IMAGE)
+        .label("Ada Lovelace")
+        .assert_exists();
+    app.query()
+        .role(Role::LABEL)
+        .label("AL")
+        .assert_not_exists();
+}
+
+#[waterui::test(theme = install_m3)]
+fn a_pictured_avatar_publishes_the_same_single_node(ui: UiBuilder) {
+    let url = portrait_url();
+    let mut app = ui
+        .viewport(120, 120)
+        .mount(move || avatar("Grace Hopper").image(url.clone()));
+
+    let nodes = app.query().role(Role::IMAGE).all();
+    assert_eq!(
+        nodes.len(),
+        1,
+        "the decorative picture must not add a second, unlabelled node"
+    );
+    app.query()
+        .role(Role::IMAGE)
+        .label("Grace Hopper")
+        .assert_exists();
+}
+
+#[waterui::test(theme = install_m3)]
+fn renaming_relabels_the_node_it_already_published(ui: UiBuilder) {
+    let name = Binding::container(Str::from("Ada Lovelace"));
+    let name_for_view = name.clone();
+    let mut app = ui
+        .viewport(120, 120)
+        .mount(move || avatar(name_for_view.clone()));
+
+    let before = app
+        .query()
+        .role(Role::IMAGE)
+        .label("Ada Lovelace")
+        .single()
+        .id();
+
+    name.set(Str::from("Grace Hopper"));
+    assert!(
+        app.query()
+            .role(Role::IMAGE)
+            .label("Grace Hopper")
+            .wait_for_existence(Duration::from_secs(2)),
+        "the avatar's label must follow its name signal"
+    );
+
+    let after = app
+        .query()
+        .role(Role::IMAGE)
+        .label("Grace Hopper")
+        .single()
+        .id();
+    assert_eq!(
+        before, after,
+        "a name change relabels the published node; it must not replace the subtree"
+    );
+    app.query()
+        .role(Role::IMAGE)
+        .label("Ada Lovelace")
+        .assert_not_exists();
+}
+
+#[waterui::test(theme = install_m3)]
+fn the_monogram_follows_the_name_without_a_second_node(ui: UiBuilder) {
+    let name = Binding::container(Str::from("Ada Lovelace"));
+    let name_for_view = name.clone();
+    let mut app = ui
+        .viewport(120, 120)
+        .mount(move || avatar(name_for_view.clone()));
+
+    name.set(Str::from("山田 太郎"));
+    assert!(
+        app.query()
+            .role(Role::IMAGE)
+            .label("山田 太郎")
+            .wait_for_existence(Duration::from_secs(2)),
+        "the avatar's label must follow its name signal"
+    );
+    assert_eq!(
+        app.query().role(Role::IMAGE).all().len(),
+        1,
+        "the monogram redraw must not publish a node of its own"
+    );
+}
+
+/// One row of the gallery a reviewer reads: every silhouette, the ring, the
+/// monogram and a real picture.
+///
+/// `observed` is the picture whose load the capture waits on; it is attached to
+/// one avatar per gallery so the wait is on a real completion event rather than
+/// a guessed duration.
+fn row(url: Url, side: f32, observed: Option<Rc<Cell<bool>>>) -> impl View {
+    let watched = url.clone();
+    hstack((
+        avatar("Ada Lovelace").size(side),
+        avatar("山田 太郎")
+            .size(side)
+            .shape(RoundedRectangle::new(0.25)),
+        avatar("Katherine Johnson")
+            .size(side)
+            .ring(Color::new(theme_color::Accent), side / 20.0),
+        avatar("Grace Hopper").image(url).size(side),
+        observed.map(|observed| {
+            Avatar::new("Grace Hopper", move || {
+                let observed = Rc::clone(&observed);
+                Photo::new(watched.clone())
+                    .resizable()
+                    .on_event(move |event: PhotoEvent| {
+                        if matches!(event, PhotoEvent::Loaded) {
+                            observed.set(true);
+                        }
+                    })
+            })
+            .size(side)
+            .ring(Color::new(theme_color::Accent), side / 20.0)
+        }),
+    ))
+    .spacing(16.0)
+}
+
+/// The gallery: a realistic list-row size on top, and the same avatars at a
+/// size where the clip's edge, the ring's concentricity and the monogram's
+/// optical centring can be judged by eye.
+fn gallery(url: Url, loaded: Rc<Cell<bool>>) -> impl View {
+    vstack((row(url.clone(), 40.0, None), row(url, 128.0, Some(loaded))))
+        .spacing(20.0)
+        .padding_with(16.0)
+}
+
+fn capture(ui: UiBuilder, stage: &str) {
+    let url = portrait_url();
+    let loaded = Rc::new(Cell::new(false));
+    let observer = Rc::clone(&loaded);
+    let mut app: OffscreenApp = ui
+        .viewport(820, 236)
+        .mount_offscreen(move || gallery(url.clone(), Rc::clone(&observer)));
+
+    assert!(
+        app.pump_until(Duration::from_secs(5), || loaded.get()),
+        "the test portrait must decode before the gallery is captured"
+    );
+    let _ = app.capture_snapshot("avatar-preview", "gallery", stage);
+}
+
+#[ignore = "writes a visual acceptance PNG for direct image review"]
+#[waterui::test(theme = install_m3)]
+fn avatar_gallery_light(ui: UiBuilder) {
+    capture(ui, "light");
+}
+
+#[ignore = "writes a visual acceptance PNG for direct image review"]
+#[waterui::test]
+fn avatar_gallery_dark(ui: UiBuilder) {
+    capture(
+        ui.theme(|env: &mut Environment| {
+            hydrolysis_m3::install_with_colors(
+                env,
+                hydrolysis_m3::MaterialColorScheme::baseline_dark(),
+            );
+        }),
+        "dark",
+    );
+}


### PR DESCRIPTION
Fixes #93.

An avatar is a small portrait standing in for a person or an entity: an image clipped to a shape, with something legible to show when there is no image. It composes entirely from primitives that already exist — a stack, a frame, a clip, theme tokens — so it is a Rust-side composer and ships no new FFI type (Framework Design Principle #2).

## Where it lives

`src/widget/avatar.rs`, beside `Card`, `Accordion` and `Divider`, rather than `components/foundation/controls`. `waterui-controls` cannot reach any of the three things an avatar is made of: the picture (`waterui-media` depends on `waterui-controls`, so the arrow would have to reverse), the clip (`waterui-shape`), or the dynamic-range metadata, which lives in the facade crate. `src/widget` is where the existing Rust-side composers already sit.

## API

```rust
avatar("Ada Lovelace")                              // monogram derived from the name
Avatar::new("Ada Lovelace", || my_identicon())      // general: any fallback view
    .image(url)                                     // reactive picture layered over it
    .shape(RoundedRectangle::new(0.25))             // circle by default
    .size(64.0)
    .ring(Color::new(theme_color::Accent), 2.0)
    .dynamic_range(ColorSpace::Hdr)                 // opt back into HDR
```

Style is an attribute throughout (Principle 1): there is one `Avatar`, not a `CircleAvatar` and a `SquareAvatar`. `.shape` takes any `impl Shape` and keeps its resolved `ShapeKind`, which is also what sizes the ring's corner radius — no parallel shape type is introduced.

## HDR off by default — the issue

The knob is view metadata: `ViewExt::color_space(ColorSpace::Sdr)`, which is the friendly wrapper over `StandardDynamicRange`. Its own documentation already names this case ("in some cases you may want to apply standard dynamic range colour for certain views, for instance, user avatar"), so the component adopts it rather than inventing anything. An HDR source painted at 40 points drives its highlights past the display's white point, so the small bright disc blooms against the text beside it and a row of avatars flickers as each one loads. `.dynamic_range(ColorSpace::Hdr)` asks for the framework default back, for the case where the picture is the subject rather than a marker.

Two unit tests realize the body and downcast it, so "SDR by default" and "HDR on request" are asserted against the metadata that actually reaches a backend.

## Theming and accessibility

The container is `SurfaceVariant` and the monogram `MutedForeground` — Material's own `surface-variant` / `on-surface-variant` pair, so the avatar is legible in light and dark with nothing asked of the caller (Principle 6).

The name is required at construction, exactly as every control's `Label` is. Assistive technology announces it, and the decorative contents are excluded from the accessibility tree, so an avatar publishes exactly one node whether it is showing a picture or two letters.

Everything reactive is precise: the name is a signal, the monogram is derived from it by `map`, and the picture's source is a signal `Photo` already follows. Nothing goes through `watch(...)`, and a test asserts that changing the name through a `Binding` keeps the *same* accessibility node id and merely relabels it.

## The monogram

One grapheme cluster from the first word, and one from the last when there is more than one word: `"Ada Lovelace"` reads `AL`, `"山田 太郎"` reads `山太`. A single word contributes a single glyph — `"Ada"` is `A`, not `AD`, because slicing a second letter out of one word produces an abbreviation nobody wrote, and in an unspaced script it would cut a name in half. Grapheme clusters rather than `char`s, so a combining mark or an emoji sequence is never split; uppercasing is Unicode's own and leaves caseless scripts alone.

## Tests

`tests/avatar.rs` covers the semantics through `waterui-testing` (one node, the name as its label, no second node for the monogram or the picture, and node identity preserved across a rename) and renders a two-row gallery — a realistic 40pt list-row size and a 128pt row for judging edges — in both colour schemes through the existing offscreen snapshot infrastructure. The PNGs were reviewed by eye: the clip is a clean circle with smooth anti-aliased edges, the rounded-rectangle variant has circular corners, the ring is concentric and even, and the monogram is optically centred and legible on both the light and the dark container.

The gallery keeps a CJK avatar, whose monogram currently renders as tofu because hydrolysis's font collection has no CJK face. That is pre-existing and independent of this change — the monogram string itself is `山太`, asserted by unit test — and the gallery is left honest rather than made to render correctly by construction.

## Verification

`cargo check`, `cargo clippy --all-targets -D warnings`, `cargo nextest run` and `cargo test --doc` on `waterui-internal` and `waterui`, plus `cargo check -p waterui-internal --no-default-features` for the build without the `media` feature, and `rustfmt --edition 2024` on the changed files.
