### PR TITLE
fix(mermaid): pin waterui-canvas to the restored HTML5 arc_to

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,6 +387,9 @@ name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
 
 [[package]]
 name = "arboard"
@@ -2607,6 +2610,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3228,6 +3242,29 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
+]
+
+[[package]]
 name = "envy"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3281,6 +3318,16 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "error-chain"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d2f06b9cac1506ece98fe3231e3cc9c4410ec3d5b1f24ae1c8946f0742cdefc"
+dependencies = [
+ "backtrace",
+ "version_check",
 ]
 
 [[package]]
@@ -5573,7 +5620,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "525e9ff3e1a4be2fbea1fdf0e98686a6d98b4d8f937e1bf7402245af1909e8c3"
 dependencies = [
  "byteorder-lite",
- "quick-error",
+ "quick-error 2.0.1",
 ]
 
 [[package]]
@@ -6316,6 +6363,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4a5ff6bcca6c4867b1c4fd4ef63e4db7436ef363e0ad7531d1558856bae64f4"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.5.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0717cef1bc8b636c6e1c1bbdefc09e6322da8a9321966e8928ef80d20f7f770f"
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6636,6 +6689,33 @@ dependencies = [
  "indexmap 2.14.0",
  "papaya",
  "thiserror 2.0.20",
+]
+
+[[package]]
+name = "mathcat"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a23e5a28e90434c787466125d2d2658d284f6f2779d6fbe6a6155f442be985"
+dependencies = [
+ "bitflags 2.13.1",
+ "cfg-if 1.0.4",
+ "dirs",
+ "env_logger",
+ "error-chain",
+ "fastrand",
+ "lazy_static",
+ "log",
+ "phf",
+ "radix_fmt",
+ "regex",
+ "roman-numerals-rs",
+ "strum 0.27.2",
+ "strum_macros 0.27.2",
+ "sxd-document",
+ "sxd-xpath",
+ "unicode-script",
+ "yaml-rust",
+ "zip 6.0.0",
 ]
 
 [[package]]
@@ -8432,6 +8512,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
+name = "peresil"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57"
+
+[[package]]
 name = "petgraph"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8832,6 +8918,12 @@ checksum = "d55d956fa96f5ec02be2e13af0e20391a5aa83d6a074e3ad368959d0fab299ea"
 
 [[package]]
 name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
+name = "quick-error"
 version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a993555f31e5a609f617c12db6250dedcac1b0a85076912c436e6fc9b2c8e6a3"
@@ -8876,6 +8968,12 @@ name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "radix_fmt"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce082a9940a7ace2ad4a8b7d0b1eac6aa378895f18be598230c5f2284ac05426"
 
 [[package]]
 name = "rand"
@@ -9338,6 +9436,12 @@ dependencies = [
  "symphonia",
  "thiserror 2.0.20",
 ]
+
+[[package]]
+name = "roman-numerals-rs"
+version = "3.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c85cd47a33a4510b1424fe796498e174c6a9cf94e606460ef022a19f3e4ff85e"
 
 [[package]]
 name = "roughr-merman"
@@ -10396,6 +10500,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "sxd-document"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d82f37be9faf1b10a82c4bd492b74f698e40082f0f40de38ab275f31d42078"
+dependencies = [
+ "peresil",
+ "typed-arena",
+]
+
+[[package]]
+name = "sxd-xpath"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e39da5d30887b5690e29de4c5ebb8ddff64ebd9933f98a01daaa4fd11b36ea"
+dependencies = [
+ "peresil",
+ "quick-error 1.2.3",
+ "sxd-document",
+]
+
+[[package]]
 name = "symphonia"
 version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -10797,7 +10922,7 @@ dependencies = [
  "fax",
  "flate2",
  "half",
- "quick-error",
+ "quick-error 2.0.1",
  "weezl",
  "zune-jpeg",
 ]
