### PR TITLE
feat(math): speak the formula instead of announcing its MathML

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arboard"
@@ -2607,6 +2610,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3242,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +3318,16 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "backtrace",
+ "version_check",
 ]
 
 [[package]]
@@ -5573,7 +5620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -6316,6 +6363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6636,6 +6689,33 @@ dependencies = [
  "indexmap 2.14.0",
  "papaya",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "mathcat"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a23e5a28e90434c787466125d2d2658d284f6f2779d6fbe6a6155f442be985"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if 1.0.4",
+ "dirs",
+ "env_logger",
+ "error-chain",
+ "fastrand",
+ "lazy_static",
+ "log",
+ "phf",
+ "radix_fmt",
+ "regex",
+ "roman-numerals-rs",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "sxd-document",
+ "sxd-xpath",
+ "unicode-script",
+ "yaml-rust",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -8432,6 +8512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "peresil"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57"
+
+[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8832,6 +8918,12 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
@@ -8876,6 +8968,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_fmt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
 
 [[package]]
 name = "rand"
@@ -9338,6 +9436,12 @@ dependencies = [
  "symphonia",
  "thiserror 2.0.20",
 ]
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "roughr-merman"
@@ -10396,6 +10500,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sxd-document"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d82f37be9faf1b10a82c4bd492b74f698e40082f0f40de38ab275f31d42078"
+dependencies = [
+ "peresil",
+ "typed-arena",
+]
+
+[[package]]
+name = "sxd-xpath"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e39da5d30887b5690e29de4c5ebb8ddff64ebd9933f98a01daaa4fd11b36ea"
+dependencies = [
+ "peresil",
+ "quick-error 1.2.3",
+ "sxd-document",
+]
+
+[[package]]
 name = "symphonia"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10797,7 +10922,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -11270,6 +11395,12 @@ dependencies = [
  "serde_derive",
  "syntect",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
 
 [[package]]
 name = "typed-path"
@@ -13135,6 +13266,7 @@ name = "waterui-math"
 version = "0.1.0"
 dependencies = [
  "kurbo 0.13.1",
+ "mathcat",
  "nami",
  "parley",
  "peniko",
@@ -14743,6 +14875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "yeslogic-fontconfig-sys"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15053,6 +15194,21 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "time",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "bzip2 0.6.1",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -237,6 +237,12 @@ pulldown-latex = "0.8"
 # it goes through a writer that escapes and balances tags rather than through
 # `push_str`/`format!` chains.
 quick-xml = "0.41"
+# Turns that MathML into the sentence a screen reader reads out — the ClearSpeak
+# / MathSpeak engine assistive-technology vendors ship. `include-zip` compiles
+# the speech rules into the binary as one bzip2 archive served from an in-memory
+# filesystem, so the rules are not files anything has to install, bundle, or
+# find at runtime; without it MathCAT looks for a `Rules` directory on disk.
+mathcat = { version = "0.7.5", features = ["include-zip"] }
 toml = "1.1.3"
 vello_cpu = { version = "0.0.9", default-features = false }
 lyon = "1.0"

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -125,9 +125,10 @@ waterui = { path = "../..", default-features = false }
 waterui-canvas.workspace = true
 waterui-svg.workspace = true
 # A formula is the scene content that has something to say about itself: it
-# answers `SceneContent::accessibility_label` with its MathML, which is what
-# proves dew's scene leaf publishes a content-supplied name rather than a bare
-# unnamed image. Test-only for the same reason as the two crates above.
+# answers `SceneContent::accessibility_label` with itself spoken as a sentence,
+# which is what proves dew's scene leaf publishes a content-supplied name rather
+# than a bare unnamed image. Test-only for the same reason as the two crates
+# above.
 waterui-math.workspace = true
 # The component issue #180 is actually about: an interactive chart wraps its
 # canvas in `Metadata<GestureObserver>` and `Metadata<OnEvent>`, and every one

--- a/backends/dew/tests/accessibility.rs
+++ b/backends/dew/tests/accessibility.rs
@@ -13,7 +13,7 @@ use waterui_core::{AnyView, Str};
 use waterui_dew::{DewRuntime, HostBoard};
 use waterui_math::ast::MathStyle;
 use waterui_math::view::Math;
-use waterui_math::{latex, mathml};
+use waterui_math::{latex, mathml, speech};
 use waterui_navigation::{NavigationStack, NavigationView, Tab, Tabs};
 use waterui_text::text;
 
@@ -237,10 +237,10 @@ fn a_control_keeps_its_own_title_when_the_application_names_nothing() {
 /// A scene leaf takes the application's name over the description its content
 /// generated for itself.
 ///
-/// A formula answers `SceneContent::accessibility_label` with its `MathML`, which
-/// is the best a drawing can say about itself and still worse than a caption
-/// the application wrote. The two must not both be announced, so the override
-/// replaces it rather than adding to it.
+/// A formula answers `SceneContent::accessibility_label` with itself spoken as a
+/// sentence, which is the best a drawing can say about itself and still worse
+/// than a caption the application wrote. The two must not both be announced, so
+/// the override replaces it rather than adding to it.
 #[test]
 fn an_application_label_replaces_a_scene_leaf_default_description() {
     const FORMULA: &str = r"\frac{a}{b}";
@@ -253,10 +253,11 @@ fn an_application_label_replaces_a_scene_leaf_default_description() {
     );
     runtime.pump().expect("the formula frame renders");
 
-    let mathml = mathml::to_mathml(
+    let markup = mathml::to_mathml(
         &latex::parse(FORMULA).expect("the fixture formula parses"),
         MathStyle::Text,
     );
+    let said = speech::speak(&markup).expect("the fixture formula speaks");
     let update = runtime
         .board()
         .accessibility_tree()
@@ -271,7 +272,7 @@ fn an_application_label_replaces_a_scene_leaf_default_description() {
         update
             .nodes
             .iter()
-            .all(|(_, node)| node.label() != Some(mathml.as_str())),
+            .all(|(_, node)| node.label() != Some(said.as_str())),
         "the content's own description is replaced, not announced alongside"
     );
 }

--- a/backends/dew/tests/scene_render.rs
+++ b/backends/dew/tests/scene_render.rs
@@ -32,7 +32,7 @@ use waterui_graphics::{Scene2D, SceneContent, SceneInvalidator, SceneView, inval
 use waterui_layout::scroll::ScrollView;
 use waterui_math::ast::MathStyle;
 use waterui_math::view::Math;
-use waterui_math::{latex, mathml};
+use waterui_math::{latex, mathml, speech};
 use waterui_svg::Svg;
 
 mod support;
@@ -142,10 +142,10 @@ fn a_scene_publishes_an_accessibility_node() {
 /// A formula reaches the panel as anonymous filled paths, so this node is the
 /// only place its content can be announced at all. Dew published it unnamed:
 /// the tree said "image" and nothing else. The content's own
-/// `SceneContent::accessibility_label` — the formula's `MathML` — is what names
-/// it, the same answer hydrolysis offers for the same drawing, so a formula is
-/// readable on both self-drawn backends rather than on whichever one the test
-/// happened to run.
+/// `SceneContent::accessibility_label` — the formula spoken as a sentence — is
+/// what names it, the same answer hydrolysis offers for the same drawing, so a
+/// formula is readable on both self-drawn backends rather than on whichever one
+/// the test happened to run.
 #[test]
 fn scene_content_names_its_own_accessibility_node() {
     const FORMULA: &str = r"\frac{a}{b}";
@@ -158,13 +158,14 @@ fn scene_content_names_its_own_accessibility_node() {
     );
     runtime.pump().expect("the first frame renders");
 
-    // The expectation comes from the same public converter the view publishes
-    // through, so it tracks the converter instead of rotting into a stale
+    // The expectation comes from the same public converter and speech engine the
+    // view publishes through, so it tracks them instead of rotting into a stale
     // literal.
-    let expected = mathml::to_mathml(
+    let markup = mathml::to_mathml(
         &latex::parse(FORMULA).expect("the fixture formula parses"),
         MathStyle::Text,
     );
+    let expected = speech::speak(&markup).expect("the fixture formula speaks");
 
     let update = runtime
         .board()
@@ -178,7 +179,7 @@ fn scene_content_names_its_own_accessibility_node() {
         .collect();
     assert!(
         labels.contains(&Some(expected.as_str())),
-        "the formula's image node must carry its MathML, got {labels:?}"
+        "the formula's image node must carry its speech, got {labels:?}"
     );
 }
 

--- a/components/visual/math/Cargo.toml
+++ b/components/visual/math/Cargo.toml
@@ -30,6 +30,13 @@ peniko.workspace = true
 ttf-parser.workspace = true
 pulldown-latex.workspace = true
 quick-xml.workspace = true
+# Speech. A formula drawn as filled paths has no content an assistive technology
+# can reach, and the MathML this crate publishes is markup rather than a
+# sentence — this is what turns one into the other, and the result is the name
+# the formula's accessibility node carries. Not optional: a component that
+# cannot be read out has no accessibility tree worth the name, and a crate this
+# one is not linked into pays nothing for it.
+mathcat.workspace = true
 serde = { workspace = true, features = ["derive"] }
 thiserror.workspace = true
 toml.workspace = true

--- a/components/visual/math/README.md
+++ b/components/visual/math/README.md
@@ -13,7 +13,8 @@ Math::new(r"\frac{-b \pm \sqrt{b^2 - 4ac}}{2a}").display().font_size(28.0)
 ```
 LaTeX ──(pulldown-latex)──► MathItem tree ──► layout ──► Scene2D commands
                                   │                          │
-                                  └──► MathML ──► a11y        └──► any backend
+                                  └──► MathML ──(MathCAT)──►   └──► any backend
+                                          speech ──► a11y
 ```
 
 A formula is parsed into a semantic tree, laid out against the chosen face's
@@ -46,15 +47,44 @@ The gap between two adjacent atoms is a function of the class on each side, so
 ## Accessibility
 
 The semantic tree is kept after layout, not consumed by it. `mathml::to_mathml`
-publishes it as MathML, which is what assistive technology reads — a formula
-drawn as anonymous filled paths has no content at all to a screen reader.
+publishes it as MathML — a formula drawn as anonymous filled paths has no
+content at all to a screen reader.
 
-That markup reaches the accessibility tree: the drawing answers
-`SceneContent::accessibility_label` with it, and the backend names the formula's
-node with it. The markup follows the source signal, so a formula bound to state
-stays current. `.a11y_label("Quadratic formula")` still wins wherever the
-application names the formula itself — the markup is what the node says when
-nobody named it.
+MathML is the payload a platform's math accessibility API takes, but it is
+markup, not a sentence: read out, `<mfrac><mi>a</mi><mi>b</mi></mfrac>` is
+noise. `speech::speak` turns it into the sentence, through
+[MathCAT](https://nsoiffer.github.io/MathCAT/) — the ClearSpeak / MathSpeak
+engine assistive-technology vendors ship — and that sentence is what reaches
+the accessibility tree:
+
+```rust
+let formula = latex::parse(r"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}")?;
+let spoken = speech::speak(&mathml::to_mathml(&formula, MathStyle::Display))?;
+```
+
+```text
+x is equal to; the fraction with numerator; negative b plus or minus;
+the square root of b squared minus 4 eigh c; and denominator 2 eigh
+```
+
+`eigh` is how the engine spells the letter `a` so a text-to-speech voice does
+not read it as the article.
+
+The drawing answers `SceneContent::accessibility_label` with that sentence, and
+the backend names the formula's node with it. It follows the source signal, so a
+formula bound to state stays current. `.a11y_label("Quadratic formula")` still
+wins wherever the application names the formula itself — the speech is what the
+node says when nobody named it. A formula that cannot be spoken leaves the node
+unnamed and logs the reason; there is deliberately no generic "math formula" to
+announce instead, because it tells a listener nothing and would hide the
+failure.
+
+MathCAT reads its speech rules from a `Rules` directory. This crate takes it
+with the `include-zip` feature, which compiles the whole rule set into the
+binary as one bzip2 archive served from an in-memory filesystem — nothing to
+install beside the application, and nothing for the asset pipeline to carry.
+That costs about 2.7 MiB of release artifact (0.93 MiB of rules, the rest code
+and tables), paid only by a build that links this crate.
 
 ## Fonts
 

--- a/components/visual/math/src/lib.rs
+++ b/components/visual/math/src/lib.rs
@@ -9,7 +9,8 @@
 //! The semantic tree is kept rather than discarded after layout, because it is
 //! also the accessibility representation: a formula drawn as anonymous vector
 //! paths is unreadable to a screen reader, and the tree is what `MathML` is
-//! published from.
+//! published from. `MathML` is markup rather than a sentence, so [`speech`]
+//! turns it into the one the formula's accessibility node actually carries.
 //!
 //! # Displaying a formula
 //!
@@ -38,6 +39,23 @@
 //! # Ok::<(), Box<dyn core::error::Error>>(())
 //! ```
 //!
+//! # Hearing one
+//!
+//! The markup is what a platform's math accessibility API takes as its payload;
+//! it is not what a screen reader can read out. [`speech`] is where the sentence
+//! comes from, and it is the name the formula's node carries.
+//!
+//! ```
+//! use waterui_math::ast::MathStyle;
+//! use waterui_math::{latex, mathml, speech};
+//!
+//! let formula = latex::parse(r"\sqrt{x}")?;
+//! let spoken = speech::speak(&mathml::to_mathml(&formula, MathStyle::Text))?;
+//!
+//! assert!(spoken.contains("square root"));
+//! # Ok::<(), Box<dyn core::error::Error>>(())
+//! ```
+//!
 //! A construct the layout engine does not implement is refused by name rather
 //! than silently dropped, so a formula never renders as a quietly wrong one.
 //!
@@ -57,4 +75,5 @@ pub mod layout;
 pub mod mathml;
 pub mod scene;
 pub mod spacing;
+pub mod speech;
 pub mod view;

--- a/components/visual/math/src/speech.rs
+++ b/components/visual/math/src/speech.rs
@@ -1,0 +1,154 @@
+//! What a formula sounds like when it is read out.
+//!
+//! A formula reaches the screen as filled paths and glyph runs, so the node the
+//! leaf publishes is the only place a screen reader can learn what it says.
+//! `MathML` is the payload a platform's math accessibility API wants, but it is
+//! markup rather than a sentence: read out, `<mfrac><mi>a</mi><mi>b</mi></mfrac>`
+//! is noise. This module turns the markup [`crate::mathml`] publishes into the
+//! sentence, through [`MathCAT`], the `ClearSpeak` / `MathSpeak` engine assistive
+//! technology vendors use.
+//!
+//! `MathCAT` reads its speech rules from a `Rules` directory. This crate takes it
+//! with the `include-zip` feature, which compiles the whole rule set into the
+//! binary as one bzip2 archive and serves it from an in-memory filesystem — so a
+//! formula speaks with nothing installed beside the application, and the rules
+//! are not an asset anything has to carry, install, or find at runtime.
+//!
+//! The `Language` preference is left at `MathCAT`'s own default of `Auto`, which
+//! it resolves itself.
+//!
+//! ```
+//! use waterui_math::ast::MathStyle;
+//! use waterui_math::{latex, mathml, speech};
+//!
+//! let formula = latex::parse(r"\frac{a}{b}")?;
+//! let spoken = speech::speak(&mathml::to_mathml(&formula, MathStyle::Text))?;
+//!
+//! assert_eq!(spoken, "eigh over b");
+//! # Ok::<(), Box<dyn core::error::Error>>(())
+//! ```
+//!
+//! [`MathCAT`]: https://nsoiffer.github.io/MathCAT/
+
+use alloc::string::{String, ToString as _};
+use core::cell::Cell;
+
+/// Why a formula could not be spoken.
+///
+/// Every variant is a real failure with a name. There is deliberately no
+/// "math formula" to say instead: a listener told only that a formula is
+/// present has learnt nothing, and a generic announcement would hide the
+/// failure behind something that sounds like it worked.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SpeechError {
+    /// The rule set compiled into the binary could not be opened.
+    #[error("the embedded MathCAT speech rules could not be read: {0}")]
+    Rules(String),
+    /// `MathCAT` refused the markup, or could not speak it.
+    #[error("MathCAT could not speak the formula's MathML: {0}")]
+    Markup(String),
+    /// `MathCAT` accepted the markup and produced nothing.
+    #[error("MathCAT produced no speech for the formula")]
+    Silent,
+}
+
+/// The root the embedded rule archive is mounted at.
+///
+/// With `include-zip` this is a path inside the in-memory filesystem the crate
+/// builds from its compiled-in archive, not a directory on disk.
+const RULES_ROOT: &str = "Rules";
+
+thread_local! {
+    /// Whether this thread has already pointed `MathCAT` at the rule archive.
+    ///
+    /// `MathCAT` keeps its preference manager, its rule tables and the formula
+    /// it is currently holding in thread-local storage, so "which rules are
+    /// loaded" is a per-thread fact and this is the flag that matches it.
+    /// Reading the rules again per formula would re-open the archive and
+    /// re-parse the preference files on every accessibility emission.
+    static RULES_READY: Cell<bool> = const { Cell::new(false) };
+}
+
+/// Speaks `mathml`.
+///
+/// # Errors
+///
+/// Returns [`SpeechError`] when the embedded rules cannot be read, when
+/// `MathCAT` refuses the markup, or when it produces nothing to say.
+pub fn speak(mathml: &str) -> Result<String, SpeechError> {
+    RULES_READY.with(|ready| {
+        if ready.get() {
+            return Ok(());
+        }
+        libmathcat::set_rules_dir(RULES_ROOT.to_string())
+            .map_err(|error| SpeechError::Rules(libmathcat::errors_to_string(&error)))?;
+        ready.set(true);
+        Ok(())
+    })?;
+
+    libmathcat::set_mathml(mathml.to_string())
+        .map_err(|error| SpeechError::Markup(libmathcat::errors_to_string(&error)))?;
+    let spoken = libmathcat::get_spoken_text()
+        .map_err(|error| SpeechError::Markup(libmathcat::errors_to_string(&error)))?;
+
+    let spoken = spoken.trim();
+    if spoken.is_empty() {
+        return Err(SpeechError::Silent);
+    }
+    Ok(spoken.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{SpeechError, speak};
+    use crate::ast::MathStyle;
+    use crate::{latex, mathml};
+
+    fn spoken(source: &str) -> String {
+        let item = latex::parse(source).unwrap_or_else(|error| panic!("`{source}`: {error}"));
+        speak(&mathml::to_mathml(&item, MathStyle::Display))
+            .unwrap_or_else(|error| panic!("`{source}`: {error}"))
+    }
+
+    /// The point of the whole module: a fraction is announced in words — "eigh
+    /// over b", the letter spelled the way a speech engine has to spell it so a
+    /// text-to-speech voice does not read `a` as the article — rather than as
+    /// the markup that describes it.
+    #[test]
+    fn a_fraction_is_spoken_in_words() {
+        let said = spoken(r"\frac{a}{b}");
+
+        assert!(
+            said.contains("over"),
+            "a simple fraction is announced as one thing over another, got `{said}`"
+        );
+        assert!(
+            !said.contains('<'),
+            "speech is a sentence, not markup, got `{said}`"
+        );
+    }
+
+    /// The formula from the issue this module exists for. Every landmark of it
+    /// has to survive into the sentence, because a listener who hears only
+    /// "fraction" cannot reconstruct the formula.
+    #[test]
+    fn the_quadratic_formula_keeps_all_of_its_parts() {
+        let said = spoken(r"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}").to_lowercase();
+
+        for landmark in ["fraction", "square root", "plus or minus", "squared"] {
+            assert!(
+                said.contains(landmark),
+                "the quadratic formula must be spoken with `{landmark}`, got `{said}`"
+            );
+        }
+    }
+
+    /// Markup that is not `MathML` at all is refused by name.
+    #[test]
+    fn something_that_is_not_mathml_is_refused() {
+        assert!(matches!(
+            speak("not markup at all"),
+            Err(SpeechError::Markup(_))
+        ));
+    }
+}

--- a/components/visual/math/src/view.rs
+++ b/components/visual/math/src/view.rs
@@ -18,7 +18,7 @@ use waterui_text::FontCollection;
 use crate::ast::{MathItem, MathStyle};
 use crate::font::MathFont;
 use crate::layout::Layouter;
-use crate::{latex, mathml, scene};
+use crate::{latex, mathml, scene, speech};
 
 /// The math family used when the caller names none.
 ///
@@ -372,16 +372,21 @@ impl SceneContent for MathContent {
         Some(size)
     }
 
-    /// The formula as `MathML`, which is what a screen reader reads.
+    /// The formula spoken as a sentence.
     ///
     /// A formula reaches the screen as filled paths and glyph runs — to
     /// assistive technology that is a picture with no content — so this node is
-    /// the only place the formula can be said at all. It is read fresh on every
-    /// emission, and the source watcher installed by [`Self::set_invalidator`]
-    /// is what schedules the frame that re-emits it, so a formula bound to
-    /// state stays current without its subtree being rebuilt.
+    /// the only place the formula can be said at all, and what a node is named
+    /// gets read out. `MathML` is the payload a platform's math accessibility
+    /// API takes; read aloud it is noise, so the name is the sentence
+    /// [`crate::speech`] produces from that markup instead.
+    ///
+    /// It is read fresh on every emission, and the source watcher installed by
+    /// [`Self::set_invalidator`] is what schedules the frame that re-emits it,
+    /// so a formula bound to state stays current without its subtree being
+    /// rebuilt.
     fn accessibility_label(&self) -> Option<String> {
-        Some(accessibility_markup(&self.source.get(), self.style))
+        accessibility_speech(&self.source.get(), self.style)
     }
 
     fn set_invalidator(&mut self, invalidator: Option<SceneInvalidator>) {
@@ -438,23 +443,42 @@ impl View for Math {
     }
 }
 
-/// The formula's accessibility payload: its `MathML`.
+/// What the formula's accessibility node says.
 ///
-/// A source that does not parse has no semantic tree and therefore no markup,
-/// and it does not draw either — so the only content that exists is the LaTeX
-/// the author wrote, and that is what the node says. The parse failure is
-/// reported: a formula that silently reads as its own source is a formula that
-/// silently did not render.
-fn accessibility_markup(source: &Str, style: MathStyle) -> String {
-    match latex::parse(source.as_str()) {
-        Ok(item) => mathml::to_mathml(&item, style),
+/// A source that does not parse has no semantic tree and therefore no markup to
+/// speak from, and it does not draw either — so the only content that exists is
+/// the LaTeX the author wrote, and that is what the node says. The parse failure
+/// is reported: a formula that silently reads as its own source is a formula
+/// that silently did not render.
+///
+/// A formula that parsed but that `MathCAT` cannot speak leaves the node
+/// unnamed, which is what [`SceneContent::accessibility_label`] means by
+/// `None`: content that cannot say anything true about itself. There is
+/// deliberately nothing generic to say in its place — "math formula" tells a
+/// listener nothing and would hide the failure — so the error is logged with
+/// the formula that produced it.
+fn accessibility_speech(source: &Str, style: MathStyle) -> Option<String> {
+    let item = match latex::parse(source.as_str()) {
+        Ok(item) => item,
         Err(error) => {
             tracing::error!(
                 %error,
                 formula = %source,
                 "formula does not parse; its source is all the accessibility node can say"
             );
-            String::from(source.as_str())
+            return Some(String::from(source.as_str()));
+        }
+    };
+
+    match speech::speak(&mathml::to_mathml(&item, style)) {
+        Ok(spoken) => Some(spoken),
+        Err(error) => {
+            tracing::error!(
+                %error,
+                formula = %source,
+                "formula cannot be spoken; its accessibility node stays unnamed"
+            );
+            None
         }
     }
 }
@@ -490,9 +514,9 @@ mod tests {
     use waterui_str::Str;
     use waterui_text::FontCollection;
 
-    use super::{DEFAULT_MATH_FAMILY, Math, MathContent, accessibility_markup};
+    use super::{DEFAULT_MATH_FAMILY, Math, MathContent, accessibility_speech};
     use crate::ast::MathStyle;
-    use crate::{latex, mathml};
+    use crate::{latex, mathml, speech};
 
     /// A [`SceneInvalidator`] that counts the frames it was asked for.
     fn counting_invalidator() -> (SceneInvalidator, Rc<Cell<usize>>) {
@@ -522,22 +546,28 @@ mod tests {
         let _ = Math::new(Str::from_static("x")).body(&Environment::new());
     }
 
-    /// The accessibility payload is the converter's markup, never a blank.
+    /// The node carries the formula spoken as a sentence, not the markup.
     ///
-    /// It used to be: the conversion's `Result` was discarded into an empty
-    /// string, so a node that was supposed to carry the formula carried
-    /// nothing at all. The converter is total now, and this pins that the view
-    /// publishes exactly what it produces.
+    /// It used to carry the `MathML` itself, which a screen reader reads out as
+    /// tag names. This pins that the view publishes exactly what the speech
+    /// engine says about the same formula.
     #[test]
-    fn the_accessibility_payload_is_the_converters_markup() {
+    fn the_accessibility_node_carries_speech_rather_than_markup() {
         let source = Str::from_static(r"\frac{a}{b}");
-        let expected = mathml::to_mathml(
+        let markup = mathml::to_mathml(
             &latex::parse(source.as_str()).expect("the fixture formula parses"),
             MathStyle::Text,
         );
+        let expected = speech::speak(&markup).expect("the fixture formula speaks");
 
-        assert!(!expected.is_empty(), "a parsed formula always has markup");
-        assert_eq!(accessibility_markup(&source, MathStyle::Text), expected);
+        assert_eq!(
+            accessibility_speech(&source, MathStyle::Text).as_deref(),
+            Some(expected.as_str())
+        );
+        assert!(
+            !expected.contains('<'),
+            "the node must carry a sentence, not markup, got `{expected}`"
+        );
     }
 
     /// A source that does not parse has no tree and therefore no markup, and it
@@ -552,9 +582,9 @@ mod tests {
         );
 
         assert_eq!(
-            accessibility_markup(&source, MathStyle::Text),
-            source.as_str(),
-            "the node must carry the source when there is no markup to carry"
+            accessibility_speech(&source, MathStyle::Text).as_deref(),
+            Some(source.as_str()),
+            "the node must carry the source when there is nothing to speak from"
         );
     }
 

--- a/components/visual/math/tests/e2e_semantics.rs
+++ b/components/visual/math/tests/e2e_semantics.rs
@@ -10,21 +10,25 @@ use nami::Binding;
 use waterui::ViewExt as _;
 use waterui_math::ast::MathStyle;
 use waterui_math::view::Math;
-use waterui_math::{latex, mathml};
+use waterui_math::{latex, mathml, speech};
 use waterui_str::Str;
 use waterui_testing::{Role, SemanticApp, UiBuilder};
 
 const FRACTION: &str = r"\frac{a}{b}";
 const ROOT: &str = r"\sqrt{x}";
+/// The formula the whole feature exists for.
+const QUADRATIC: &str = r"x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}";
 
-/// The markup the converter produces for `source`.
+/// What `source` sounds like when it is read out.
 ///
-/// Computed through the same public converter the view publishes from rather
-/// than pasted as a literal, so the expectation tracks the converter instead of
-/// rotting into a stale string the next `MathML` change silently invalidates.
-fn markup(source: &str, style: MathStyle) -> String {
+/// Computed through the same public converter and speech engine the view
+/// publishes through rather than pasted as a literal, so the expectation tracks
+/// them instead of rotting into a stale string the next rules update silently
+/// invalidates.
+fn spoken(source: &str, style: MathStyle) -> String {
     let item = latex::parse(source).unwrap_or_else(|error| panic!("`{source}`: {error}"));
-    mathml::to_mathml(&item, style)
+    speech::speak(&mathml::to_mathml(&item, style))
+        .unwrap_or_else(|error| panic!("`{source}`: {error}"))
 }
 
 fn unlabelled_formula() -> impl waterui::View {
@@ -39,13 +43,18 @@ fn display_formula() -> impl waterui::View {
     Math::new(FRACTION).display()
 }
 
-/// The formula reaches the tree as an image node carrying its `MathML`.
+fn quadratic_formula() -> impl waterui::View {
+    Math::new(QUADRATIC).display()
+}
+
+/// The formula reaches the tree as an image node that says the formula out
+/// loud.
 #[waterui::test(unlabelled_formula)]
-fn an_unnamed_formula_publishes_its_mathml(app: &mut SemanticApp) {
+fn an_unnamed_formula_is_announced_as_speech(app: &mut SemanticApp) {
     let node = app
         .query()
         .role(Role::IMAGE)
-        .label(markup(FRACTION, MathStyle::Text))
+        .label(spoken(FRACTION, MathStyle::Text))
         .single();
 
     let bounds = node.bounds();
@@ -57,21 +66,54 @@ fn an_unnamed_formula_publishes_its_mathml(app: &mut SemanticApp) {
     );
 }
 
-/// The style the formula is set in reaches the markup, because a formula
+/// The quadratic formula is carried as a sentence a listener can follow, not as
+/// the markup that describes it and not as the LaTeX that produced it.
+///
+/// This is the assertion the whole feature is for, so it checks the substance
+/// rather than mere presence: every landmark of the formula — the fraction, the
+/// radical, the sign, the exponent — has to survive into what the node says, and
+/// neither `MathML` tags nor LaTeX control sequences may appear in it. A node
+/// that reverted to publishing markup, that published the source, or that
+/// published a generic announcement all fail here.
+#[waterui::test(quadratic_formula)]
+fn the_quadratic_formula_is_published_as_a_sentence(app: &mut SemanticApp) {
+    let said = spoken(QUADRATIC, MathStyle::Display);
+
+    assert!(
+        !said.trim().is_empty(),
+        "the quadratic formula must be spoken, not left silent"
+    );
+    assert!(
+        !said.contains('<') && !said.contains('\\'),
+        "the node carries a sentence, not markup or LaTeX, got `{said}`"
+    );
+
+    let lowered = said.to_lowercase();
+    for landmark in ["fraction", "square root", "plus or minus", "squared"] {
+        assert!(
+            lowered.contains(landmark),
+            "the quadratic formula must be spoken with `{landmark}`, got `{said}`"
+        );
+    }
+
+    app.query().role(Role::IMAGE).label(said).assert_exists();
+}
+
+/// The style the formula is set in reaches the speech, because a formula
 /// announced as set on its own line is not the same announcement as an inline
 /// one.
 #[waterui::test(display_formula)]
-fn display_style_reaches_the_published_markup(app: &mut SemanticApp) {
+fn display_style_reaches_the_published_speech(app: &mut SemanticApp) {
     app.query()
         .role(Role::IMAGE)
-        .label(markup(FRACTION, MathStyle::Display))
+        .label(spoken(FRACTION, MathStyle::Display))
         .assert_exists();
 }
 
 /// What the application named the formula wins: it knows what the formula is
-/// for, and the markup is only the payload of last resort.
+/// for, and the spoken formula is only the announcement of last resort.
 #[waterui::test(labelled_formula)]
-fn an_application_label_wins_over_the_markup(app: &mut SemanticApp) {
+fn an_application_label_wins_over_the_speech(app: &mut SemanticApp) {
     app.query()
         .role(Role::IMAGE)
         .label("Ratio of a to b")
@@ -80,23 +122,23 @@ fn an_application_label_wins_over_the_markup(app: &mut SemanticApp) {
     assert!(
         !app.query()
             .role(Role::IMAGE)
-            .label(markup(FRACTION, MathStyle::Text))
+            .label(spoken(FRACTION, MathStyle::Text))
             .exists(),
-        "a formula the application named must not also be announced as raw markup"
+        "a formula the application named must not also be announced as its own speech"
     );
 }
 
-/// The markup follows the source signal, so a formula bound to state does not
-/// freeze at the markup it had when its subtree was built.
+/// The speech follows the source signal, so a formula bound to state does not
+/// freeze at the sentence it had when its subtree was built.
 #[waterui::test]
-fn the_published_markup_follows_the_source_signal(ui: UiBuilder) {
+fn the_published_speech_follows_the_source_signal(ui: UiBuilder) {
     let source = Binding::container(Str::from_static(FRACTION));
     let mounted = source.clone();
     let mut app = ui.mount(move || Math::new(mounted.clone()));
 
     app.query()
         .role(Role::IMAGE)
-        .label(markup(FRACTION, MathStyle::Text))
+        .label(spoken(FRACTION, MathStyle::Text))
         .assert_exists();
 
     source.set(Str::from_static(ROOT));
@@ -104,8 +146,8 @@ fn the_published_markup_follows_the_source_signal(ui: UiBuilder) {
     assert!(
         app.query()
             .role(Role::IMAGE)
-            .label(markup(ROOT, MathStyle::Text))
+            .label(spoken(ROOT, MathStyle::Text))
             .wait_for_existence(Duration::from_secs(2)),
-        "the published markup must follow the formula's signal"
+        "the published speech must follow the formula's signal"
     );
 }

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -144,9 +144,10 @@ flow-markdown = [
 ]
 # Mathematical formulas in Markdown: `$…$` and `$$…$$` are parsed and typeset
 # through `waterui-math`. Off by default, and deliberately so — it brings a
-# layout engine, an OpenType `MATH` table reader and a LaTeX parser, and the
-# component declares a math font for the asset pipeline to bundle. An
-# application that shows no formulas should pay none of that.
+# layout engine, an OpenType `MATH` table reader, a LaTeX parser and MathCAT's
+# speech rules (about 2.7 MiB of release artifact), and the component declares a
+# math font for the asset pipeline to bundle. An application that shows no
+# formulas should pay none of that.
 #
 # With this off the Markdown parser is built without `ENABLE_MATH`, so a dollar
 # sign in prose stays a dollar sign, exactly as it does today.


### PR DESCRIPTION
A formula's accessibility node carried the MathML the component publishes.
Markup is the payload a platform's math accessibility API takes, but it is not
a sentence: a screen reader given a node's name reads it out, and
`<mfrac><mi>a</mi><mi>b</mi></mfrac>` read out is noise.

`speech::speak` turns that markup into the sentence, through
[MathCAT](https://nsoiffer.github.io/MathCAT/) — the ClearSpeak / MathSpeak
engine assistive-technology vendors ship — and the sentence is what the node
carries. The quadratic formula reaches the accessibility tree as:

> x is equal to; the fraction with numerator; negative b plus or minus; the
> square root of b squared minus 4 eigh c; and denominator 2 eigh

(`eigh` is how the engine spells the letter `a` so a text-to-speech voice does
not read it as the article.)

## The footprint question, settled

MathCAT reads its speech rules from a `Rules` directory at runtime, which is why
#229 asked for the measurement before the feature.

| | |
|---|---|
| `Rules/` on disk, unpacked | 6.5 MiB across 160 YAML files (5.4 MiB languages, 1.0 MiB braille) |
| Embedded via the crate's `include-zip` feature | **978,384 bytes** (0.93 MiB), one bzip2 archive served from an in-memory filesystem |
| Release artifact linking `waterui-math`, before | 3,732,320 bytes |
| Release artifact linking `waterui-math`, after | 6,555,408 bytes |
| **Delta** | **2,823,088 bytes — 2.69 MiB** |

Measured on the release profile this workspace actually ships (`lto = true`,
`codegen-units = 1`, `opt-level = "z"`, `strip = true`, `panic = "abort"`), on
the linked binary for `waterui-math`, built identically with and without the
dependency. Section breakdown of the delta: `__text` +936 KiB, `__const`
+1.26 MiB (of which the rule archive is 0.93 MiB, the rest `phf`/`regex`/
`strum` tables), `__DATA_CONST` +311 KiB, unwind and exception tables +190 KiB.

**The rules do not need the asset pipeline.** With `include-zip` they are
compiled in and read out of memory, so nothing is installed beside the
application, nothing is bundled per platform, and there is no runtime path to
find. The larger-change escape hatch #229 anticipated is not needed.

**Feature granularity.** The right grain is the component itself, and it is
already there: `waterui-math` is optional behind `waterui/markdown-math`, which
is off by default. An application that draws no formulas links none of this and
pays nothing. A sub-feature inside `waterui-math` was rejected deliberately —
the only thing it could produce is a build where a formula's node reverts to
markup or to nothing, which is the fallback this repository forbids. Speech is
the label, not an optional extra channel.

**Supply chain.** `cargo deny check licenses bans` passes (MathCAT and its
transitive additions are MIT / Apache-2.0 / MIT-OR-Apache-2.0). `cargo audit`
still exits 0; the graph gains one informational `unmaintained` advisory,
`yaml-rust` (RUSTSEC-2024-0320), alongside the five the workspace already
carries. `cargo machete` is clean.

## Behaviour

A formula that cannot be spoken leaves its node unnamed and logs why. There is
deliberately no generic "math formula" to announce instead: it tells a listener
nothing and would hide the failure behind something that sounds like it worked.
A source that does not parse keeps publishing the LaTeX the author wrote, which
is unchanged and still tested — there is no tree to speak from and nothing drew
either.

`backends/dew`'s two accessibility tests asserted the old MathML label; they now
assert the speech, computed through the same public engine rather than pasted as
a literal.

## Test

`the_quadratic_formula_is_published_as_a_sentence` in
`components/visual/math/tests/e2e_semantics.rs` mounts the quadratic formula and
reads the Hydrolysis accessibility tree. It fails if the node reverts to
publishing markup or LaTeX (no `<` and no `\` may appear), if the formula goes
silent, or if any landmark of it is lost on the way to speech — `fraction`,
`square root`, `plus or minus` and `squared` all have to survive, so a
degradation to a generic announcement fails too. The other four e2e tests
(unnamed formula, display style, application label winning, speech following the
source signal) now assert against speech as well.

## Verification

- `cargo check -p waterui-math --all-targets`
- `cargo clippy -p waterui-math --all-targets -- -D warnings`
- `cargo nextest run -p waterui-math` — 46 passed
- `cargo test --doc -p waterui-math` — 5 passed
- `cargo clippy -p waterui-dew --all-targets -- -D warnings`, plus the two
  changed dew accessibility tests

Fixes #229