### PR TITLE
fix(hydrolysis): shape non-Latin scripts through the platform's fallback

### DIFF
--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -44,7 +44,13 @@ runs:
         # (xcap -> waterkit-screen pulls it in under --all-features). It has so
         # far arrived only as a transitive dependency of libgtk-4-dev; declare
         # what the workspace actually links rather than inheriting it.
-        packages="nasm libasound2-dev libva-dev libfontconfig1-dev libgbm-dev libegl-dev libxcb1-dev libglib2.0-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libgtk-4-dev libpipewire-0.3-dev libudev-dev"
+        # fonts-noto-cjk and fonts-noto-core are faces, not headers: the
+        # self-drawn renderer shapes a script the bundled Roboto does not cover
+        # through the platform's own fallback, exactly as it does on a user's
+        # machine, so a runner with no CJK, Arabic, Hebrew, Thai or Devanagari
+        # face installed makes that text shape to `.notdef` and the coverage
+        # tests fail for want of a font rather than for want of a fix.
+        packages="nasm libasound2-dev libva-dev libfontconfig1-dev libgbm-dev libegl-dev libxcb1-dev libglib2.0-dev libpango1.0-dev libgdk-pixbuf-2.0-dev libgtk-4-dev libpipewire-0.3-dev libudev-dev fonts-noto-core fonts-noto-cjk"
         if [ "${{ inputs.gpu }}" = "true" ]; then
           packages="$packages mesa-vulkan-drivers libvulkan1"
         fi

--- a/backends/dew/src/views/navigation.rs
+++ b/backends/dew/src/views/navigation.rs
@@ -732,21 +732,33 @@ fn render_destination(
     });
     let bottom = entry.chrome.bottom_layout(renderer.state_cell());
 
-    let bar_height = bar.as_ref().map_or(0.0, |layout| layout.height);
-    let bottom_height = bottom.as_ref().map_or(0.0, |(height, _)| *height);
+    // Where the chrome stops and the content starts is one edge, so it is
+    // computed once — on layout's `f32` grid, the coarser of the two the
+    // backend works in. Painting the bar to its `f64` height and starting the
+    // content at that height narrowed to `f32` describes two edges up to half
+    // an ULP apart, which is a hairline of window background under the bar or a
+    // hairline of content painted beneath it, depending on which way the height
+    // rounds. Invisible while every bar measured to a round number; a title
+    // whose font puts the height off that grid shows it immediately.
+    let top_seam = f64::from(to_f32(
+        bounds.y0 + bar.as_ref().map_or(0.0, |layout| layout.height),
+    ));
+    let bottom_seam = f64::from(to_f32(
+        bounds.y1 - bottom.as_ref().map_or(0.0, |(height, _)| *height),
+    ));
     if let Some(layout) = &bar {
-        let rect = Rect::new(bounds.x0, bounds.y0, bounds.x1, bounds.y0 + bar_height);
+        let rect = Rect::new(bounds.x0, bounds.y0, bounds.x1, top_seam);
         entry.chrome.render(renderer, ctx, rect, layout);
     }
-    if let Some((height, sizes)) = &bottom {
-        let rect = Rect::new(bounds.x0, bounds.y1 - height, bounds.x1, bounds.y1);
+    if let Some((_, sizes)) = &bottom {
+        let rect = Rect::new(bounds.x0, bottom_seam, bounds.x1, bounds.y1);
         entry.chrome.render_bottom(renderer, ctx, rect, sizes);
     }
     let content = LayoutRect::new(
-        Point::new(to_f32(bounds.x0), to_f32(bounds.y0 + bar_height)),
+        Point::new(to_f32(bounds.x0), to_f32(top_seam)),
         Size::new(
             to_f32(bounds.width()),
-            to_f32((bounds.height() - bar_height - bottom_height).max(0.0)),
+            to_f32((bottom_seam - top_seam).max(0.0)),
         ),
     );
     entry.content.render(renderer, ctx.child(content));

--- a/backends/hydrolysis/src/runner/fonts.rs
+++ b/backends/hydrolysis/src/runner/fonts.rs
@@ -93,49 +93,70 @@ impl ResourceFontFamilies {
     }
 }
 
