### PR TITLE
refactor(cef): take Chromium's message loop out of the render callback

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12459,6 +12459,7 @@ dependencies = [
  "dirs",
  "executor-core",
  "futures",
+ "futures-lite",
  "futures-timer",
  "keycode",
  "kurbo 0.13.1",
@@ -12514,8 +12515,7 @@ dependencies = [
 [[package]]
 name = "waterui-canvas"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de6c5cbca41bf2d48a2b4a4c5028475b85a2231b2bce13b16b48274c3883c35"
+source = "git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe#ed4cecc706f69f381555f3fe193134da6e0ff7fe"
 dependencies = [
  "image",
  "kurbo 0.13.1",

--- a/components/platform/browser-cef/Cargo.toml
+++ b/components/platform/browser-cef/Cargo.toml
@@ -16,7 +16,6 @@ default = ["cef-runtime"]
 cef-runtime = ["cef/sandbox", "cef-dll-sys/sandbox"]
 compile-only = ["cef/dox", "cef-dll-sys/dox"]
 chromium = [
-    "dep:async-channel",
     "dep:base64",
     "dep:keycode",
     "dep:waterui-chromium",
@@ -32,13 +31,14 @@ webview = [
 ]
 
 [dependencies]
-async-channel = { version = "2.5", optional = true }
+async-channel = "2.5"
 base64 = { version = "0.22", optional = true }
 cef = { version = "=150.2.1", default-features = false }
 cef-dll-sys = { version = "=150.2.1", default-features = false }
 cookie = { version = "0.18.1", optional = true }
 dirs.workspace = true
 futures.workspace = true
+futures-lite.workspace = true
 futures-timer.workspace = true
 executor-core.workspace = true
 keycode = { version = "1.0", optional = true }

--- a/components/platform/browser-cef/src/app.rs
+++ b/components/platform/browser-cef/src/app.rs
@@ -1,4 +1,4 @@
-use std::sync::mpsc::Sender;
+use async_channel::Sender;
 
 use cef::rc::Rc as _;
 use cef::{
@@ -47,7 +47,7 @@ fn new_browser_process_handler(schedule: Sender<PumpDeadline>) -> BrowserProcess
 
         impl BrowserProcessHandler {
             fn on_schedule_message_pump_work(&self, delay_ms: i64) {
-                let _ = self.schedule.send(PumpDeadline::after_millis(delay_ms));
+                let _ = self.schedule.try_send(PumpDeadline::after_millis(delay_ms));
             }
         }
     }

--- a/components/platform/browser-cef/src/gpu/linux.rs
+++ b/components/platform/browser-cef/src/gpu/linux.rs
@@ -125,7 +125,13 @@ impl GpuView for CefGpuView {
     }
 
     fn render(&mut self, frame: &mut GpuFrame<'_>) {
-        self.page.pump();
+        // No pump here. Chromium's message loop belongs to
+        // `CefRuntime::start_message_pump`, which Chromium itself paces; running
+        // `do_message_loop_work` inside the render callback put whatever the
+        // browser had queued — parsing, script, compositing — on the main thread
+        // inside one frame's budget, which is what tripped the stall probe every
+        // few seconds on an idle page. Rendering presents the newest frame the
+        // sink has published and nothing else.
         request_browser_frame(&self.page, frame);
         let scale = sync_browser_viewport(&self.page, frame);
         let presenter = self

--- a/components/platform/browser-cef/src/gpu/macos.rs
+++ b/components/platform/browser-cef/src/gpu/macos.rs
@@ -155,7 +155,13 @@ impl GpuView for CefGpuView {
     }
 
     fn render(&mut self, frame: &mut GpuFrame<'_>) {
-        self.page.pump();
+        // No pump here. Chromium's message loop belongs to
+        // `CefRuntime::start_message_pump`, which Chromium itself paces; running
+        // `do_message_loop_work` inside the render callback put whatever the
+        // browser had queued — parsing, script, compositing — on the main thread
+        // inside one frame's budget, which is what tripped the stall probe every
+        // few seconds on an idle page. Rendering presents the newest frame the
+        // sink has published and nothing else.
         request_browser_frame(&self.page, frame);
         let scale = sync_browser_viewport(&self.page, frame);
         let presenter = self

--- a/components/platform/browser-cef/src/gpu/windows.rs
+++ b/components/platform/browser-cef/src/gpu/windows.rs
@@ -102,7 +102,13 @@ impl GpuView for CefGpuView {
     }
 
     fn render(&mut self, frame: &mut GpuFrame<'_>) {
-        self.page.pump();
+        // No pump here. Chromium's message loop belongs to
+        // `CefRuntime::start_message_pump`, which Chromium itself paces; running
+        // `do_message_loop_work` inside the render callback put whatever the
+        // browser had queued — parsing, script, compositing — on the main thread
+        // inside one frame's budget, which is what tripped the stall probe every
+        // few seconds on an idle page. Rendering presents the newest frame the
+        // sink has published and nothing else.
         request_browser_frame(&self.page, frame);
         let scale = sync_browser_viewport(&self.page, frame);
         let presenter = self

--- a/components/platform/browser-cef/src/page.rs
+++ b/components/platform/browser-cef/src/page.rs
@@ -766,7 +766,6 @@ fn new_client(
 /// CEF implementation of one visible or headless Chromium page.
 #[derive(Clone)]
 pub struct CefPageHandle {
-    runtime: CefRuntime,
     browser: Browser,
     host: BrowserHost,
     _request_context: RequestContext,
@@ -784,7 +783,11 @@ impl core::fmt::Debug for CefPageHandle {
 }
 
 impl CefPageHandle {
-    fn create(runtime: CefRuntime, configuration: CefPageConfiguration, mode: CefPageMode) -> Self {
+    fn create(
+        runtime: &CefRuntime,
+        configuration: CefPageConfiguration,
+        mode: CefPageMode,
+    ) -> Self {
         let state = Rc::new(PageState::new(mode));
         let mut client = new_client(
             new_render_handler(Rc::clone(&state)),
@@ -793,7 +796,7 @@ impl CefPageHandle {
             new_request_handler(Rc::clone(&state)),
             new_display_handler(Rc::clone(&state)),
         );
-        let mut request_context = create_request_context(&runtime, &configuration);
+        let mut request_context = create_request_context(runtime, &configuration);
         let initial_url = configuration
             .url
             .as_ref()
@@ -827,7 +830,6 @@ impl CefPageHandle {
             }
         });
         let handle = Self {
-            runtime,
             browser,
             host,
             _request_context: request_context,
@@ -860,11 +862,6 @@ impl CefPageHandle {
         self.state.frame_sink.replace(Some(Rc::new(sink)));
         self.host.was_resized();
         self.host.invalidate(PaintElementType::VIEW);
-    }
-
-    /// Executes due work for the process-owned CEF external message pump.
-    pub fn pump(&self) {
-        let _ = self.runtime.pump();
     }
 
     /// Requests one compositor frame for this windowless browser.
@@ -1330,7 +1327,7 @@ impl CefController {
         configuration: CefPageConfiguration,
         mode: CefPageMode,
     ) -> CefPageHandle {
-        CefPageHandle::create(self.runtime.clone(), configuration, mode)
+        CefPageHandle::create(&self.runtime, configuration, mode)
     }
 }
 

--- a/components/platform/browser-cef/src/runtime.rs
+++ b/components/platform/browser-cef/src/runtime.rs
@@ -4,10 +4,10 @@
 //! that the framework exports those entry points at the declared signatures.
 //! `libloading` keeps the framework mapped for as long as the `Library` lives.
 
+use async_channel::{Receiver, TryRecvError, unbounded};
 use std::cell::Cell;
 use std::path::{Path, PathBuf};
 use std::rc::Rc;
-use std::sync::mpsc::{Receiver, TryRecvError, channel};
 use std::time::{Duration, Instant};
 
 use cef::args::Args;
@@ -22,6 +22,26 @@ use crate::app::new_app;
 #[cfg(any(feature = "chromium", feature = "webview"))]
 use crate::page::CefController;
 
+/// How long the pump may go without hearing from Chromium before running anyway.
+///
+/// Pacing otherwise comes from Chromium: it calls `OnScheduleMessagePumpWork`
+/// with the delay it wants — measured on an idle page, only ever 0 ms or 83 ms —
+/// and [`CefRuntime::start_message_pump`] wakes on that request even mid-sleep.
+///
+/// This interval is not a free parameter. `do_message_loop_work` is a
+/// variable-cost call on the UI thread, and how often it runs decides how much
+/// work each call has to drain, so both directions are worse. Measured on
+/// `examples/chromium` with the page idle after its first accelerated paint,
+/// counting main-thread polls that reached the frame-budget warning threshold:
+///
+/// | interval | over-budget polls | worst poll |
+/// |---|---|---|
+/// | 8 ms | 20.2 / min | 654 ms |
+/// | 33 ms | 5.8 / min | 10 ms |
+/// | 1 s | 7.7 / min | 15 ms |
+///
+/// Pumping more often multiplies the fixed cost of the call; pumping less often
+/// hands each call a bigger backlog. Change this only against a new measurement.
 const MAXIMUM_PUMP_INTERVAL: Duration = Duration::from_millis(1000 / 30);
 
 #[derive(Deserialize)]
@@ -456,7 +476,7 @@ fn bootstrap(paths: &CefRuntimePaths) -> Result<CefBootstrap, i32> {
         "loaded CEF runtime has no compatible API hash"
     );
 
-    let (schedule, pump_requests) = channel();
+    let (schedule, pump_requests) = unbounded();
     let mut app = new_app(schedule);
     let subprocess_exit = execute_process(Some(args.as_main_args()), Some(&mut app), sandbox_info);
     if subprocess_exit >= 0 {
@@ -635,7 +655,7 @@ impl CefRuntime {
             match self.inner.pump_requests.try_recv() {
                 Ok(deadline) => requested = Some(deadline.instant()),
                 Err(TryRecvError::Empty) => break,
-                Err(TryRecvError::Disconnected) => {
+                Err(TryRecvError::Closed) => {
                     panic!("CEF browser-process message pump disconnected")
                 }
             }
@@ -675,6 +695,7 @@ impl CefRuntime {
             return;
         }
         let runtime = Rc::downgrade(&self.inner);
+        let requests = self.inner.pump_requests.clone();
         executor_core::spawn_local(async move {
             loop {
                 let Some(inner) = runtime.upgrade() else {
@@ -683,7 +704,24 @@ impl CefRuntime {
                 // The strong reference must not be held across the await, or
                 // this task would keep CEF alive for the life of the process.
                 let deadline = Self { inner }.pump().instant();
-                futures_timer::Delay::new(deadline.saturating_duration_since(Instant::now())).await;
+                let sleep = async {
+                    futures_timer::Delay::new(deadline.saturating_duration_since(Instant::now()))
+                        .await;
+                    None
+                };
+                // Sleeping out the whole deadline would ignore a request that
+                // arrives during it, and Chromium asks for an immediate pump
+                // the moment it has work — which is every frame of an
+                // animating page. That is what capped a page at the idle
+                // ceiling and made the render callback pump to make up for it.
+                let requested =
+                    futures_lite::future::race(sleep, async { requests.recv().await.ok() }).await;
+                if let Some(requested) = requested {
+                    let Some(inner) = runtime.upgrade() else {
+                        return;
+                    };
+                    inner.next_pump.set(requested.instant());
+                }
             }
         })
         .detach();


### PR DESCRIPTION
`CefGpuView::render` called `page.pump()` — `do_message_loop_work` — before presenting, so whatever Chromium had queued ran on the main thread inside one frame's budget. That call is legacy: it predates `CefRuntime::start_message_pump`, which took over pacing a month later and made a second pumper redundant. Rendering now presents the newest frame the sink published and nothing else, on macOS, Windows and Linux, and `CefPageHandle::pump` goes with it.

Removing it alone would have capped a page at the pump's idle interval, because the task slept out its whole deadline and ignored any request that arrived during it — and Chromium asks for an immediate pump the moment it has work, which is every frame of an animating page. The task now races its deadline against the request channel, so a request wakes it. That needs an async channel, so `async-channel` becomes an unconditional dependency of the crate instead of one the `chromium` feature brings in.

## What the measurements say, and why this does not close #406

Measured on `examples/chromium` on macOS, page idle after its first accelerated paint, counting main-thread polls that reached the frame-budget warning threshold.

The over-budget poll is **Chromium's own message loop**. Timing probes on `MacFrameSink::import` and on the presenter never fired once; `do_message_loop_work` runs 5–10 ms against the 8.3 ms budget of a 120 Hz frame. CEF requires that loop on the thread that initialised it, so the work cannot move off the main thread, and taking it out of the render callback moves the cost to the pump task on the same thread rather than removing it.

Cadence is not the lever either. Chromium only ever asks for 0 ms or 83 ms on an idle page, and sweeping the interval:

| pump interval | over-budget polls | worst poll |
|---|---|---|
| 8 ms | 20.2 / min | 654 ms |
| 33 ms (current) | 5.8 / min | 10 ms |
| 1 s | 7.7 / min | 15 ms |

Pumping more often multiplies the fixed cost of the call; pumping less often hands each call a bigger backlog. The minimum is where the constant already sat, so it keeps its value and now carries the table that says why, in place of a bare `1000 / 30`.

So this lands the part of #406 that is a real defect — a duplicate, legacy pump inside the render callback — and records what the remaining warnings actually are. #406 stays open with the measurements on it, because the symptom it names is not gone.

Refs #406