### PR TITLE
ci: reserve the dev gate for cached compilation checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ permissions:
   # dorny/paths-filter lists a pull request's changed files.
   pull-requests: read
 
-# The per-change gate (#379): what a pull request or a push to `dev` runs.
+# The pull-request gate (#379); dev pushes use the lint-only dev.yml (#458).
 # It is deliberately the default-features shape on Linux plus the checks a
 # change can break, chosen per change by the `changes` job below. The full
 # matrix — every clippy shape, macOS and Windows, the all-features runs, the
@@ -17,7 +17,7 @@ on:
   # Integration branches only: a branch that also has a PR would otherwise run
   # the whole gate twice for one commit.
   push:
-    branches: [main, dev]
+    branches: [main]
   pull_request:
     branches: ["**"]
 
@@ -34,16 +34,16 @@ env:
   # build. Local development still uses sccache; this is CI-only.
   #
   # The 10 GB quota is the budget every rust-cache block in this repository is
-  # written against (#328). Only two jobs store a target directory: the macOS
-  # and Windows Test legs (`test-macos-latest`, `test-windows-latest`), the
-  # slowest cold builds on the scarcest runners, both written by the nightly
-  # run. Every other job stores just `~/.cargo` under one per-OS key
-  # (`cargo-home-<OS>`), written by a single job per OS on the integration
-  # branches and read by the rest. The full set of per-job target tarballs
-  # measured ~27 GB against the cap, so each dev run evicted what the previous
-  # one wrote and every job restored nothing. Incremental artifacts are
-  # per-machine rebuild state, useless to a fresh runner, and they bloat the
-  # cache that is restored.
+  # written against (#328). The fast lint job now owns the target-cache budget
+  # (#458), including workspace check artifacts. Only its integration-branch
+  # fast runs write that cache; the full nightly lint is a restore-only reader.
+  # Daily test profiles no longer save their multi-GB target archives, which
+  # previously occupied the budget while every dev push cold-compiled clippy.
+  # The other jobs share Cargo sources under per-OS cargo-home keys, with one
+  # writer per OS. No test or platform coverage is removed by this allocation.
+  # The former full set of target archives measured ~27 GB against the cap.
+  # Incremental artifacts are per-machine rebuild state, useless to a fresh
+  # runner, so they stay disabled rather than bloating the restored cache.
   CARGO_INCREMENTAL: 0
 
 jobs:

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -1,0 +1,19 @@
+name: Dev CI
+
+on:
+  push:
+    branches: [dev]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: dev-ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    uses: ./.github/workflows/test.yml
+    with:
+      full: false

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -69,11 +69,11 @@ jobs:
       # ordinary ones, so storing it under the shared key would just overwrite
       # a useful tarball with one nothing else can restore. The target dir is
       # deliberately NOT cached: the instrumented tarball measures 3-5GB, and
