### PR TITLE
fix(dew): decide the tab bar's seam once, on layout's grid

### DIFF
--- a/backends/dew/src/views/tabs.rs
+++ b/backends/dew/src/views/tabs.rs
@@ -494,7 +494,20 @@ impl TabsNode {
             .fold(0.0_f64, f64::max);
         let desired_height = ITEM_PADDING_Y.mul_add(2.0, tallest).max(MIN_BAR_HEIGHT) + HAIRLINE;
         let bar_height = desired_height.min(bounds.height() / 2.0);
-        let bar = kurbo::Rect::new(bounds.x0, bounds.y1 - bar_height, bounds.x1, bounds.y1);
+        // Where the bar stops and the page starts is one edge, so it is decided
+        // once, on layout's `f32` grid — the same contract `navigation.rs`
+        // keeps for its own chrome. The bar is painted in kurbo's `f64` and the
+        // page is framed in `f32`, so an edge left at `f64` and narrowed only on
+        // the page's side describes two positions up to half an ULP apart: a
+        // hairline of page painted under the bar, or a hairline of window
+        // background between them. The bar's height comes from the tallest tab
+        // label, so whether it lands on the `f32` grid is a property of the font.
+        let bar = kurbo::Rect::new(
+            bounds.x0,
+            f64::from(to_f32(bounds.y1 - bar_height)),
+            bounds.x1,
+            bounds.y1,
+        );
         self.render_selected_page(
             renderer,
             ctx,

--- a/backends/dew/tests/navigation_render.rs
+++ b/backends/dew/tests/navigation_render.rs
@@ -9,7 +9,6 @@ use std::rc::Rc;
 
 use kurbo::Rect;
 use nami::binding;
-use peniko::Brush;
 use waterui::Plugin as _;
 use waterui::color::{ResolvedColor, Srgb};
 use waterui::prelude::*;
@@ -25,6 +24,11 @@ use waterui_navigation::{
 };
 
 mod support;
+
+use support::{
+    assert_exact_f64, display_srgb, exact_f64, full_width_solid_fills, only_solid_fill,
+    solid_color,
+};
 
 const WIDTH: u32 = 240;
 const HEIGHT: u32 = 240;
@@ -75,46 +79,9 @@ fn run(build: impl Fn() -> NavigationStack<(), ()> + 'static) -> DewRuntime<Host
     runtime
 }
 
-const fn solid_color(command: &PlacedCommand) -> Option<peniko::Color> {
-    match command.command() {
-        DrawCommand::FillPath {
-            brush: Brush::Solid(color),
-            ..
-        } => Some(*color),
-        _ => None,
-    }
-}
-
-const fn exact_f64(left: f64, right: f64) -> bool {
-    left.to_bits() == right.to_bits()
-}
-
+/// Bit-for-bit equality on the `f32` half of the geometry.
 const fn exact_f32(left: f32, right: f32) -> bool {
     left.to_bits() == right.to_bits()
-}
-
-fn assert_exact_f64(left: f64, right: f64) {
-    assert_eq!(left.to_bits(), right.to_bits());
-}
-
-fn solid_fill_bounds(list: &DisplayList, color: peniko::Color) -> Vec<Rect> {
-    list.commands()
-        .iter()
-        .filter(|command| solid_color(command) == Some(color))
-        .map(PlacedCommand::bounds)
-        .collect()
-}
-
-fn display_srgb(red: u8, green: u8, blue: u8) -> peniko::Color {
-    let resolved = ResolvedColor::from_srgb(Srgb::new_u8(red, green, blue));
-    let srgb = resolved.to_srgb_with_headroom();
-    peniko::Color::new([srgb.red, srgb.green, srgb.blue, resolved.opacity])
-}
-
-fn only_solid_fill(list: &DisplayList, color: peniko::Color) -> Rect {
-    let bounds = solid_fill_bounds(list, color);
-    assert_eq!(bounds.len(), 1, "expected exactly one {color:?} fill");
-    bounds[0]
 }
 
 fn assert_root_background(list: &DisplayList) {
@@ -122,25 +89,11 @@ fn assert_root_background(list: &DisplayList) {
         .commands()
         .first()
         .expect("every Dew frame begins with its root background");
-    assert!(solid_color(first).is_some());
+    assert!(support::solid_color(first).is_some());
     assert_eq!(
         first.bounds(),
         Rect::new(0.0, 0.0, f64::from(WIDTH), f64::from(HEIGHT))
     );
-}
-
-fn full_width_solid_fills(list: &DisplayList, width: f64) -> Vec<Rect> {
-    list.commands()
-        .iter()
-        .skip(1)
-        .filter_map(|command| {
-            let bounds = command.bounds();
-            (solid_color(command).is_some()
-                && exact_f64(bounds.x0, 0.0)
-                && exact_f64(bounds.x1, width))
-            .then_some(bounds)
-        })
-        .collect()
 }
 
 /// A stack renders its root destination's content under the bar, and the bar

--- a/backends/dew/tests/navigation_render.rs
+++ b/backends/dew/tests/navigation_render.rs
@@ -26,8 +26,7 @@ use waterui_navigation::{
 mod support;
 
 use support::{
-    assert_exact_f64, display_srgb, exact_f64, full_width_solid_fills, only_solid_fill,
-    solid_color,
+    assert_exact_f64, display_srgb, exact_f64, full_width_solid_fills, only_solid_fill, solid_color,
 };
 
 const WIDTH: u32 = 240;

--- a/backends/dew/tests/support/mod.rs
+++ b/backends/dew/tests/support/mod.rs
@@ -1,9 +1,11 @@
+use kurbo::Rect;
 use waterui::Plugin as _;
+use waterui::color::{ResolvedColor, Srgb};
 use waterui::theme::{FontSettings, Theme};
 use waterui_backend_core::frame_signals::FrameSignals;
 use waterui_backend_core::time::Instant;
 use waterui_core::Environment;
-use waterui_dew::{DewRenderer, FontSources};
+use waterui_dew::{DewRenderer, DisplayList, DrawCommand, FontSources, PlacedCommand};
 use waterui_text::font::{FontWeight, ResolvedFont};
 
 use std::path::PathBuf;
@@ -77,4 +79,68 @@ pub fn report_path(case: &str, file_name: &str) -> PathBuf {
     let directory = TestArtifacts::new("dew").case_dir(case);
     std::fs::create_dir_all(&directory).expect("the dew report directory must be creatable");
     directory.join(file_name)
+}
+
+/// The solid colour a command fills with, when it fills with one.
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub const fn solid_color(command: &PlacedCommand) -> Option<peniko::Color> {
+    match command.command() {
+        DrawCommand::FillPath {
+            brush: peniko::Brush::Solid(color),
+            ..
+        } => Some(*color),
+        _ => None,
+    }
+}
+
+/// Bit-for-bit equality: a geometry assertion that tolerates a rounding
+/// difference cannot see the rounding differences these tests are about.
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub const fn exact_f64(left: f64, right: f64) -> bool {
+    left.to_bits() == right.to_bits()
+}
+
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn assert_exact_f64(left: f64, right: f64) {
+    assert_eq!(left.to_bits(), right.to_bits());
+}
+
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn solid_fill_bounds(list: &DisplayList, color: peniko::Color) -> Vec<Rect> {
+    list.commands()
+        .iter()
+        .filter(|command| solid_color(command) == Some(color))
+        .map(PlacedCommand::bounds)
+        .collect()
+}
+
+/// The colour a `Color::srgb(...)` reaches the display list as.
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn display_srgb(red: u8, green: u8, blue: u8) -> peniko::Color {
+    let resolved = ResolvedColor::from_srgb(Srgb::new_u8(red, green, blue));
+    let srgb = resolved.to_srgb_with_headroom();
+    peniko::Color::new([srgb.red, srgb.green, srgb.blue, resolved.opacity])
+}
+
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn only_solid_fill(list: &DisplayList, color: peniko::Color) -> Rect {
+    let bounds = solid_fill_bounds(list, color);
+    assert_eq!(bounds.len(), 1, "expected exactly one {color:?} fill");
+    bounds[0]
+}
+
+/// Every solid fill spanning the whole window, skipping the root background.
+#[allow(dead_code, reason = "each integration test binary uses its own subset")]
+pub fn full_width_solid_fills(list: &DisplayList, width: f64) -> Vec<Rect> {
+    list.commands()
+        .iter()
+        .skip(1)
+        .filter_map(|command| {
+            let bounds = command.bounds();
+            (solid_color(command).is_some()
+                && exact_f64(bounds.x0, 0.0)
+                && exact_f64(bounds.x1, width))
+            .then_some(bounds)
+        })
+        .collect()
 }

--- a/backends/dew/tests/tabs_render.rs
+++ b/backends/dew/tests/tabs_render.rs
@@ -12,6 +12,8 @@ use waterui_navigation::{NavigationView, Tab, Tabs, tab_style};
 
 mod support;
 
+use support::{display_srgb, full_width_solid_fills, only_solid_fill};
+
 const WIDTH: u32 = 240;
 const HEIGHT: u32 = 240;
 
@@ -53,6 +55,60 @@ fn tap_labeled(runtime: &mut DewRuntime<HostBoard>, label: &str) -> Option<water
         f64::midpoint(bounds.x0, bounds.x1),
         f64::midpoint(bounds.y0, bounds.y1),
     )
+}
+
+/// The tab bar's top edge is where the page stops — one edge, not two.
+///
+/// The bar is painted in kurbo's `f64` and the page is framed in layout's
+/// `f32`, so an edge computed on both sides at its own precision describes two
+/// positions up to half an `f32` ULP apart: a hairline of page under the bar,
+/// or a hairline of window background between them. The bar's height comes from
+/// the tallest tab label, so whether it happens to land on the `f32` grid is a
+/// property of the installed font. The window is a fractional height here so
+/// the seam is off that grid whatever the font measures — a scaled display
+/// hands a backend exactly such bounds — and the assertion is bit-for-bit,
+/// because half an ULP is the whole defect.
+#[test]
+fn the_tab_bar_starts_exactly_where_the_page_ends() {
+    /// A window height a scaled display produces, and one whose distance from
+    /// the bar's height is not representable in `f32`.
+    const FRACTIONAL_HEIGHT: f64 = 240.1;
+
+    let selection = binding(Screen::Now);
+    let mut renderer = support::test_renderer();
+    let list = renderer.render_tree(
+        AnyView::new(Tabs::new(
+            &selection,
+            vec![
+                Tab::new(Screen::Now, "Now", || {
+                    NavigationView::new("Now", Color::srgb(255, 0, 0))
+                }),
+                Tab::new(Screen::Later, "Later", || {
+                    NavigationView::new("Later", Color::srgb(0, 0, 255))
+                }),
+            ],
+        )),
+        &support::test_environment(),
+        f64::from(WIDTH),
+        FRACTIONAL_HEIGHT,
+    );
+
+    let page = only_solid_fill(&list, display_srgb(255, 0, 0));
+    // The page sits between two full-width surfaces: the navigation bar its own
+    // destination draws, and the tab bar at the foot of the window.
+    let mut bars = full_width_solid_fills(&list, f64::from(WIDTH))
+        .into_iter()
+        .filter(|bounds| bounds.height() > 1.0 && *bounds != page)
+        .collect::<Vec<_>>();
+    bars.sort_by(|left, right| left.y0.total_cmp(&right.y0));
+    let [_navigation_bar, bar] = bars.as_slice() else {
+        panic!("a tab container over a navigation view emits two bars, got {bars:?}")
+    };
+    assert_eq!(
+        page.y1.to_bits(),
+        bar.y0.to_bits(),
+        "the page {page:?} and the bar {bar:?} disagree about the seam"
+    );
 }
 
 /// Selecting a tab shows its page, and coming back shows the first page with


### PR DESCRIPTION
Fixes #441 — the tab-bar half. The navigation half ships in #437, where the
failure surfaced.

`render_tab_bar` painted the bar from `bounds.y1 - bar_height` in kurbo's `f64`
and framed the page under it from the same difference narrowed to layout's
`f32`. That is one edge described twice at two precisions, so the two agree only
when the difference happens to be exactly representable in `f32`. When it is
not, there is up to half an `f32` ULP of page painted under the bar, or half an
ULP of window background showing between them. The bar's height comes from the
tallest tab label, so whether it lands on that grid is a property of the
installed font and of the window's own height — neither of which the backend
gets to assume.

The seam is now computed once, before either side reads it.

The regression test renders into a fractionally tall window, which is what a
scaled display hands a backend, so the seam is off the `f32` grid whatever the
font measures. It fails on the previous behaviour and passes on this one; the
assertion is bit-for-bit, because half an ULP is the entire defect.

`solid_color`, `exact_f64`, `assert_exact_f64`, `solid_fill_bounds`,
`display_srgb`, `only_solid_fill` and `full_width_solid_fills` move from
`navigation_render.rs` into `tests/support/mod.rs`, where the tabs test reads
them, rather than being copied into a second file.

`cargo nextest run -p waterui-dew`: 116 tests, all passing. Clippy clean at
`-D warnings` on `--all-targets`.