-/// Replaces the renderer's font collection with the bundled deterministic set.
+/// The faces a test host registers, and the ones it pins its generic families
+/// to. Everything the renderer measures in a test is shaped through one of
+/// these unless no bundled face maps the cluster.
+#[cfg(any(test, feature = "testing"))]
+const TEST_FONTS: &[(&str, &[u8])] = &[
+    (
+        "Roboto-Regular.ttf",
+        include_bytes!("../../test-fonts/Roboto-Regular.ttf"),
+    ),
+    (
+        "Roboto-Medium.ttf",
+        include_bytes!("../../test-fonts/Roboto-Medium.ttf"),
+    ),
+    (
+        "Roboto-Bold.ttf",
+        include_bytes!("../../test-fonts/Roboto-Bold.ttf"),
+    ),
+    (
+        "Roboto-Italic.ttf",
+        include_bytes!("../../test-fonts/Roboto-Italic.ttf"),
+    ),
+];
+
+/// The collection a test host shapes with: the bundled Roboto for everything it
+/// covers, the platform's own faces for everything it does not.
 ///
-/// Test text used to shape against whatever the host OS discovered, so a
-/// layout assertion tuned on one platform's metrics failed on another's fonts
-/// and every snapshot golden was platform-specific. The test hosts shape with
-/// exactly the Roboto files bundled with this crate instead — system discovery
-/// off, identical metrics on every runner. Characters outside Roboto's
-/// coverage shape as missing glyphs on purpose: a test that needs another
-/// script should say so loudly rather than silently depending on the host's
-/// fallback set.
+/// Test text used to shape against whatever the host OS discovered first, so a
+/// layout assertion tuned on one platform's metrics failed on another's fonts.
+/// Pinning the generic families to exactly the Roboto files bundled with this
+/// crate is what fixed that, and it is why Latin and Cyrillic still measure
+/// identically on every runner: a family the collection registered itself is
+/// matched ahead of any system family of the same generic.
+///
+/// Turning system discovery off on top of that pinning did not help and cost
+/// the platform *fallback*, which is the only thing that can answer a cluster
+/// the pinned face has no glyph for. Every script outside Roboto's coverage —
+/// Han, Hangul, Arabic, Hebrew, Thai, Devanagari — therefore shaped to
+/// `.notdef` and drew as tofu, which is how the avatar gallery came to render
+/// `山田 太郎`'s monogram as two empty boxes while `Ольга Ладыженская`'s read
+/// correctly, and why no non-Latin text could be tested or reviewed by eye
+/// anywhere in the framework.
+///
+/// So discovery stays on and the pinning does the deterministic half of the
+/// job by itself. Only what Roboto cannot cover reaches the platform's
+/// fallback — the same path the shipping runner's own collection takes, which
+/// is what makes a script exercised here evidence about the renderer rather
+/// than about the test host.
 #[cfg(any(test, feature = "testing"))]
 pub(crate) fn deterministic_test_fonts() -> parley::FontContext {
     use parley::fontique::{Blob, CollectionOptions};
     use std::sync::Arc;
 
-    const FONTS: &[(&str, &[u8])] = &[
-        (
-            "Roboto-Regular.ttf",
-            include_bytes!("../../test-fonts/Roboto-Regular.ttf"),
-        ),
-        (
-            "Roboto-Medium.ttf",
-            include_bytes!("../../test-fonts/Roboto-Medium.ttf"),
-        ),
-        (
-            "Roboto-Bold.ttf",
-            include_bytes!("../../test-fonts/Roboto-Bold.ttf"),
-        ),
-        (
-            "Roboto-Italic.ttf",
-            include_bytes!("../../test-fonts/Roboto-Italic.ttf"),
-        ),
-    ];
-
     let mut font_cx = parley::FontContext {
         collection: Collection::new(CollectionOptions {
-            system_fonts: false,
+            // On for fallback, not for selection: `ResourceFontFamilies::install`
+            // below pins the generic families to the bundled Roboto, so a
+            // system face is only ever reached for a cluster Roboto cannot map.
+            system_fonts: true,
             ..CollectionOptions::default()
         }),
         source_cache: parley::fontique::SourceCache::default(),
     };
     let mut resource_fonts = ResourceFontFamilies::default();
-    for (name, bytes) in FONTS {
+    for (name, bytes) in TEST_FONTS {
         let families = font_cx
             .collection
             .register_fonts(Blob::new(Arc::new(*bytes)), None);
@@ -239,4 +260,124 @@ pub(super) fn native_resource_fonts() -> parley::FontContext {
 /// `parley`'s contexts are not `Sync`; the faces in it are the same ones.
 pub(super) fn seed_renderer(renderer: &mut HydrolysisRenderer, fonts: &FontCollection) {
     *renderer.state_mut().text_fonts_mut() = fonts.use_fonts(|fonts| fonts.clone());
+}
+
+#[cfg(test)]
+mod tests {
+    use parley::PositionedLayoutItem;
+    use waterui_core::Environment;
+    use waterui_core::layout::HorizontalAlignment;
+    use waterui_text::styled::StyledStr;
+
+    use super::{TEST_FONTS, deterministic_test_fonts};
+    use crate::renderer::{TextMeasureService, resolve_text_layout_input};
+
+    /// One sample per script a `WaterUI` application is expected to draw.
+    ///
+    /// The first two are what the bundled Roboto covers and what every layout
+    /// assertion in the suite is written against; the rest are the scripts that
+    /// can only be answered by the platform's fallback, and each of them drew
+    /// as a row of tofu boxes before this collection asked for one.
+    const SAMPLES: &[(&str, &str)] = &[
+        ("Latin", "Ada Lovelace"),
+        ("Cyrillic", "Ольга Ладыженская"),
+        ("Han", "山田 太郎"),
+        ("Hangul", "안녕하세요"),
+        ("Arabic", "مرحبا بالعالم"),
+        ("Hebrew", "שלום עולם"),
+        ("Thai", "สวัสดี"),
+        ("Devanagari", "नमस्ते"),
+    ];
+
+    /// A shaping service seeded exactly as a headless test host seeds it.
+    fn test_host_service() -> TextMeasureService {
+        let mut service = TextMeasureService::new();
+        *service.fonts_mut() = deterministic_test_fonts();
+        service
+    }
+
+    /// Shapes `text` through the renderer's own service and reports how many
+    /// glyphs came back, how many of them are `.notdef`, and whether every run
+    /// resolved to one of the bundled faces.
+    ///
+    /// `.notdef` is glyph 0 by definition, and glyph 0 is the box a reader sees.
+    /// Counting it is the same observation as reading the image, made where it
+    /// cannot be argued with.
+    fn shaped(service: &TextMeasureService, text: &'static str) -> (usize, usize, bool) {
+        let mut env = Environment::new();
+        crate::testing::install_theme(&mut env);
+        let input =
+            resolve_text_layout_input(&StyledStr::from(text), HorizontalAlignment::Leading, &env);
+        let layout = service.shape(&input, None);
+        let mut glyphs = 0;
+        let mut missing = 0;
+        let mut all_bundled = true;
+        for line in layout.lines() {
+            for item in line.items() {
+                let PositionedLayoutItem::GlyphRun(run) = item else {
+                    continue;
+                };
+                let face = run.run().font().data.data();
+                all_bundled &= TEST_FONTS.iter().any(|(_, bundled)| face == *bundled);
+                for glyph in run.glyphs() {
+                    glyphs += 1;
+                    missing += usize::from(glyph.id == 0);
+                }
+            }
+        }
+        (glyphs, missing, all_bundled)
+    }
+
+    /// The defect this collection was fixed for: a cluster the bundled face
+    /// cannot map must reach a face that can, on every script, not just the
+    /// ones Roboto happens to carry.
+    #[test]
+    fn no_script_shapes_to_a_missing_glyph() {
+        let service = test_host_service();
+        for (script, text) in SAMPLES {
+            let (glyphs, missing, _) = shaped(&service, text);
+            assert!(glyphs > 0, "{script} sample `{text}` produced no glyphs");
+            assert_eq!(
+                missing, 0,
+                "{missing} of {glyphs} glyphs in the {script} sample `{text}` are `.notdef`, \
+                 which is the tofu box: the collection found no face covering the script"
+            );
+        }
+    }
+
+    /// ...and the half that must not move while it does: pinning the generic
+    /// families to the bundled Roboto is what keeps a layout assertion tuned on
+    /// one runner true on the next, so the scripts Roboto covers have to keep
+    /// resolving to Roboto rather than to whatever the host installed.
+    #[test]
+    fn the_scripts_roboto_covers_still_shape_through_roboto() {
+        let service = test_host_service();
+        for (script, text) in &SAMPLES[..2] {
+            let (glyphs, _, all_bundled) = shaped(&service, text);
+            assert!(glyphs > 0, "{script} sample `{text}` produced no glyphs");
+            assert!(
+                all_bundled,
+                "the {script} sample `{text}` reached a system face; the bundled Roboto \
+                 covers it and must be matched first, or every metric in the suite \
+                 becomes host-dependent"
+            );
+        }
+    }
+
+    /// And the same statement from the other side: a script Roboto does not
+    /// carry must be answered by a face that is *not* bundled. Without this the
+    /// test above could pass on a collection that had quietly stopped
+    /// registering anything at all.
+    #[test]
+    fn a_script_roboto_lacks_is_answered_by_a_platform_face() {
+        let service = test_host_service();
+        for (script, text) in &SAMPLES[2..] {
+            let (_, _, all_bundled) = shaped(&service, text);
+            assert!(
+                !all_bundled,
+                "the {script} sample `{text}` claims to shape through the bundled Roboto, \
+                 which has no glyph for it"
+            );
+        }
+    }
 }

--- a/tests/text_scripts.rs
+++ b/tests/text_scripts.rs
@@ -1,0 +1,80 @@
+//! Visual acceptance for non-Latin text in the self-drawn renderer.
+//!
+//! Hydrolysis shapes with `parley` over the font collection the host installs.
+//! A collection that resolves a family but never asks the platform for a face
+//! covering the run's script maps every cluster outside that family to
+//! `.notdef` — glyph 0, which draws as an empty box — so an application whose
+//! content is Chinese, Japanese, Korean, Arabic, Hebrew, Thai or Devanagari
+//! renders as rows of tofu while Latin and Cyrillic look fine (#426).
+//!
+//! The counted half of that statement is asserted without pixels, next to the
+//! collection itself, in `hydrolysis`'s `runner::fonts` tests: no cluster of
+//! any of these samples may shape to glyph 0. This is the half a reader has to
+//! confirm, because a glyph id says nothing about whether the shape drawn is
+//! the letter — so the gallery is ignored by default and reviewed by eye.
+
+use hydrolysis_m3::install as install_m3;
+use waterui::component::{hstack, vstack};
+use waterui::prelude::*;
+use waterui_testing::{OffscreenApp, UiBuilder};
+
+/// One line per script, each labelled in Latin so a reviewer can tell which
+/// row failed without being able to read the row itself.
+///
+/// The samples are words, not lone codepoints: a script whose shaping depends
+/// on its neighbours — Arabic's joining forms, Devanagari's conjunct and
+/// reordered vowel, Thai's stacked marks — only shows a broken font stack when
+/// there is more than one cluster to join.
+const SAMPLES: &[(&str, &str)] = &[
+    ("Latin", "Ada Lovelace"),
+    ("Cyrillic", "Ольга Ладыженская"),
+    ("Han (ja)", "山田 太郎"),
+    ("Han (zh)", "北京欢迎你"),
+    ("Hangul", "안녕하세요"),
+    ("Arabic", "مرحبا بالعالم"),
+    ("Hebrew", "שלום עולם"),
+    ("Thai", "สวัสดีชาวโลก"),
+    ("Devanagari", "नमस्ते दुनिया"),
+];
+
+fn gallery() -> impl View {
+    vstack(
+        SAMPLES
+            .iter()
+            .map(|(script, sample)| {
+                hstack((
+                    text(*script).width(120.0),
+                    text(*sample).font(waterui::text::font::Title),
+                ))
+                .spacing(16.0)
+            })
+            .collect::<Vec<_>>(),
+    )
+    .spacing(8.0)
+    .padding_with(16.0)
+}
+
+fn capture(ui: UiBuilder, stage: &str) {
+    let mut app: OffscreenApp = ui.viewport(520, 420).mount_offscreen(gallery);
+    let _ = app.capture_snapshot("text-scripts", "gallery", stage);
+}
+
+#[ignore = "writes a visual acceptance PNG for direct image review"]
+#[waterui::test(theme = install_m3)]
+fn script_gallery_light(ui: UiBuilder) {
+    capture(ui, "light");
+}
+
+#[ignore = "writes a visual acceptance PNG for direct image review"]
+#[waterui::test]
+fn script_gallery_dark(ui: UiBuilder) {
+    capture(
+        ui.theme(|env: &mut Environment| {
+            hydrolysis_m3::install_with_colors(
+                env,
+                hydrolysis_m3::MaterialColorScheme::baseline_dark(),
+            );
+        }),
+        "dark",
+    );
+}


### PR DESCRIPTION
Fixes #426

## Which of the two candidate causes it was

The second, and it is in the **headless test host**, not in the shipping runner.

`deterministic_test_fonts` built its `fontique::Collection` with `system_fonts: false` and registered four bundled Roboto files. With discovery off there is no platform backend to ask, so `Collection::fallback_families` can only return what was installed by hand — and nothing installs a fallback for a script the bundled faces do not carry. Every cluster outside Roboto's coverage therefore shaped to `.notdef`, which is glyph 0, which draws as the tofu box. Roboto carries Cyrillic, which is exactly why `Ольга Ладыженская` → `ОЛ` looked fine in the same gallery that drew `山田 太郎` → `山太` as two empty squares.

`native_resource_fonts`, the collection the shipping runner installs, starts from `parley::FontContext::new()` with discovery on and has always reached the platform's own fallback (CoreText on Apple, fontconfig on Linux, DirectWrite on Windows). Measured against parley 0.11.1 on this machine, all six scripts resolve to a real face with zero `.notdef` there.

## The fix

Discovery goes back on in the test host, and the determinism it was switched off for is provided by the mechanism that actually provides it: `ResourceFontFamilies::install` pins `SansSerif` / `UiSansSerif` / `SystemUi` to the bundled Roboto, and a family the collection registered itself is matched ahead of any system family of the same generic. Latin and Cyrillic still shape through Roboto on every runner, byte for byte; only what Roboto cannot map reaches the platform's fallback — the same path the runner takes.

No font is bundled and no snapshot is re-baselined: the full test suites of `hydrolysis`, `waterui`, `waterui-testing`, `waterui-text`, `hydrolysis-m3` and every component crate with offscreen tests pass unchanged.

## Evidence

Three tests in `runner::fonts` state it without looking at a pixel, shaping through the renderer's own `TextMeasureService`:

- no sample of Latin, Cyrillic, Han, Hangul, Arabic, Hebrew, Thai or Devanagari shapes to glyph 0;
- the two scripts Roboto carries still resolve to a bundled face (the determinism half);
- the six it does not resolve to a face that is *not* bundled, so the test above cannot pass on a collection that quietly stopped registering anything.

All three fail on `dev`: reverting just `system_fonts` reports `4 of 5 glyphs in the Han sample 山田 太郎 are .notdef`.

`tests/text_scripts.rs` renders the same samples through the existing offscreen snapshot path for direct image review, light and dark. Read by eye on macOS: every row draws its own script, Arabic joins and orders right-to-left, Hebrew orders right-to-left, Thai stacks its marks and Devanagari forms its conjunct. The avatar gallery — the reported reproduction, left untouched in the tree — now draws `山太`.

## CI

`fonts-noto-core` and `fonts-noto-cjk` are added to the Linux runner's package list. The tests fall back to the platform's faces by design, so a runner with none installed would fail them for want of a font rather than for want of a fix.