### PR TITLE
ci(wasm): lint the wasm32 lane instead of only compiling it

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -157,9 +157,12 @@ jobs:
   # runner and everything else under `cfg(target_arch = "wasm32")` is compiled
   # out — so the browser build rotted through three unrelated breakages before
   # anyone pointed a compiler at it (#408). This is the cheapest statement that
-  # it still builds: a `cargo check` of the web runner plus the two crates whose
+  # it still builds: a clippy pass over the web runner plus the two crates whose
   # wasm-only paths it reaches (`waterui-media` reads local photos through the
   # kit file system there, and the kit dialog has a whole browser backend).
+  #
+  # It lints rather than merely compiles, so `cfg(target_arch = "wasm32")` code
+  # is held to the same bar as every other target (#413).
   #
   # It runs in both tiers rather than only in the nightly: a pull request
   # touching any of those three can break it, and the check is a couple of
@@ -171,7 +174,8 @@ jobs:
     env:
       # Cargo caps lints for registry dependencies, so this holds the workspace
       # crates — and only them — to the same "no new warnings" bar as the host
-      # lint pass. `cargo check` takes no trailing rustc arguments.
+      # lint pass. It reaches further than the trailing `-- -D warnings` below,
+      # which only covers the packages named with `-p`.
       RUSTFLAGS: -D warnings
     steps:
       - uses: actions/checkout@v4
@@ -191,12 +195,21 @@ jobs:
           cache-targets: false
           save-if: false
           cache-on-failure: true
-      - name: Check the web runner for wasm32
+      - name: Lint the web runner for wasm32
         run: |
-          cargo check --target wasm32-unknown-unknown \
+          cargo clippy --target wasm32-unknown-unknown \
             -p hydrolysis --features hydrolysis/web \
             -p waterui-media \
-            -p waterkit-dialog
+            -p waterkit-dialog \
+            -- -D warnings
+      # `kit` is its own Cargo workspace, excluded from the root one, so the
+      # step above builds `waterkit-dialog` as a plain path dependency: cargo
+      # only points clippy-driver at members of the workspace it was invoked
+      # from, and the dialog's browser backend would go unlinted there however
+      # the flags are spelled. Lint it from the workspace that owns it.
+      - name: Lint the kit dialog browser backend for wasm32
+        working-directory: kit
+        run: cargo clippy -p waterkit-dialog --target wasm32-unknown-unknown -- -D warnings
 
   # The workspace test run, per platform. On Linux it also carries the
   # doctests, which share its build; on macOS those go to `macos-suites`, so

--- a/backends/hydrolysis/src/platform.rs
+++ b/backends/hydrolysis/src/platform.rs
@@ -460,6 +460,13 @@ impl OffscreenGpuContext {
         pollster::block_on(Self::new_for_tests())
     }
 
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            clippy::arc_with_non_send_sync,
+            reason = "`OffscreenGpuContextInner` holds a wgpu adapter, device and queue, which the WebGPU backend makes neither `Send` nor `Sync` because they are JS objects. The context is shared by reference count on every target and is `Send + Sync` on all of them but this one, so the storage type is `Arc` everywhere rather than `Rc` here and `Arc` elsewhere."
+        )
+    )]
     async fn new_with_adapter_selection(selection: AdapterSelection) -> Self {
         let instance = wgpu::Instance::new(wgpu::InstanceDescriptor::new_without_display_handle());
         let adapter =
@@ -634,7 +641,7 @@ async fn request_hydrolysis_adapter(
             .await
             .expect("hydrolysis adapter selection: failed to find web adapter");
         log_selected_adapter(context, &adapter);
-        return adapter;
+        adapter
     }
 
     #[cfg(not(all(target_arch = "wasm32", feature = "web")))]

--- a/backends/hydrolysis/src/platform/web_impl.rs
+++ b/backends/hydrolysis/src/platform/web_impl.rs
@@ -890,10 +890,9 @@ fn map_modifiers_from_keyboard(event: &KeyboardEvent) -> Modifiers {
 
 /// The DOM `key` attribute already *is* the W3C UI Events logical key.
 fn map_w3c_key(event: &KeyboardEvent) -> keyboard_types::Key {
-    event
-        .key()
-        .parse()
-        .unwrap_or_else(|_| keyboard_types::Key::Named(keyboard_types::NamedKey::Unidentified))
+    event.key().parse().unwrap_or(keyboard_types::Key::Named(
+        keyboard_types::NamedKey::Unidentified,
+    ))
 }
 
 /// The DOM `code` attribute already *is* the W3C UI Events physical code.

--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -349,6 +349,13 @@ impl HydrolysisRenderer {
 
     /// As [`Self::new`], with the window renderer's Vello options spelled out.
     #[must_use]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            clippy::arc_with_non_send_sync,
+            reason = "`SharedSceneRenderer` and `WgslModuleCache` own wgpu handles, which the WebGPU backend makes neither `Send` nor `Sync` because they are JS objects. The renderer is shared by reference count on every target and is `Send + Sync` on all of them but this one, so the storage type is `Arc` everywhere rather than `Rc` here and `Arc` elsewhere."
+        )
+    )]
     pub fn new_with_options(
         adapter: &wgpu::Adapter,
         device: &wgpu::Device,

--- a/backends/hydrolysis/src/runner/web_runner.rs
+++ b/backends/hydrolysis/src/runner/web_runner.rs
@@ -204,10 +204,18 @@ impl BrowserRunner {
     }
 }
 
