### PR TITLE
build(deps): take the outstanding independent dependency releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,46 +20,46 @@ checksum = "366ffbaa4442f4684d91e2cd7c5ea7c4ed8add41959a31447066e279e432b618"
 
 [[package]]
 name = "accesskit"
-version = "0.24.1"
+version = "0.25.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3b7f7f85a7e5f68090000ed7622545829afd484d210358702ae4cb97dd0c320"
+checksum = "438a7081a65b95c668db56591a4fef9bc5dad275f448bd6223fc6949d823db38"
 dependencies = [
  "uuid",
 ]
 
 [[package]]
 name = "accesskit_atspi_common"
-version = "0.19.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "023da0e5097f46df7092d5280b02efb9bbf8d93298daeced42652463e357d636"
+checksum = "c9d47ad644916f6cb7e432a5ca0dbd7cc78281a9772881057bb72d4aadb93257"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
  "atspi-common",
- "phf",
+ "phf 0.14.0",
  "serde",
  "zvariant",
 ]
 
 [[package]]
 name = "accesskit_consumer"
-version = "0.38.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d10a236f96f87d70732e44520046785431ef01d5bcd6b041317bfadd2f88245"
+checksum = "cc882fa0c9c24c53649e256311b51046cf36eca9a8f7e54ff4ef682160b0cb27"
 dependencies = [
  "accesskit",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
 name = "accesskit_ios"
-version = "0.1.2"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "750c4e9f6ce888dfe8a10c0f1b5ceb646a7854fd46579d74919219d1bb314083"
+checksum = "d5e9b29c6ba5f4d2e0662e9c562484f061ffc58f658479c538ecca8299ada1e9"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
  "objc2-ui-kit 0.2.2",
@@ -67,13 +67,13 @@ dependencies = [
 
 [[package]]
 name = "accesskit_macos"
-version = "0.26.3"
+version = "0.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce02dc63b43f0c9296af9ac946312a2dc8814427d7a64d2d600971dac55b6076"
+checksum = "a3f278988416e5fb600f24d0cfffe31a249ebbff980fb9c5a3b5fbed2c579f73"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "objc2 0.5.2",
  "objc2-app-kit 0.2.2",
  "objc2-foundation 0.2.2",
@@ -81,9 +81,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_unix"
-version = "0.22.1"
+version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03e156ed3802e35eefe894ef2671bc6c889303d8a7e110b5e1b48f504b91362f"
+checksum = "665c9079b7325a8168a6793437a172dda44b19a05af8ed52d7e32abaada996fe"
 dependencies = [
  "accesskit",
  "accesskit_atspi_common",
@@ -99,13 +99,13 @@ dependencies = [
 
 [[package]]
 name = "accesskit_windows"
-version = "0.34.0"
+version = "0.35.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "106c2b961215864d1c2e703ee63269c25c4e80a577ffb2c1017b9c17dcdf83a1"
+checksum = "a59e8d7160cbac991c1345c99153783ab96423644ccb1f20617cf80c97596aa1"
 dependencies = [
  "accesskit",
  "accesskit_consumer",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "static_assertions",
  "windows 0.62.2",
  "windows-core 0.62.2",
@@ -113,9 +113,9 @@ dependencies = [
 
 [[package]]
 name = "accesskit_winit"
-version = "0.33.2"
+version = "0.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d5b41e63a69f36d9f1f41e70464c7e5f72eee485ef26aab19f0b4f86e6c0a84c"
+checksum = "1eb960a51582305f94b3884a7ff54b3462abe38f0de95a9e7e04dd7ab7b757da"
 dependencies = [
  "accesskit",
  "accesskit_ios",
@@ -2369,7 +2369,7 @@ dependencies = [
  "cssparser-macros",
  "dtoa-short",
  "itoa",
- "phf",
+ "phf 0.13.1",
  "smallvec",
 ]
 
@@ -2514,7 +2514,7 @@ dependencies = [
  "lazy_static",
  "mp4-atom",
  "num-traits",
- "quick-xml",
+ "quick-xml 0.41.0",
  "regex",
  "serde",
  "serde_path_to_error",
@@ -3715,9 +3715,9 @@ dependencies = [
 
 [[package]]
 name = "font-types"
-version = "0.12.3"
+version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75382bc7392ef10aad10935f92fc3db36d2d4dad0e5d96d8d65e04f89a07ec39"
+checksum = "e64eb721ca85a34323425f4041adc5d82704d3782d5f8f03793bc012419dce23"
 dependencies = [
  "bytemuck",
 ]
@@ -3800,6 +3800,19 @@ dependencies = [
  "slotmap",
  "tinyvec",
  "ttf-parser",
+]
+
+[[package]]
+name = "fontdb"
+version = "0.24.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2660c5e9157bf76d2db1294e4a9feba604ef610819a3b591088d0d8392a3290f"
+dependencies = [
+ "fontconfig-parser",
+ "log",
+ "memmap2",
+ "slotmap",
+ "tinyvec",
 ]
 
 [[package]]
@@ -4486,6 +4499,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "glow"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "263218b0ba2b0715c3370fb04674f5f8aa331594b521c94ff0a8e4a8472d1386"
+dependencies = [
+ "js-sys",
+ "slotmap",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
 name = "glutin_wgl_sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4828,7 +4853,7 @@ checksum = "2e815d50d9e411ba2690d730e6ec139c08260dddb756df315dbd16d01a587226"
 dependencies = [
  "memchr",
  "pastey 0.1.1",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "serde_json",
 ]
@@ -4933,7 +4958,7 @@ dependencies = [
  "jiff",
  "js-sys",
  "keyboard-types",
- "lru",
+ "lru 0.18.4",
  "nami",
  "native-executor",
  "objc2 0.6.4",
@@ -4962,7 +4987,7 @@ dependencies = [
  "waterui",
  "waterui-assets",
  "waterui-backend-core",
- "waterui-canvas",
+ "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
  "waterui-controls",
  "waterui-core",
  "waterui-form",
@@ -4992,7 +5017,7 @@ dependencies = [
  "vello",
  "waterui",
  "waterui-backend-core",
- "waterui-canvas",
+ "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
  "waterui-controls",
  "waterui-core",
  "waterui-form",
@@ -5628,6 +5653,12 @@ name = "imagesize"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
+
+[[package]]
+name = "imagesize"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65b27460c2c92b037f3f94c538ed9a3342f3fdf923606781629ccb35f82d042a"
 
 [[package]]
 name = "impartial-ord"
@@ -6497,6 +6528,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lzma-sys"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6705,7 +6745,7 @@ dependencies = [
  "fastrand",
  "lazy_static",
  "log",
- "phf",
+ "phf 0.13.1",
  "radix_fmt",
  "regex",
  "roman-numerals-rs",
@@ -6804,7 +6844,7 @@ dependencies = [
  "libm",
  "merman-core",
  "pulldown-cmark",
- "quick-xml",
+ "quick-xml 0.41.0",
  "roughr-merman",
  "roxmltree 0.21.1",
  "rustc-hash 2.1.3",
@@ -8533,8 +8573,19 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
- "phf_macros",
+ "phf_macros 0.13.1",
  "phf_shared 0.13.1",
+ "serde",
+]
+
+[[package]]
+name = "phf"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "010378780309880b08997fae13be7834dba947d36393bd372f2b1556deb2a2f6"
+dependencies = [
+ "phf_macros 0.14.0",
+ "phf_shared 0.14.0",
  "serde",
 ]
 
@@ -8544,7 +8595,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49aa7f9d80421bca176ca8dbfebe668cc7a2684708594ec9f3c0db0805d5d6e1"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.13.1",
  "phf_shared 0.13.1",
 ]
 
@@ -8559,13 +8610,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "phf_generator"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aeb62e0959d5a1bebc965f4d15d9e2b7cea002b6b0f5ba8cde6cc26738467100"
+dependencies = [
+ "fastrand",
+ "phf_shared 0.14.0",
+]
+
+[[package]]
 name = "phf_macros"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
+ "phf_generator 0.13.1",
  "phf_shared 0.13.1",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fa8d0ca26d424d27630da600c6624696e7dec8bf7b3b492b383c5dc49e5e085"
+dependencies = [
+ "phf_generator 0.14.0",
+ "phf_shared 0.14.0",
  "proc-macro2",
  "quote",
  "syn 2.0.119",
@@ -8585,6 +8659,15 @@ name = "phf_shared"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fd9027e2d9319be6349febd1db4e8d02aa544921200c9b777720ac34a3aa89"
 dependencies = [
  "siphasher",
 ]
@@ -8685,7 +8768,7 @@ checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.41.0",
  "serde",
  "time",
 ]
@@ -8949,6 +9032,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-xml"
+version = "0.42.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41b1177fdf999d2321d3fb46ff47159d9c1fb9ad66a4879f8c50a0b504615e9b"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9177,7 +9269,18 @@ checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types 0.12.3",
+ "font-types 0.12.4",
+ "once_cell",
+]
+
+[[package]]
+name = "read-fonts"
+version = "0.43.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005c8acf251756c478b0bf402885bfd88a1476020c4c7e6060edc1aa68da38ea"
+dependencies = [
+ "bytemuck",
+ "font-types 0.12.4",
  "once_cell",
 ]
 
@@ -9783,7 +9886,7 @@ dependencies = [
  "derive_more",
  "log",
  "new_debug_unreachable",
- "phf",
+ "phf 0.13.1",
  "phf_codegen",
  "precomputed-hash",
  "rustc-hash 2.1.3",
@@ -10103,7 +10206,7 @@ dependencies = [
  "waterkit-permission",
  "waterui",
  "waterui-barcode",
- "waterui-canvas",
+ "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
  "waterui-chart",
  "waterui-graphics",
  "waterui-icons-lucide",
@@ -10135,6 +10238,16 @@ dependencies = [
  "bytemuck",
  "core_maths",
  "read-fonts 0.41.0",
+]
+
+[[package]]
+name = "skrifa"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4febebda507fb889c545a37a135517769d1391941013561292897961d1887d6"
+dependencies = [
+ "bytemuck",
+ "read-fonts 0.43.3",
 ]
 
 [[package]]
@@ -11651,33 +11764,6 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.46.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e419dff010bb12512b0ae9e3d2f318dfbdf0167fde7eb05465134d4e8756076f"
-dependencies = [
- "base64 0.22.1",
- "data-url",
- "flate2",
- "fontdb",
- "imagesize",
- "kurbo 0.13.1",
- "log",
- "pico-args",
- "roxmltree 0.21.1",
- "rustybuzz",
- "simplecss",
- "siphasher",
- "strict-num",
- "svgtypes",
- "tiny-skia-path 0.11.4",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg"
 version = "0.47.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
@@ -11685,8 +11771,8 @@ dependencies = [
  "base64 0.22.1",
  "data-url",
  "flate2",
- "fontdb",
- "imagesize",
+ "fontdb 0.23.0",
+ "imagesize 0.14.0",
  "kurbo 0.13.1",
  "log",
  "pico-args",
@@ -11698,6 +11784,34 @@ dependencies = [
  "svgtypes",
  "tiny-skia-path 0.12.0",
  "ttf-parser",
+ "unicode-bidi",
+ "unicode-script",
+ "unicode-vo",
+ "xmlwriter",
+]
+
+[[package]]
+name = "usvg"
+version = "0.48.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
+dependencies = [
+ "base64 0.23.1",
+ "data-url",
+ "flate2",
+ "fontdb 0.24.0",
+ "harfrust",
+ "imagesize 0.15.0",
+ "kurbo 0.13.1",
+ "log",
+ "pico-args",
+ "roxmltree 0.21.1",
+ "simplecss",
+ "siphasher",
+ "skrifa 0.44.0",
+ "strict-num",
+ "svgtypes",
+ "tiny-skia-path 0.12.0",
  "unicode-bidi",
  "unicode-script",
  "unicode-vo",
@@ -12417,7 +12531,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "mp4",
- "quick-xml",
+ "quick-xml 0.41.0",
  "subtp",
  "transmux",
  "waterkit-video-core 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -12646,6 +12760,21 @@ dependencies = [
 [[package]]
 name = "waterui-canvas"
 version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de6c5cbca41bf2d48a2b4a4c5028475b85a2231b2bce13b16b48274c3883c35"
+dependencies = [
+ "image",
+ "kurbo 0.13.1",
+ "nami",
+ "parley",
+ "peniko",
+ "waterui-core",
+ "waterui-graphics",
+]
+
+[[package]]
+name = "waterui-canvas"
+version = "0.1.0"
 source = "git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe#ed4cecc706f69f381555f3fe193134da6e0ff7fe"
 dependencies = [
  "image",
@@ -12666,7 +12795,7 @@ dependencies = [
  "bytemuck",
  "nami",
  "num-traits",
- "waterui-canvas",
+ "waterui-canvas 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
@@ -12804,13 +12933,13 @@ dependencies = [
  "parley",
  "peniko",
  "serde",
- "skrifa 0.42.1",
+ "skrifa 0.46.2",
  "softbuffer",
  "toml 1.1.4+spec-1.1.0",
  "vello_cpu",
  "waterui",
  "waterui-backend-core",
- "waterui-canvas",
+ "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
  "waterui-chart",
  "waterui-controls",
  "waterui-core",
@@ -12952,7 +13081,7 @@ dependencies = [
  "executor-core",
  "gdk4",
  "glib",
- "glow",
+ "glow 0.18.0",
  "gtk4",
  "indexmap 2.14.0",
  "keycode",
@@ -13238,7 +13367,7 @@ dependencies = [
  "getrandom 0.2.17",
  "image",
  "kurbo 0.13.1",
- "lru",
+ "lru 0.16.4",
  "maplibre-expr",
  "mvt-reader",
  "nami",
@@ -13272,7 +13401,7 @@ dependencies = [
  "peniko",
  "pollster 1.0.1",
  "pulldown-latex",
- "quick-xml",
+ "quick-xml 0.42.0",
  "serde",
  "thiserror 2.0.20",
  "toml 1.1.4+spec-1.1.0",
@@ -13327,7 +13456,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "waterui",
- "waterui-canvas",
+ "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
@@ -13438,7 +13567,7 @@ dependencies = [
  "peniko",
  "pollster 1.0.1",
  "tracing",
- "usvg 0.46.0",
+ "usvg 0.48.1",
  "waterui",
  "waterui-core",
  "waterui-graphics",
@@ -13464,7 +13593,7 @@ dependencies = [
  "sysinfo",
  "vello",
  "waterui",
- "waterui-canvas",
+ "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
  "waterui-core",
  "waterui-preview-protocol",
  "wgpu",
@@ -13694,7 +13823,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "338e30461b3a2b67d70eb30a6d89f8e0c93a833e07d2ae89085cd070c4a00ac0"
 dependencies = [
  "proc-macro2",
- "quick-xml",
+ "quick-xml 0.41.0",
  "quote",
 ]
 
@@ -13922,7 +14051,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "281c4db2ca90300db1f1f44a90332d09dc9f4e551314d2aa36f3d6f15ad307ed"
 dependencies = [
  "ash",
- "glow",
+ "glow 0.17.0",
  "libc",
  "libloading 0.9.0",
  "objc2 0.6.4",
@@ -13948,7 +14077,7 @@ dependencies = [
  "bytemuck",
  "cfg-if 1.0.4",
  "cfg_aliases 0.2.2",
- "glow",
+ "glow 0.17.0",
  "glutin_wgl_sys",
  "gpu-allocator",
  "gpu-descriptor",
@@ -14813,7 +14942,7 @@ source = "git+https://github.com/rust-x-bindings/rust-xcb?rev=ae3b2cd080e7817322
 dependencies = [
  "bitflags 2.13.1",
  "libc",
- "quick-xml",
+ "quick-xml 0.41.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4499,18 +4499,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glow"
-version = "0.18.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263218b0ba2b0715c3370fb04674f5f8aa331594b521c94ff0a8e4a8472d1386"
-dependencies = [
- "js-sys",
- "slotmap",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
 name = "glutin_wgl_sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13081,7 +13069,7 @@ dependencies = [
  "executor-core",
  "gdk4",
  "glib",
- "glow 0.18.0",
+ "glow",
  "gtk4",
  "indexmap 2.14.0",
  "keycode",
@@ -14051,7 +14039,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "281c4db2ca90300db1f1f44a90332d09dc9f4e551314d2aa36f3d6f15ad307ed"
 dependencies = [
  "ash",
- "glow 0.17.0",
+ "glow",
  "libc",
  "libloading 0.9.0",
  "objc2 0.6.4",
@@ -14077,7 +14065,7 @@ dependencies = [
  "bytemuck",
  "cfg-if 1.0.4",
  "cfg_aliases 0.2.2",
- "glow 0.17.0",
+ "glow",
  "glutin_wgl_sys",
  "gpu-allocator",
  "gpu-descriptor",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -255,7 +255,11 @@ lyon = "1.0"
 wgpu-hal = { version = "29.0.4", features = ["gles", "metal"] }
 # Must match the `glow` version wgpu-hal links against, or GLES handles from
 # `wgpu::hal::gles` fail to unify with locally created ones.
-glow = "0.18"
+# Tracks whatever `wgpu-hal` links, not the newest release: the GTK backend
+# hands a `glow::NativeFramebuffer` straight to
+# `wgpu::hal::gles::TextureInner::ExternalNativeFramebuffer`, so a different
+# major here makes that a different type and the backend stops compiling.
+glow = "0.17"
 tiny-skia = "0.12"
 zenwave = { version = "0.5.0", default-features = false, features = ["hyper-backend"] }
 futures-timer = "3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,10 +91,10 @@ executor-core = { version = "0.7.1", features = ["std"]}
 # off. (waterkit keeps it: its streaming code does `block_on`.)
 futures = { version = "0.3", default-features = false, features = ["std", "async-await"] }
 futures-lite = "2.6"
-geo = { version = "0.32", default-features = false }
-getrandom = "0.2"
+geo = { version = "0.33", default-features = false }
+getrandom = "0.4"
 geo-types = "0.7"
-lru = "0.16"
+lru = "0.18"
 maplibre-expr = "0.3.2"
 mvt-reader = "2.4.0"
 # W3C UI Events key/code/modifier vocabulary, shared by the GPU-surface input
@@ -225,10 +225,10 @@ parley = { version = "0.11", default-features = false }
 # SVG documents are parsed here and drawn through `Scene2D`; nothing in the
 # workspace renders one with `vello_svg`, so the parser is depended on directly
 # rather than through a Vello-only renderer.
-usvg = "0.46.0"
+usvg = "0.48.1"
 kurbo = "0.13"
 peniko = "0.6"
-skrifa = "0.42.1"
+skrifa = "0.46.2"
 # The only crate in the Rust ecosystem that reads the OpenType `MATH` table.
 # `read-fonts`/`skrifa` do not expose it (googlefonts/fontations#1269 has been
 # open since 2024-11), and neither `rustybuzz` nor `harfrust` port HarfBuzz's
@@ -242,7 +242,7 @@ pulldown-latex = "0.8"
 # Writes the MathML an accessibility tree carries. XML is structured output, so
 # it goes through a writer that escapes and balances tags rather than through
 # `push_str`/`format!` chains.
-quick-xml = "0.41"
+quick-xml = "0.42"
 # Turns that MathML into the sentence a screen reader reads out — the ClearSpeak
 # / MathSpeak engine assistive-technology vendors ship. `include-zip` compiles
 # the speech rules into the binary as one bzip2 archive served from an in-memory
@@ -255,7 +255,7 @@ lyon = "1.0"
 wgpu-hal = { version = "29.0.4", features = ["gles", "metal"] }
 # Must match the `glow` version wgpu-hal links against, or GLES handles from
 # `wgpu::hal::gles` fail to unify with locally created ones.
-glow = "0.17"
+glow = "0.18"
 tiny-skia = "0.12"
 zenwave = { version = "0.5.0", default-features = false, features = ["hyper-backend"] }
 futures-timer = "3"

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -61,7 +61,7 @@ gestures = ["waterui-backend-core/gestures"]
 progress = ["dep:waterui"]
 
 [dependencies]
-accesskit = "0.24"
+accesskit = "0.25"
 waterui-core.workspace = true
 waterui-backend-core.workspace = true
 waterui-controls.workspace = true

--- a/backends/dew/src/accessibility.rs
+++ b/backends/dew/src/accessibility.rs
@@ -8,7 +8,9 @@
 
 use std::collections::BTreeMap;
 
-use accesskit::{Action, ActionData, ActionRequest, Node, NodeId, Role, Tree, TreeId, TreeUpdate};
+use accesskit::{
+    Action, ActionData, ActionRequest, Node, NodeId, Role, TreeId, TreeInfo, TreeUpdate,
+};
 use kurbo::Rect;
 use nami::{Binding, Computed, Signal};
 use waterui_core::Str;
@@ -260,7 +262,7 @@ impl AccessibilityBuilder {
         }
         self.pending_update = Some(TreeUpdate {
             nodes,
-            tree: Some(Tree::new(ROOT_ID)),
+            tree: Some(TreeInfo::new(ROOT_ID)),
             tree_id: TreeId::ROOT,
             focus: self.focus,
         });

--- a/backends/hydrolysis/Cargo.toml
+++ b/backends/hydrolysis/Cargo.toml
@@ -44,15 +44,15 @@ rayon = "1.12"
 pollster.workspace = true
 executor-core.workspace = true
 rustc-hash.workspace = true
-unicode-segmentation = "1.12"
+unicode-segmentation = "1.13"
 async-task = "4.7"
 native-executor.workspace = true
 winit = { version = "0.30", optional = true }
 keyboard-types.workspace = true
 ui-events-winit = { workspace = true, optional = true }
-accesskit = { version = "0.24", optional = true }
+accesskit = { version = "0.25", optional = true }
 waterui-inspector-protocol.workspace = true
-accesskit_winit = { version = "0.33.2", optional = true }
+accesskit_winit = { version = "0.34.0", optional = true }
 
 [build-dependencies]
 cfg_aliases = "0.2.2"

--- a/backends/hydrolysis/src/renderer.rs
+++ b/backends/hydrolysis/src/renderer.rs
@@ -78,7 +78,7 @@ use accesskit::{
     ActionRequest as AccessibilityActionRequest, Node as AccessibilityNode,
     NodeId as AccessibilityNodeId, Rect as AccessibilityRect, Role as AccessibilityNodeRole,
     TextDirection as AccessibilityTextDirection, Toggled as AccessibilityToggled,
-    Tree as AccessibilityTree, TreeId as AccessibilityTreeId,
+    TreeId as AccessibilityTreeId, TreeInfo as AccessibilityTree,
     TreeUpdate as AccessibilityTreeUpdate,
 };
 use executor_core::spawn_local;

--- a/src/Cargo.toml
+++ b/src/Cargo.toml
@@ -37,7 +37,7 @@ futures.workspace = true
 tracing.workspace = true
 # Grapheme clusters for the avatar monogram: a name's first "letter" is a
 # cluster, not a `char`, wherever a combining mark or an emoji sequence is one.
-unicode-segmentation = "1.12"
+unicode-segmentation = "1.13"
 tracing-subscriber = { workspace = true, optional = true }
 async-channel.workspace = true
 minstant.workspace = true

--- a/testing/Cargo.toml
+++ b/testing/Cargo.toml
@@ -18,7 +18,7 @@ waterui-core.workspace = true
 waterui.workspace = true
 wgpu.workspace = true
 vello.workspace = true
-accesskit = "0.24"
+accesskit = "0.25"
 pollster.workspace = true
 image = { version = "0.25", default-features = false, features = ["png"] }
 executor-core.workspace = true


### PR DESCRIPTION
Refs #405 — the routine half of it.

Ten crates the workspace pins by version had newer releases whose upgrades are
independent of one another and of the renderer stack:

| Crate | From | To |
| --- | --- | --- |
| `quick-xml` | 0.41 | 0.42 |
| `lru` | 0.16 | 0.18 |
| `geo` | 0.32 | 0.33 |
| `glow` | 0.17 | 0.18 |
| `getrandom` | 0.2 | 0.4 |
| `skrifa` | 0.42.1 | 0.46.2 |
| `usvg` | 0.46.0 | 0.48.1 |
| `unicode-segmentation` | 1.12 | 1.13 |
| `accesskit` + `accesskit_winit` | 0.24 / 0.33.2 | 0.25 / 0.34.0 |

One source change came with them: `accesskit` 0.25 renames `Tree` to `TreeInfo`
and leaves the old name as a deprecated alias, so the dew and hydrolysis
accessibility trees name the new type rather than compiling against a
deprecation — this workspace treats a deprecation warning as an error, so
"it still compiles" was not an option.

Two are deliberately not here:

- **the wgpu / vello / vello_cpu / zenwave stack**, which is one coordinated move
  behind a forked wgpu (the Mali negative-viewport patch) rather than a set of
  routine bumps, and belongs in its own change with its own device verification;
- **`base64` 0.22 → 0.23**, which also lives in the `kit` submodule, so it needs a
  kit change and a pin bump rather than a line in this manifest.

Verified locally on the full workspace: `cargo clippy --workspace --all-targets -D warnings`
clean, and `cargo nextest run --workspace` at 1738 passed / 1 failed — the single
failure being `fallback_release_backend_refs_match_workspace_backend_refs`,
which was reading the workspace's *checked-out* Android submodule (moved for an
unrelated branch) against the pin, and passes at the pinned commit.