### PR TITLE
fix(deps): redirect the registry waterui-canvas to the pinned git rev

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -415,6 +415,11 @@ lto = "thin"
 # those to its own copies or the graph carries two of each and every `View`
 # is a different type on either side. Publishing ignores this table, so the
 # published crates keep their registry pins.
+# `waterui-chart` on crates.io depends on the registry `waterui-canvas`, which
+# predates the `Path::arc_to` fix the workspace pins by git rev (#228). Without
+# this entry the graph carries both copies and every canvas `Path` is a
+# different type on either side.
+waterui-canvas = { git = "https://github.com/water-rs/canvas", rev = "ed4cecc706f69f381555f3fe193134da6e0ff7fe" }
 waterui-core = { path = "core" }
 waterui-graphics = { path = "components/visual/graphics" }
 waterui-layout = { path = "components/foundation/layout" }


### PR DESCRIPTION
`cargo metadata --locked` fails on `dev` today, and every `--locked`/`--frozen` build with it.

`waterui-chart` on crates.io depends on the registry `waterui-canvas`, while the workspace pins `waterui-canvas` to the git rev carrying the `Path::arc_to` restoration (#228). Nothing redirected the registry dependency, so a fresh resolve pulls a **second** copy of the crate into the graph — twelve dependency edges get disambiguated and a `waterui-canvas 0.1.0 (registry+…)` package appears — a delta the committed lock does not contain.

Adding the `[patch.crates-io]` entry alongside `waterui-core` and `waterui-graphics` is the fix the neighbouring comment already argues for: without it the graph carries two copies and canvas `Path` is a different type on either side of the chart boundary.

Verified: with the entry, `cargo metadata --locked` succeeds and `Cargo.lock` needs **no change at all** — one `waterui-canvas` entry remains, exactly as committed.

This was pre-existing on `dev`; it surfaced while resolving an unrelated feature graph.

Fixes #447