-      # together with the two Test tarballs that oversubscribes the 10GB cache
-      # quota — every run would then evict one of the three and put a Test leg
-      # back on a 60-minute cold build. Coverage recompiles each run (~42min,
-      # which it already did when it was being evicted 4 runs out of 4) but
-      # only stores the ~0.2GB dependency caches, so the Test legs stay warm.
+      # caching it would compete with the fast lint gate for the 10GB cache
+      # quota. Daily instrumented artifacts must not evict the check artifacts
+      # reused by every dev push. Coverage recompiles each run, as before,
+      # while restoring only the shared Cargo dependency sources. The full
+      # instrumented suite and its upload are unchanged by that allocation.
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: cargo-home-${{ runner.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,11 +3,11 @@ name: Test
 on:
   workflow_call:
     inputs:
-      # `false` is the pull-request / integration-branch gate: format, the
-      # default-features clippy pass, the default-features test run on Linux,
-      # the examples on Linux, and the skill compile gate. `true` is the
-      # nightly matrix: every clippy shape, both platforms, the all-features
-      # runs, the macOS suites and the examples on macOS.
+      # `false` is the fast gate: format and default-features workspace clippy.
+      # `true` is the nightly matrix: every test, example, doctest, platform,
+      # optional-feature lint pass and the skill compile gate. Dev pushes
+      # enter through dev.yml; pull requests keep the additional ABI and
+      # dependency checks in ci.yml. Both callers use the same fast lint.
       full:
         type: boolean
         default: false
@@ -31,9 +31,9 @@ env:
 # every pull request a 60-70 minute wait whatever it changed. Those passes,
 # the macOS platform and the macOS suites now run only when `full` is set,
 # which `nightly.yml` does once a day against `dev`; a pull request and a
-# push to `dev` run the default-features gate on Linux. Nothing is checked
-# less often than daily, and nothing a pull request can break in the default
-# shape waits behind a shape it did not touch.
+# push to `dev` run default-features clippy and format on Linux (#458).
+# The complete default-feature tests and examples also belong to nightly;
+# no test coverage is removed to shorten the per-change feedback loop.
 jobs:
   # Lint before testing: it is the cheapest failure to produce, and the one a
   # contributor is most likely to hit, so it should not wait behind the whole
@@ -43,7 +43,7 @@ jobs:
   lint:
     name: lint
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: ${{ inputs.full && 90 || 10 }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -53,23 +53,23 @@ jobs:
           components: clippy, rustfmt
       - name: Install native dependencies
         uses: ./.github/actions/setup-linux-deps
-      # The Linux `~/.cargo` tarball is written here and read by every other
-      # Linux job (see the cache budget note in ci.yml). Only the integration
-      # branches write it: a pull request reads and saves nothing, since every
-      # distinct fingerprint would otherwise mint a generation that is never
-      # reclaimed.
+      # The fast gate owns the target-cache budget, including workspace check
+      # artifacts. Only integration-branch fast runs write it; pull requests
+      # and the full nightly lint restore without adding cache generations.
+      # The check-only Cargo profile avoids optimizing build dependencies for
+      # runtime speed when this job only needs their compiler output.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: cargo-home-${{ runner.os }}
-          cache-targets: false
-          save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
-          cache-on-failure: true
+          shared-key: lint-${{ runner.os }}
+          cache-targets: true
+          cache-workspace-crates: true
+          save-if: ${{ !inputs.full && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') }}
       - name: Format
         run: cargo fmt --all -- --check
       # Workspace-wide under default features first: it is the cheapest of the
       # lint passes and the one every crate's normal build shape goes through.
       - name: Clippy (workspace)
-        run: cargo clippy --workspace --exclude '*-example' --all-targets -- -D warnings
+        run: cargo clippy --locked --profile ci-check --workspace --exclude '*-example' --all-targets -- -D warnings
       # Then every crate's own optional features. This pass used to be
       # `cargo clippy --all-targets --all-features`, with neither `-p` nor
       # `--workspace`: the root manifest carries both `[workspace]` and
@@ -149,6 +149,7 @@ jobs:
       # transcriptions to the compiler without registering runnable tests —
       # they address elements that do not exist by design and must never run.
       - name: Skill snippet compile gate
+        if: inputs.full
         run: cargo check -p skill_snippets --all-targets --features compile-gate-tests
 
   # The web runner, compiled for the target it actually runs on.
@@ -164,11 +165,12 @@ jobs:
   # It lints rather than merely compiles, so `cfg(target_arch = "wasm32")` code
   # is held to the same bar as every other target (#413).
   #
-  # It runs in both tiers rather than only in the nightly: a pull request
-  # touching any of those three can break it, and the check is a couple of
-  # minutes even cold, against the 90-120 minute legs beside it.
+  # This target-specific pass runs nightly alongside the other platform
+  # shapes (#458). The fast gate retains default-feature host clippy; the
+  # nightly still checks the actual wasm-only code and kit dialog backend.
   wasm:
     name: wasm32
+    if: inputs.full
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -218,6 +220,7 @@ jobs:
   # below on Linux and part of `macos-suites` on macOS.
   test:
     name: ${{ matrix.os }}
+    if: inputs.full
     runs-on: ${{ matrix.os }}
     timeout-minutes: 120
     strategy:
@@ -244,15 +247,15 @@ jobs:
         uses: ./.github/actions/setup-linux-deps
         with:
           gpu: "true"
-      # macOS keeps its target directory (one of the two target tarballs the
-      # cache budget in ci.yml affords); the Linux leg reads the shared Linux
-      # `~/.cargo` tarball and compiles from there. Linux runners are the
-      # plentiful ones, and its cold build is shorter than the Windows one.
+      # The nightly test profiles restore only Cargo sources. Their multi-GB
+      # target archives previously occupied the cache budget while every dev
+      # push cold-compiled clippy. The frequent lint gate now owns that budget;
+      # these daily runs keep every test without evicting its check artifacts.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: ${{ runner.os == 'macOS' && 'test-macos-latest' || format('cargo-home-{0}', runner.os) }}
-          cache-targets: ${{ runner.os == 'macOS' }}
-          save-if: ${{ runner.os == 'macOS' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') }}
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          save-if: false
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       # One full-workspace pass under default features. Every crate's own
@@ -469,6 +472,7 @@ jobs:
   # workspace), and that stays as it was.
   examples:
     name: examples (${{ matrix.os }})
+    if: inputs.full
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
@@ -493,7 +497,7 @@ jobs:
         with:
           shared-key: cargo-home-${{ runner.os }}
           cache-targets: false
-          save-if: false
+          save-if: ${{ runner.os == 'Linux' && (github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main') }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Clippy (examples)

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -48,12 +48,13 @@ jobs:
         run: dxc --version
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: test-windows-latest
-          # Only the integration branches write cache generations, as in
-          # ci.yml and test.yml: a pull request reads them and saves nothing.
-          # Every PR fingerprint used to mint its own 5 GB generation here,
-          # and with the 10 GB repository cap that evicted the Test tarballs
-          # a dev run had just written (#328).
+          shared-key: cargo-home-${{ runner.os }}
+          cache-targets: false
+          # Only the integration branches write the shared Cargo source cache.
+          # The Windows target archive no longer competes with the fast lint
+          # gate for the repository's 10 GB budget (#458). Tests still run in
+          # every supported shape below; only their cache allocation changes.
+          # Other Windows jobs restore the same source cache without saving.
           save-if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/main' }}
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4975,7 +4975,7 @@ dependencies = [
  "waterui",
  "waterui-assets",
  "waterui-backend-core",
- "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
+ "waterui-canvas",
  "waterui-controls",
  "waterui-core",
  "waterui-form",
@@ -5005,7 +5005,7 @@ dependencies = [
  "vello",
  "waterui",
  "waterui-backend-core",
- "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
+ "waterui-canvas",
  "waterui-controls",
  "waterui-core",
  "waterui-form",
@@ -10194,7 +10194,7 @@ dependencies = [
  "waterkit-permission",
  "waterui",
  "waterui-barcode",
- "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
+ "waterui-canvas",
  "waterui-chart",
  "waterui-graphics",
  "waterui-icons-lucide",
@@ -12748,21 +12748,6 @@ dependencies = [
 [[package]]
 name = "waterui-canvas"
 version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7de6c5cbca41bf2d48a2b4a4c5028475b85a2231b2bce13b16b48274c3883c35"
-dependencies = [
- "image",
- "kurbo 0.13.1",
- "nami",
- "parley",
- "peniko",
- "waterui-core",
- "waterui-graphics",
-]
-
-[[package]]
-name = "waterui-canvas"
-version = "0.1.0"
 source = "git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe#ed4cecc706f69f381555f3fe193134da6e0ff7fe"
 dependencies = [
  "image",
@@ -12783,7 +12768,7 @@ dependencies = [
  "bytemuck",
  "nami",
  "num-traits",
- "waterui-canvas 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "waterui-canvas",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
@@ -12927,7 +12912,7 @@ dependencies = [
  "vello_cpu",
  "waterui",
  "waterui-backend-core",
- "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
+ "waterui-canvas",
  "waterui-chart",
  "waterui-controls",
  "waterui-core",
@@ -13444,7 +13429,7 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.20",
  "waterui",
- "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
+ "waterui-canvas",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
@@ -13581,7 +13566,7 @@ dependencies = [
  "sysinfo",
  "vello",
  "waterui",
- "waterui-canvas 0.1.0 (git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe)",
+ "waterui-canvas",
  "waterui-core",
  "waterui-preview-protocol",
  "wgpu",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -404,6 +404,13 @@ debug = "line-tables-only"
 debug = false
 opt-level = 2
 
+[profile.ci-check]
+inherits = "dev"
+debug = false
+
+[profile.ci-check.package."*"]
+opt-level = 0
+
 [profile.release]
 lto = true
 codegen-units = 1


### PR DESCRIPTION
## Summary
- Replace the pre-existing test-heavy dev push gate with format and default-feature workspace clippy.
- Preserve every existing test command in the full nightly invocation, including examples, doctests, wasm and skill snippets.
- Give the frequent check-only profile priority over nightly test archives in the Actions cache budget.

Fixes #458

Depends on the locked canvas source correction in #459; that prerequisite is a separate PR and should land first.

#### Test plan
- [x] actionlint on the five affected workflows.
- [x] Four policy checks: dev routing, fmt/clippy-only fast path, unchanged test commands, and lint cache ownership.
- [x] Locked offline dependency resolution and `git diff --check`.
- [ ] Measure cold and warm Actions runs; a timeout is not evidence that the ten-minute target is met.
- [ ] Verify the full nightly matrix remains runnable.

Repository extraction and distributed component CI remain in #186/#194. Certified nightly distribution and CLI channel selection are tracked in #460/#461.