### PR TITLE
build(android): take the runtime's type-resolved detekt pass

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -27,7 +27,7 @@ android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
 apple-backend-commit = "5bb1cc890acf802c6e4e2e6130b1c91531743af7"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
-android-backend-commit = "0b59c2d8417f95936ee91c72c1cb4196c5e8144d"
+android-backend-commit = "ec34decedaa550ee39ab87b0c6ff8c791bee7841"
 
 [[bin]]
 name = "water"


### PR DESCRIPTION
Fixes #440. Moves the `backends/android` gitlink and the CLI scaffold pin to
water-rs/android-backend#5, which is merged and green.

What that PR settles, in the order #440 asked for it:

**The gap was not deliberate.** CI ran `:runtime:detekt`, which analyses without
type resolution. The variant tasks that resolve types existed, were never run,
and failed — ten violations in files nobody had reason to open. `:runtime:detektDebug`
now runs alongside the others, so a lint task that exists is a lint task that runs.

**The ten are cleared as readings of the code**, not as rule appeasement: two
`?: ""` on a nullable `String`, two `check(x != null)` that threw without saying
what was null, two properties only read while constructing, an abstract class
with nothing abstract in it, a dropped `MutableMap.remove` result, a `var`
`LinkedHashMap` swapped wholesale on every reconcile, and one Java vararg that
can only be called through a spread (suppressed at the call, with the reason).

**And the part that was worse than any of them**: the variant tasks reported
four compiler errors, which silently degrade every rule in the file carrying
them. Their Kotlin front end does not compile Java, so `WaterUiWebViewClient` —
deliberately Java, for the reason its own doc comment gives — was unresolved
everywhere the web view component touches it. They now analyse against the
classpath the Kotlin compiler itself used plus the module's own compiled Java,
and report none; re-introducing one of the ten still fails the task, so the
analysis is complete rather than quiet.