### PR TITLE
fix(android): clip a scroll container to its own viewport

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
 apple-backend-commit = "5bb1cc890acf802c6e4e2e6130b1c91531743af7"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
-android-backend-commit = "36a83f93240a32d61eb571392cb8cc0bd4e8e44b"
+android-backend-commit = "0b59c2d8417f95936ee91c72c1cb4196c5e8144d"
 
 [[bin]]
 name = "water"


### PR DESCRIPTION
Fixes #403

## Root cause

Every WaterUI container on Android clears `clipChildren` so a shadow or an overlay may spill past the view that owns it, the way a `UIView` does. Android spells that permission **on the parent**, not on the view, so it did not only free shadows: it freed the scroll container the window root had inset below the status bar. `examples/form` is `scroll(vstack(...))`, so the root pads itself by the status-bar inset, puts the `ScrollView` at `y=153`, and then lets it paint the rows it has scrolled past the top straight into that strip, under the clock.

The same flag decides what the tree tells accessibility. `ViewGroup.getChildVisibleRect` narrows a rect to a view's bounds only when that view's own parent clips its children, so a scrolled-away row also answered that it was on screen. The rect the framework then publishes for it is the row clamped against the viewport one edge at a time (`View.mapRectFromViewToScreenCoords`), which for a row entirely above the viewport leaves the bottom above the top — the `[32,153][812,84]` in the issue. The two symptoms are one defect, and both go with the missing viewport clip.

## Fix

A viewport is not the surrounding layout's opinion, so the scroll container brings the parent that enforces it. `ViewportClipLayout` is otherwise transparent: it measures its single child against the proposal it was given itself and lays it out over its whole area, so the WaterUI layout above it sees exactly the sizes the child reports.

## Verification

On a Pixel 9 Pro (Android 16), `examples/form` at the identical scroll position — `Newsletter: false` at `[339,153][622,205]` and `Volume: 0` at `[397,227][565,279]` in both dumps:

| | before | after |
|---|---|---|
| status bar strip | `Email:` and `Age: 0` painted under the clock | clean; content clipped at `y=153` |
| gesture bar strip | `Progress` painted under the pill | clean |
| `uiautomator dump` | 4 of 75 nodes inverted (`Email:` `[425,153][537,56]`, `Age: 0` `[428,153][533,130]`, `Progress` and its row `[32,2108][929,2088]`) | 0 of 76 nodes inverted |

## Test

`ViewportClipLayoutTest` (Robolectric) builds a scroll container inside an unclipping WaterUI-style container, insets it, scrolls three rows past the top, and pins both halves: a row past the top is off screen, and every row reported on screen has a rect whose bottom is below its top. Without the clip host the first assertion finds the scrolled-away row visible and the second sees its inverted rect.

Submodule branch: `water-rs/android-backend@0b59c2d8`, on `agent/android-viewport-clip-403`.