+/// The `requestAnimationFrame` closure, which has to stay alive on the Rust
+/// side for as long as the browser may call back into it.
+type AnimationFrameCallback = Closure<dyn FnMut(f64)>;
+
+/// Holds the frame scheduler, which cannot be built until the runner it
+/// schedules exists, so the slot is filled once construction has finished.
+type ScheduleFrameSlot = Rc<RefCell<Option<Rc<dyn Fn()>>>>;
+
 struct BrowserRunnerHandle {
     runner: RefCell<BrowserRunner>,
     raf_pending: Cell<bool>,
-    raf_callback: RefCell<Option<Closure<dyn FnMut(f64)>>>,
+    raf_callback: RefCell<Option<AnimationFrameCallback>>,
 }
 
 impl BrowserRunnerHandle {
@@ -242,7 +250,7 @@ impl BrowserRunnerHandle {
 
 pub fn run(app: App) {
     wasm_bindgen_futures::spawn_local(async move {
-        let schedule_frame_ref: Rc<RefCell<Option<Rc<dyn Fn()>>>> = Rc::new(RefCell::new(None));
+        let schedule_frame_ref: ScheduleFrameSlot = Rc::new(RefCell::new(None));
         let browser_schedule = {
             let schedule_frame_ref = schedule_frame_ref.clone();
             Rc::new(move || {

--- a/components/devtools/inspector/protocol/src/discovery.rs
+++ b/components/devtools/inspector/protocol/src/discovery.rs
@@ -194,6 +194,10 @@ fn process_exists(pid: u32) -> bool {
 }
 
 #[cfg(not(any(unix, windows)))]
+#[expect(
+    clippy::missing_const_for_fn,
+    reason = "this arm answers from a constant only because the target has no process table to ask; the `unix` and `windows` arms call into the OS, and `process_exists` has one signature on all three. Marking just this one `const` would propagate to `ProcessHandle::is_live` and make a public method `const` on some targets and not others."
+)]
 fn process_exists(_pid: u32) -> bool {
     // Without a cheap portable check, assume the process is alive and let the
     // connection attempt be the thing that fails.

--- a/components/visual/graphics/src/gpu/gpu_surface.rs
+++ b/components/visual/graphics/src/gpu/gpu_surface.rs
@@ -1300,6 +1300,13 @@ impl GpuSurface {
         clippy::future_not_send,
         reason = "offscreen GpuView setup is UI-local and borrows the main-thread Environment"
     )]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            clippy::arc_with_non_send_sync,
+            reason = "`SharedSceneRenderer` owns wgpu handles, which the WebGPU backend makes neither `Send` nor `Sync` because they are JS objects. The overriding renderer has to be the same `Arc` type the shared context hands back, so it cannot become an `Rc` on this target alone."
+        )
+    )]
     pub async fn render_offscreen_frames(
         mut self,
         runtime: &GpuRuntime,
@@ -1395,6 +1402,13 @@ impl GpuSurface {
     #[expect(
         clippy::future_not_send,
         reason = "offscreen GpuView setup is UI-local and borrows the main-thread Environment"
+    )]
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            clippy::arc_with_non_send_sync,
+            reason = "`SharedSceneRenderer` owns wgpu handles, which the WebGPU backend makes neither `Send` nor `Sync` because they are JS objects. The overriding renderer has to be the same `Arc` type the shared context hands back, so it cannot become an `Rc` on this target alone."
+        )
     )]
     pub async fn render_offscreen_hdr_frames(
         mut self,
@@ -1666,6 +1680,13 @@ impl View for GpuSurface {
     }
 }
 
