### PR TITLE
test: cap concurrent Metal shader compilation on macOS

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -86,6 +86,47 @@ slow-timeout = { period = "120s", terminate-after = 15 }
 [test-groups.gpu-device]
 max-threads = 2
 
+# How many processes may compile Metal shaders at once on macOS.
+#
+# Every test process that mounts a `waterui-testing` host builds its own
+# `wgpu::Device`, and each device runs Vello's shader initialisation. On macOS
+# that is `newLibraryWithSource`, which goes through Metal's on-disk
+# shader-compiler cache — a single file shared by every process on the machine.
+# Metal does not survive many processes reading and writing it at once: a run of
+# the mermaid suite aborted with
+#
+#     SIGBUS, subtype "FS pagein error: 22 Invalid argument"
+#     thread "Vello shader initialisation worker thread"
+#       MTLCompilerFSCache::getElementImpl
+#       MTLLibraryBuilder::newLibraryWithSource
+#       wgpu_hal::metal::Device::load_shader
+#       vello::WgpuEngine::build_shaders_if_needed
+#
+# on a machine that also had three cargo builds running (#434). The faulting
+# page belongs to that cache file, not to anything WaterUI allocated: a reader
+# paged it in while another process rewrote it.
+#
+# The cap costs nothing, which is what makes it the right answer rather than a
+# trade. These tests all queue on one GPU, so parallelism past a handful buys no
+# wall clock — measured on the mermaid suite, twice each:
+#
+#     -j 32   3.415s  2.797s
+#     -j 8    2.265s  2.624s
+#     -j 4    2.496s  2.425s
+#
+# Scoped to the packages that mount a host, so the many fast non-GPU tests on
+# macOS keep full parallelism. The cap only ever binds on a developer machine —
+# GitHub's macOS runners have three or four cores, so nextest already runs at or
+# below four processes there — and a developer machine with a dozen cores is
+# exactly where the process storm happens.
+[test-groups.metal-shader-compile]
+max-threads = 4
+
+[[profile.default.overrides]]
+platform = 'cfg(target_os = "macos")'
+filter = 'package(hydrolysis) or package(hydrolysis-m3) or package(waterui-mermaid) or package(waterui) or package(waterui-testing)'
+test-group = 'metal-shader-compile'
+
 [[profile.ci.overrides]]
 platform = 'cfg(target_os = "windows")'
 filter = 'all()'


### PR DESCRIPTION
### What the SIGBUS actually was

macOS kept a crash report from the original abort, and it names the fault precisely:

```
signal   SIGBUS, subtype "FS pagein error: 22 Invalid argument"
address  0x108f7fac0 — inside a mapped-file region (rw-, private, 2000K)
thread   "Vello shader initialisation worker thread"
stack    AccelerateCrypto_SHA256_compress
         CC_SHA256_Update
         MTLCompilerFSCache::getElementImpl
         MultiLevelCacheBase::getElement
         MTLLibraryBuilder::newLibraryWithSource
         wgpu_hal::metal::Device::load_shader
         vello::WgpuEngine::build_shaders_if_needed
```

The faulting page belongs to **Metal's on-disk shader-compiler cache**, a single file shared by every process on the machine. Every nextest process mounts its own `wgpu::Device`; every device runs Vello's shader initialisation; on macOS that goes through `newLibraryWithSource`, which hashes the source against that cache. This process was reading it when another rewrote it, and the page-in returned `EINVAL`.

So it is **not** device teardown, **not** the shared context and **not** the offscreen session's lifetime — the three suspects #434 raised. Nothing WaterUI allocated is involved; the memory is Apple's.

### The other half of the report

`1 leaky` is unrelated and not a defect. Across 16 runs at `-j 32` it appeared on four, spread over tests that never touch the GPU — including `shape::tests::a_stadiums_edges_meet_its_ends_a_radius_from_each_corner`, a 12 ms geometry test. Run on its own, that test was clean 12 times out of 12. It is nextest's 100 ms pipe-close window being missed under 32-way process contention, not a thread outliving `main`.

### The fix, and why it is free

The tests all queue on one GPU, so parallelism past a handful buys no wall clock. Mermaid suite, twice each:

| concurrency | run 1 | run 2 |
|---|---|---|
| `-j 32` | 3.415s | 2.797s |
| `-j 8` | 2.265s | 2.624s |
| `-j 4` | 2.496s | 2.425s |

With the group in place the suite runs in 2.29–2.71s, i.e. unchanged. And the cap only ever binds on a developer machine: GitHub's macOS runners have three or four cores, so nextest is already at or below four processes there — while a dozen-core laptop running three cargo builds is exactly where the storm happened.

Scoped to the packages that mount a `waterui-testing` host, so the many fast non-GPU tests on macOS keep full parallelism.

Fixes #434