### PR TITLE
feat(waterui): forward the markdown-math feature through the facade

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -339,6 +339,11 @@ navigation-restoration = [
     "waterui-dylib?/navigation-restoration",
 ]
 flow-markdown = ["waterui-internal/flow-markdown", "waterui-dylib?/flow-markdown"]
+# Mathematical formulas in Markdown. Deliberately outside `all`: it brings a
+# layout engine, an OpenType `MATH` table reader, a LaTeX parser and MathCAT's
+# speech rules — about 2.7 MiB — and a bundled math font for the asset pipeline,
+# and `all` is what every full-feature CI leg builds on every platform.
+markdown-math = ["waterui-internal/markdown-math", "waterui-dylib?/markdown-math"]
 std = ["waterui-internal/std", "waterui-dylib?/std"]
 dynamic_linking = ["dep:waterui-dylib"]
 # Every feature the framework offers an application. `dynamic_linking` is

--- a/deny.toml
+++ b/deny.toml
@@ -17,6 +17,13 @@ allow = [
     "BSD-2-Clause",
     "BSD-3-Clause",
     "BSL-1.0",
+    # MathCAT's build script unpacks its speech-rule bundle with `zip`, which
+    # brings `libbz2-rs-sys`. The bzip2 licence is BSD-style and permissive —
+    # redistribution in source and binary form, keep the notice, do not
+    # misrepresent the origin — so it sits in the same class as `Zlib` and
+    # `0BSD` above. It reaches no shipped artifact either way: the crate is a
+    # build dependency and its code never enters an application binary.
+    "bzip2-1.0.6",
     "CC0-1.0",
     "CDLA-Permissive-2.0",
     "IJG",

--- a/utils/dylib/Cargo.toml
+++ b/utils/dylib/Cargo.toml
@@ -45,6 +45,7 @@ webview = ["waterui-internal/webview"]
 navigation-restoration = ["waterui-internal/navigation-restoration"]
 snackbar = ["waterui-internal/snackbar"]
 flow-markdown = ["waterui-internal/flow-markdown"]
+markdown-math = ["waterui-internal/markdown-math"]
 std = ["waterui-internal/std"]
 all = [
     "waterui-internal/all",


### PR DESCRIPTION
`waterui-internal` and the Markdown component have carried `markdown-math` since math landed, but neither the `waterui` facade nor `waterui-dylib` re-exported it. An application depending on `waterui` therefore had no way to turn it on — `waterui = { workspace = true, features = ["markdown-math"] }` failed to resolve, and `$…$` in Markdown rendered as literal text.

The feature stays **outside `all`** on purpose, and the manifest says why: it pulls a layout engine, an OpenType `MATH` table reader, a LaTeX parser, MathCAT's speech rules and a bundled math font — about 2.7 MiB — and `all` is what every full-feature CI leg builds on every platform.

Verified by building and running the `flow_markdown` example on macOS with the feature enabled: `$r = \\frac{e}{b}$` renders as a formula instead of literal text.

Fixes #446