+#[cfg_attr(
+    target_arch = "wasm32",
+    expect(
+        clippy::future_not_send,
+        reason = "holds a `wgpu::Buffer` and the device across the buffer-map await; on the WebGPU backend those are JS objects whose map state lives in an `Rc<RefCell<_>>`, and the same future is `Send` on every other target"
+    )
+)]
 async fn readback_texture(
     runtime: &GpuRuntime,
     texture: &wgpu::Texture,

--- a/components/visual/graphics/src/gpu/shared_context.rs
+++ b/components/visual/graphics/src/gpu/shared_context.rs
@@ -262,6 +262,14 @@ impl fmt::Debug for SharedGpuContext {
 }
 
 impl SharedGpuContext {
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            clippy::future_not_send,
+            clippy::arc_with_non_send_sync,
+            reason = "wgpu's WebGPU backend is a thin wrapper over JS objects held in `Rc<RefCell<_>>`, so its adapter/device/queue handles and its request futures are neither `Send` nor `Sync` on this target alone. The context is shared by reference count on every target, so the storage type stays `Arc` rather than splitting into `Rc` here and `Arc` everywhere else."
+        )
+    )]
     async fn new() -> Result<Self, SharedContextError> {
         let (instance, adapter) = request_instance_and_adapter().await?;
         let scene_engine = SceneEngine::for_adapter(&adapter);
@@ -325,6 +333,13 @@ impl SharedGpuContext {
     }
 }
 
+#[cfg_attr(
+    target_arch = "wasm32",
+    expect(
+        clippy::future_not_send,
+        reason = "`wgpu::Instance::request_adapter` resolves through `navigator.gpu.requestAdapter()`, a JS promise the WebGPU backend keeps in an `Rc<RefCell<_>>`; the same future is `Send` on every other target"
+    )
+)]
 async fn request_adapter(
     instance: &wgpu::Instance,
 ) -> Result<wgpu::Adapter, wgpu::RequestAdapterError> {
@@ -350,6 +365,13 @@ async fn request_instance_and_adapter()
 }
 
 #[cfg(not(target_os = "android"))]
