### PR TITLE
ci(webview): require bridge JavaScript tests in nightly

### DIFF
--- a/.github/NIGHTLY_FAILURE.md
+++ b/.github/NIGHTLY_FAILURE.md
@@ -4,4 +4,4 @@ labels: ci
 ---
 The nightly full matrix failed: {{ env.RUN_URL }}
 
-Every job in that run is gating for `dev`: the per-change gate (`ci.yml`) only runs the default-features shape on Linux, so a failure here is either a shape a pull request cannot see (all-features, macOS, Windows, coverage, `cargo hack --each-feature`) or hosted-runner and toolchain drift. Read the failing job's log, fix the root cause on a topic branch, and close this issue when the next nightly is green.
+Every required check in that run gates nightly certification, including the WebView JavaScript bridge unit suite. The dev-push gate only runs format and compilation/lint checks; nightly also covers tests, all-features, macOS, Windows, coverage and `cargo hack --each-feature`. Read the failing job's log and uploaded test results, fix the root cause on a topic branch, and close this issue when the next nightly is green. A JavaScript suite failure must prevent certified nightly promotion even when every Rust check succeeds.

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,6 +41,10 @@ jobs:
     with:
       full: true
 
+  webview-js:
+    name: WebView JavaScript
+    uses: ./.github/workflows/webview-js.yml
+
   windows:
     name: Windows
     uses: ./.github/workflows/windows.yml
@@ -126,7 +130,7 @@ jobs:
 
   test-report:
     name: Test Report
-    needs: [test, windows]
+    needs: [test, windows, webview-js]
     if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 10
@@ -145,7 +149,7 @@ jobs:
   # failure that nobody was watching at 03:17 UTC is on the board by morning.
   report:
     name: Report failure
-    needs: [test, windows, coverage, feature-checks]
+    needs: [test, windows, coverage, feature-checks, webview-js]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/webview-js.yml
+++ b/.github/workflows/webview-js.yml
@@ -1,0 +1,35 @@
+name: WebView JavaScript
+
+on:
+  workflow_call:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Bridge unit tests
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: "1.3.4"
+      - name: Run JavaScript bridge tests
+        id: suite
+        run: bun test components/platform/webview/tests/js/ --reporter=junit --reporter-outfile=webview-js.xml
+      - name: Upload JavaScript test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: webview-js-results
+          path: webview-js.xml
+          if-no-files-found: error
+      - name: Report JavaScript test result
+        if: always()
+        env:
+          RESULT: ${{ steps.suite.outcome }}
+        run: |
+          printf '### WebView JavaScript\n\nBridge unit tests: **%s**\n' "$RESULT" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Close the pre-existing JavaScript coverage gap by running the existing WebView bridge suite as a required nightly job.
- Upload JUnit results and report the test outcome, including failures in the existing nightly issue report.
- Keep product tests off the dev-push compilation gate; expose the same job for explicit standalone verification.

Fixes #466

Certified nightly promotion in #460 must depend on this job as well as the existing full matrix.

#### Test plan
- [x] Existing JavaScript bridge suite: 22 tests passed locally.
- [x] actionlint on nightly.yml and webview-js.yml.
- [x] git diff --check.
- [ ] Run the full nightly workflow on this branch, including the JavaScript job.