@@ -11270,6 +11395,12 @@ dependencies = [
  "serde_derive",
  "syntect",
 ]
+
+[[package]]
+name = "typed-arena"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
 
 [[package]]
 name = "typed-path"
@@ -12459,6 +12590,7 @@ dependencies = [
  "dirs",
  "executor-core",
  "futures",
+ "futures-lite",
  "futures-timer",
  "keycode",
  "kurbo 0.13.1",
@@ -12514,8 +12646,7 @@ dependencies = [
 [[package]]
 name = "waterui-canvas"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de6c5cbca41bf2d48a2b4a4c5028475b85a2231b2bce13b16b48274c3883c35"
+source = "git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe#ed4cecc706f69f381555f3fe193134da6e0ff7fe"
 dependencies = [
  "image",
  "kurbo 0.13.1",
@@ -13135,6 +13266,7 @@ name = "waterui-math"
 version = "0.1.0"
 dependencies = [
  "kurbo 0.13.1",
+ "mathcat",
  "nami",
  "parley",
  "peniko",
@@ -14743,6 +14875,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a5a4b21e1a62b67a2970e6831bc091d7b87e119e7f9791aef9702e3bef04448"
 
 [[package]]
+name = "yaml-rust"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
+dependencies = [
+ "linked-hash-map",
+]
+
+[[package]]
 name = "yeslogic-fontconfig-sys"
 version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15053,6 +15194,21 @@ dependencies = [
  "crossbeam-utils",
  "flate2",
  "time",
+]
+
+[[package]]
+name = "zip"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a05c7c36fde6c09b08576c9f7fb4cda705990f73b58fe011abf7dfb24168b"
+dependencies = [
+ "arbitrary",
+ "bzip2 0.6.1",
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "zopfli",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,7 +127,13 @@ waterui-visualizer = "0.3.0"
 waterui-form = { version = "0.3.0", path = "components/foundation/form" }
 waterui-controls = { version = "0.3.0", path = "components/foundation/controls"}
 waterui-graphics = { version = "0.3.0", path = "components/visual/graphics", default-features = false }
-waterui-canvas = "0.1.0"
+# `waterui-canvas` 0.1.0 predates the `Path::arc_to` fix (#228): the standalone
+# repository forked from this one before it landed, so the published crate still
+# rounds a corner with the deflection angle, the wrong bisector, and the arc's
+# own `MoveTo` spliced into the contour. Every rounded outline and every routed
+# edge it draws comes apart (#418, #419). Pinned to the restored implementation
+# in water-rs/canvas#5; drop this once a release carrying it ships.
+waterui-canvas = { git = "https://github.com/water-rs/canvas", rev = "ed4cecc706f69f381555f3fe193134da6e0ff7fe" }
 waterui-mermaid = { version = "0.1.0", path = "components/data/mermaid" }
 # Mermaid parsing, semantic model and diagram layout. Consumed from our fork
 # while `typed-layout-projection` is unreleased upstream: `merman-render`'s only

--- a/components/data/mermaid/src/draw.rs
+++ b/components/data/mermaid/src/draw.rs
@@ -110,16 +110,9 @@ fn connector(ctx: &mut DrawingContext, edge: &Edge, palette: &Palette, origin: P
         .iter()
         .map(|point| Point::new(point.x + origin.x, point.y + origin.y))
         .collect();
-    let [first, rest @ ..] = points.as_slice() else {
+    let Some(path) = edge_path(&points) else {
         return;
     };
-    if rest.is_empty() {
-        return;
-    }
-
-    let mut path = Path::new();
-    path.move_to(*first);
-    route(&mut path, &points);
 
     ctx.set_stroke_style(palette.edge);
     ctx.set_line_width(match edge.stroke {
@@ -141,6 +134,23 @@ fn connector(ctx: &mut DrawingContext, edge: &Edge, palette: &Palette, origin: P
         points[last - 1],
         palette,
     );
+}
+
+/// The stroked path of one edge's routed polyline.
+///
+/// `None` when there is nothing to stroke: a polyline needs two points before
+/// it is a line.
+fn edge_path(points: &[Point]) -> Option<Path> {
+    let [first, rest @ ..] = points else {
+        return None;
+    };
+    if rest.is_empty() {
+        return None;
+    }
+    let mut path = Path::new();
+    path.move_to(*first);
+    route(&mut path, points);
+    Some(path)
 }
 
 /// Appends the routed polyline to `path`, rounding each interior corner.
@@ -234,5 +244,131 @@ fn marker(
             );
         }
         EdgeMarker::None => {}
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use waterui_core::layout::{Point, Rect, Size};
+
+    use waterui_text::FontCollection;
+
+    use super::{CORNER_RADIUS, edge_path};
+    use crate::engine::render;
+    use crate::layout::DiagramLayout;
+    use crate::shape;
+
+    /// A flowchart whose edges turn: `TD` stacks the nodes, and `D --> A` runs
+    /// back up past them, so every edge is a routed polyline with corners in it
+    /// rather than one straight segment.
+    const TURNING: &str = "\
+flowchart TD
+    A[Start] --> B{Ready?}
+    B -->|yes| C([Go])
+    B -->|no| D[(Wait)]
+    D --> A
+";
+
+    /// How far a piece of geometry may sit outside where it belongs before the
+    /// diagram is wrong rather than rounded.
+    const SLACK: f32 = 0.5;
+
+    fn diagram() -> DiagramLayout {
+        render(TURNING, FontCollection::system()).expect("the flowchart lays out")
+    }
+
+    /// The box every point of `points` lies in.
+    fn hull(points: &[Point]) -> Rect {
+        let (mut min, mut max) = (points[0], points[0]);
+        for point in points {
+            min = Point::new(min.x.min(point.x), min.y.min(point.y));
+            max = Point::new(max.x.max(point.x), max.y.max(point.y));
+        }
+        Rect::new(min, Size::new(max.x - min.x, max.y - min.y))
+    }
+
+    /// How far `inner` sticks out of `outer`, in the worst direction.
+    fn escape(inner: Rect, outer: Rect) -> f32 {
+        (outer.x() - inner.x())
+            .max(inner.max_x() - outer.max_x())
+            .max(outer.y() - inner.y())
+            .max(inner.max_y() - outer.max_y())
+            .max(0.0)
+    }
+
+    fn canvas(diagram: &DiagramLayout) -> Rect {
+        Rect::new(Point::zero(), diagram.size)
+    }
+
+    /// Nothing this crate paints for a node may leave the diagram's own bounds:
+    /// the scene is exactly `diagram.size` and anything outside it is clipped
+    /// away by the container.
+    #[core::prelude::v1::test]
+    fn every_node_outline_stays_on_the_canvas() {
+        let diagram = diagram();
+        let canvas = canvas(&diagram);
+        for node in &diagram.nodes {
+            let outline = shape::outline(node.shape, node.frame);
+            for path in outline.body.iter().chain(&outline.details) {
+                let bounds = path.bounding_box().expect("a node outline draws something");
+                assert!(
+                    escape(bounds, canvas) <= SLACK,
+                    "node `{}` draws {bounds:?}, outside the {canvas:?} canvas",
+                    node.id
+                );
+            }
+        }
+    }
+
+    /// The routed path of an edge is its polyline with the corners rounded, so
+    /// it can never travel further than the polyline itself does — a fillet
+    /// lives inside the corner it rounds.
+    ///
+    /// This is what a broken corner-rounding primitive breaks: the tangent
+    /// distance comes out inverted, the arc's centre lands on the wrong side,
+    /// and the path shoots off along the last segment's direction far past the
+    /// node it was heading for. `D --> A` here left the diagram entirely.
+    #[core::prelude::v1::test]
+    fn every_edge_path_follows_its_own_polyline() {
+        let diagram = diagram();
+        let canvas = canvas(&diagram);
+        for edge in &diagram.edges {
+            let path = edge_path(&edge.points).expect("a routed edge draws something");
+            let bounds = path.bounding_box().expect("a routed edge draws something");
+            let corridor = hull(&edge.points);
+            assert!(
+                escape(bounds, corridor) <= CORNER_RADIUS,
+                "edge `{}` draws {bounds:?}, off the {corridor:?} its points span",
+                edge.id
+            );
+            assert!(
+                escape(bounds, canvas) <= SLACK,
+                "edge `{}` draws {bounds:?}, outside the {canvas:?} canvas",
+                edge.id
+            );
+        }
+    }
+
+    /// An edge starts and ends on a node. Mermaid trims the polyline to the
+    /// node's border, so each end lands on the box of the node it belongs to —
+    /// a diamond's slanted face is inside its box, which is why this is stated
+    /// as the box rather than its outline.
+    #[core::prelude::v1::test]
+    fn every_edge_ends_on_a_node() {
+        let diagram = diagram();
+        for edge in &diagram.edges {
+            for (which, end) in [("start", edge.points.first()), ("end", edge.points.last())] {
+                let end = *end.expect("a routed edge has endpoints");
+                let touched = diagram
+                    .nodes
+                    .iter()
+                    .find(|node| escape(Rect::new(end, Size::new(0.0, 0.0)), node.frame) <= SLACK);
+                assert!(
+                    touched.is_some(),
+                    "the {which} of edge `{}` is at {end:?}, on no node",
+                    edge.id
+                );
+            }
+        }
     }
 }


### PR DESCRIPTION
A `flowchart TD` with a cycle draws its edges as fragments: the `Start` connector curls off to the side instead of leaving the box, the two decision branches touch neither end, and `Wait --> Start` runs down and to the right, off the diagram entirely.

The layout was never at fault. Every node box and every routed polyline `merman` hands over is inside the diagram's bounds, and each polyline already ends on the border of the node it belongs to. The painting came apart.

`draw::route` rounds each interior corner of a routed polyline with `Path::arc_to`, the platform's corner-fillet primitive, and that primitive is broken in the published `waterui-canvas` 0.1.0 three ways at once:

- it takes the deflection between the travel directions for the interior angle at the corner, so the tangent distance comes out as `r * tan(θ/2)` instead of `r / tan(θ/2)`;
- it places the arc's centre on the bisector of the travel directions rather than of the two vectors leaving the corner, ninety degrees away;
- it splices the `MoveTo` that `kurbo::Arc::to_path` opens with into the contour, lifting the pen mid-edge.

A right angle survives the first two by coincidence, which is exactly why the `LR` diagram of straight segments always looked right while a forty-degree turn shoots the path far past the node it was heading for.

**This is a regression, not a latent gap.** The monorepo fixed `arc_to` in `ef11533` (#228) on 2 September. The standalone repository had already forked without it, so when `cba85e1c` dropped the in-tree copy two days later and took `waterui-canvas` 0.1.0 from crates.io, the fix went with it. That failure mode is now audited across every split-out crate in #431 — `arc_to` was the only functional loss — and the pin's removal is tracked in #432.

Pins the crate to water-rs/canvas#5 (merged), which restores the implementation unchanged and adds `Path::bounding_box` so a consumer can assert what it drew.

Three tests in `draw` cover the geometry the pictures were showing: every node outline stays on the canvas, every edge path stays inside the box its own polyline spans and on the canvas, and every edge ends on a node. The middle one fails against the published `arc_to`.

Verified by eye on the re-exported `decision` flowchart: every edge meets its node, `Wait --> Start` routes up the right side into the top of `Start`, the diamond is fully on canvas, and `Go` is a closed pill. 28/28 mermaid tests, clippy clean.

Fixes #418