+#[cfg_attr(
+    target_arch = "wasm32",
+    expect(
+        clippy::future_not_send,
+        reason = "awaits `request_adapter` above, whose WebGPU implementation is a JS promise held in an `Rc<RefCell<_>>`, and holds the resulting `wgpu::Instance` across it; both are `Send` on every other target"
+    )
+)]
 async fn request_instance_and_adapter()
 -> Result<(wgpu::Instance, wgpu::Adapter), SharedContextError> {
     let mut descriptor = wgpu::InstanceDescriptor::new_without_display_handle();
@@ -432,6 +454,14 @@ impl GpuRuntime {
     /// # Errors
     ///
     /// Returns the adapter or device initialization error.
+    #[cfg_attr(
+        target_arch = "wasm32",
+        expect(
+            clippy::future_not_send,
+            clippy::arc_with_non_send_sync,
+            reason = "awaits `SharedGpuContext::new`, whose WebGPU adapter and device requests are JS promises, and stores the resulting JS-backed handles; the runtime is shared by reference count on every target, so the storage type stays `Arc` rather than splitting into `Rc` here and `Arc` everywhere else"
+        )
+    )]
     pub async fn new() -> Result<Self, SharedContextError> {
         Ok(Self {
             context: Arc::new(SharedGpuContext::new().await?),

--- a/components/visual/graphics/src/gradients/gradient_renderer.rs
+++ b/components/visual/graphics/src/gradients/gradient_renderer.rs
@@ -537,6 +537,13 @@ struct MeshGpuResources {
     clippy::too_many_lines,
     reason = "mesh pipeline construction is one ordered graph of layouts, buffers, bindings, and validation"
 )]
+#[cfg_attr(
+    target_arch = "wasm32",
+    expect(
+        clippy::future_not_send,
+        reason = "holds the `GpuContext` and the buffers it created across the error-scope await; on the WebGPU backend every wgpu handle is a JS object kept in `Rc<RefCell<_>>`, and the same future is `Send` on every other target"
+    )
+)]
 async fn create_mesh_resources(ctx: &GpuContext<'_>, label_prefix: &str) -> MeshGpuResources {
     let (vertex_shader, fragment_shader, bind_group_layout) = single_bind_group_render_stages(
         &MESH_GRADIENT,

--- a/src/runtime/task/runtime_guard.rs
+++ b/src/runtime/task/runtime_guard.rs
@@ -22,8 +22,15 @@ const FALLBACK_REFRESH_RATE_HZ: f64 = 60.0;
 #[cfg(all(any(unix, windows), not(target_os = "espidf")))]
 type CpuClockSample = ThreadTime;
 
+/// Stands in for [`ThreadTime`] on targets with no per-thread CPU clock, so the
+/// sample a poll carries is a named "this platform cannot measure CPU time"
+/// rather than a bare `()`.
 #[cfg(not(all(any(unix, windows), not(target_os = "espidf"))))]
-type CpuClockSample = ();
+#[derive(Debug, Clone, Copy)]
+struct NoCpuClock;
+
+#[cfg(not(all(any(unix, windows), not(target_os = "espidf"))))]
+type CpuClockSample = NoCpuClock;
 
 #[cfg(all(any(unix, windows), not(target_os = "espidf")))]
 fn cpu_clock_now() -> CpuClockSample {
@@ -31,8 +38,8 @@ fn cpu_clock_now() -> CpuClockSample {
 }
 
 #[cfg(not(all(any(unix, windows), not(target_os = "espidf"))))]
-fn cpu_clock_now() -> CpuClockSample {
-    ()
+const fn cpu_clock_now() -> CpuClockSample {
+    NoCpuClock
 }
 
 #[cfg(all(any(unix, windows), not(target_os = "espidf")))]
@@ -41,7 +48,7 @@ fn cpu_clock_elapsed(start: CpuClockSample) -> Duration {
 }
 
 #[cfg(not(all(any(unix, windows), not(target_os = "espidf"))))]
-fn cpu_clock_elapsed(_start: CpuClockSample) -> Duration {
+const fn cpu_clock_elapsed(_start: CpuClockSample) -> Duration {
     Duration::ZERO
 }
 


### PR DESCRIPTION
`cargo check` proved the browser build still compiled but said nothing about its quality, so `cfg(target_arch = "wasm32")` code was the one target in the tree that no lint gate covered. The lane now runs `cargo clippy -- -D warnings`.

`kit` is its own Cargo workspace, excluded from the root one, so cargo never points clippy-driver at `waterkit-dialog` from the repository root however the flags are spelled — the dialog's browser backend gets a second step running clippy from the workspace that owns it.

Turning the gate on exposed pre-existing wasm-only findings, all fixed here rather than filed:

- `waterui-graphics`: every wgpu handle is a JS object held in `Rc<RefCell<_>>` under the WebGPU backend, so its GPU futures are `!Send` and its `Arc<SharedGpuContext>` / `Arc<SharedSceneRenderer>` are neither `Send` nor `Sync`. Nine item-level `expect`s, gated to wasm because the same code is `Send + Sync` everywhere else, and the storage type stays `Arc` rather than splitting per target.
- `hydrolysis`: the same wgpu reasoning for two `Arc` sites; a needless `return` in the web adapter branch, an `unwrap_or_else` that substitutes a constant, and two complex types now named by aliases.
- `waterui`: the fallback CPU clock returned `()`, which made the per-poll sample a unit binding. It is now a `NoCpuClock` marker, and both fallback helpers are `const fn`.
- `waterui-inspector-protocol`: `process_exists` answers from a constant only on targets with no process table; an `expect` records why that arm is not `const fn`, since making it so would leak into the public `ProcessHandle::is_live` on some targets and not others.

The `waterkit-dialog` findings named in the issue are item-level `#[expect(clippy::future_not_send, reason = …)]` on the browser-backend futures, in the `kit` submodule (`fix(dialog): admit that the browser dialog futures cannot be Send`), with the pin bumped here.

Fixes #413