### PR TITLE
feat(nightly): publish only immutable tested snapshots

### DIFF
--- a/.github/scripts/prepare_nightly.py
+++ b/.github/scripts/prepare_nightly.py
@@ -1,0 +1,74 @@
+import hashlib
+import json
+import os
+from pathlib import Path
+import re
+import subprocess
+import tomllib
+
+
+def git(*args):
+    return subprocess.check_output(["git", *args], text=True).strip()
+
+
+def prepare():
+    revision = git("rev-parse", "HEAD")
+    if revision != os.environ["GITHUB_SHA"]:
+        raise RuntimeError("The checkout is not the revision tested by this run")
+    repository = os.environ["GITHUB_REPOSITORY"]
+    date = git("show", "-s", "--format=%cs", "HEAD").replace("-", "")
+    tag = f"nightly-{date}-{revision[:12]}"
+    pages = json.loads(subprocess.check_output([
+        "gh", "api", f"repos/{repository}/releases", "--paginate", "--slurp",
+    ], text=True))
+    releases = [
+        release for page in pages for release in page
+        if not release["draft"] and release["prerelease"]
+        and re.fullmatch(r"nightly-\d{8}-[0-9a-f]{12}", release["tag_name"])
+    ]
+    if any(release["tag_name"] == tag for release in releases):
+        return {"eligible": "false", "reason": "This revision is already certified"}
+    if releases:
+        latest = max(releases, key=lambda release: release["published_at"])
+        latest_revision = git("rev-parse", f'{latest["tag_name"]}^{{commit}}')
+        comparison = subprocess.run([
+            "git", "merge-base", "--is-ancestor", latest_revision, revision,
+        ])
+        if comparison.returncode == 1:
+            return {"eligible": "false", "reason": "This run does not advance the certified revision"}
+        comparison.check_returncode()
+    submodules = {}
+    for line in subprocess.check_output(["git", "submodule", "status", "--recursive"], text=True).splitlines():
+        if not line.startswith(" "):
+            raise RuntimeError(f"Submodule is not at its recorded revision: {line}")
+        commit, path, *_ = line.split()
+        submodules[path] = commit
+    lockfiles = {}
+    for path in [Path("Cargo.lock"), *(Path(path) / "Cargo.lock" for path in submodules)]:
+        if path.is_file():
+            lockfiles[str(path)] = hashlib.sha256(path.read_bytes()).hexdigest()
+    scaffold = tomllib.loads(Path("cli/Cargo.toml").read_text())["package"]["metadata"]["waterui-scaffold"]
+    manifest = {
+        "schema_version": 1,
+        "channel": "nightly",
+        "repository": repository,
+        "revision": revision,
+        "tag": tag,
+        "run_id": int(os.environ["GITHUB_RUN_ID"]),
+        "run_attempt": int(os.environ["GITHUB_RUN_ATTEMPT"]),
+        "submodules": submodules,
+        "lockfiles": lockfiles,
+        "scaffold": scaffold,
+    }
+    Path("framework.json").write_text(json.dumps(manifest, indent=2) + "\n")
+    return {"eligible": "true", "tag": tag, "revision": revision}
+
+
+if __name__ == "__main__":
+    outputs = prepare()
+    with Path(os.environ["GITHUB_OUTPUT"]).open("a") as output:
+        for key, value in outputs.items():
+            output.write(f"{key}={value}\n")
+    if outputs["eligible"] == "false":
+        with Path(os.environ["GITHUB_STEP_SUMMARY"]).open("a") as summary:
+            summary.write(outputs["reason"] + "\n")

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -94,7 +94,7 @@ jobs:
       # cargo's build profile. The ci profile matters here because it disables
       # fail-fast — without it a single failing test ends the run and hides the
       # state of every test after it (see #153, where one failure masked 632).
-      - run: cargo llvm-cov nextest --workspace --exclude '*-example' --features waterui/all --lcov --output-path lcov.info
+      - run: cargo llvm-cov nextest --locked --workspace --exclude '*-example' --features waterui/all --lcov --output-path lcov.info
         env:
           NEXTEST_PROFILE: ci
       - uses: codecov/codecov-action@v4
@@ -126,7 +126,7 @@ jobs:
       # proved nothing — it produced no signal in any recent run. `--each-feature`
       # is linear and catches the failure that actually happens: a feature that
       # does not build on its own.
-      - run: cargo hack check --each-feature --no-dev-deps
+      - run: cargo hack check --locked --each-feature --no-dev-deps
 
   test-report:
     name: Test Report
@@ -145,11 +145,54 @@ jobs:
       - name: Generate Step Summary
         run: python3 .github/scripts/generate_test_summary.py artifacts >> "$GITHUB_STEP_SUMMARY"
 
+  promote:
+    name: Certify nightly
+    needs: [test, windows, coverage, feature-checks, webview-js, test-report]
+    if: github.ref == 'refs/heads/dev'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+          fetch-depth: 0
+          submodules: recursive
+      - name: Prepare the tested snapshot
+        id: snapshot
+        run: python3 .github/scripts/prepare_nightly.py
+      - name: Upload immutable snapshot assets
+        if: steps.snapshot.outputs.eligible == 'true'
+        uses: softprops/action-gh-release@v2.3.2
+        with:
+          tag_name: ${{ steps.snapshot.outputs.tag }}
+          target_commitish: ${{ steps.snapshot.outputs.revision }}
+          name: ${{ steps.snapshot.outputs.tag }}
+          draft: true
+          prerelease: true
+          make_latest: "false"
+          fail_on_unmatched_files: true
+          files: |
+            framework.json
+            Cargo.lock
+          body: |
+            Certified framework revision: ${{ steps.snapshot.outputs.revision }}
+            Full test run: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+            framework.json records the tested dependency lock and submodule revisions.
+      - name: Publish the complete certification
+        if: steps.snapshot.outputs.eligible == 'true'
+        env:
+          TAG: ${{ steps.snapshot.outputs.tag }}
+        run: gh release edit "$TAG" --draft=false --prerelease --latest=false
+
   # One issue per broken nightly, updated in place while it stays red, so a
   # failure that nobody was watching at 03:17 UTC is on the board by morning.
   report:
     name: Report failure
-    needs: [test, windows, coverage, feature-checks, webview-js]
+    needs: [test, windows, coverage, feature-checks, webview-js, promote]
     if: failure()
     runs-on: ubuntu-latest
     timeout-minutes: 5

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
       - name: Clippy (all features, workspace)
         if: inputs.full
         run: |
-          cargo clippy --workspace --all-targets --all-features \
+          cargo clippy --locked --workspace --all-targets --all-features \
             --exclude '*-example' \
             --exclude waterui-core \
             --exclude waterui-ffi \
@@ -105,7 +105,7 @@ jobs:
       # crate has, it gets here.
       - name: Clippy (waterui-core, every stable feature)
         if: inputs.full
-        run: cargo clippy -p waterui-core --all-targets --features std,serde -- -D warnings
+        run: cargo clippy --locked -p waterui-core --all-targets --features std,serde -- -D warnings
       # `waterui-ffi` selects its ABI with mutually exclusive features and
       # `ffi/src/lib.rs` turns `c-api` + `android-jni` into a `compile_error!`.
       # This is the `c-api` half with every optional C surface a runtime build
@@ -113,7 +113,7 @@ jobs:
       # and the compile-only `cef-header` shape is the `macos-suites` job below.
       - name: Clippy (waterui-ffi, C ABI surfaces)
         if: inputs.full
-        run: cargo clippy -p waterui-ffi --all-targets --features map,chromium,webview-cef -- -D warnings
+        run: cargo clippy --locked -p waterui-ffi --all-targets --features map,chromium,webview-cef -- -D warnings
       # `webview-system` bridges the macOS WKWebView into the winit window and
       # `compile_error!`s anywhere else, so this is every hydrolysis feature but
       # that one. `macos-suites` compiles `webview-system` in its
@@ -121,7 +121,7 @@ jobs:
       - name: Clippy (hydrolysis, every portable feature)
         if: inputs.full
         run: |
-          cargo clippy -p hydrolysis --all-targets \
+          cargo clippy --locked -p hydrolysis --all-targets \
             --features accessibility,inspector-signals,testing,web,winit -- -D warnings
       # `compile-only` swaps in CEF's `dox` stubs and stops the build script
       # downloading the distribution that `cef-runtime` — and the `real_engine`
@@ -132,7 +132,7 @@ jobs:
       # `--all-targets` skips it for want of its required feature.
       - name: Clippy (waterui-browser-cef, CEF runtime)
         if: inputs.full
-        run: cargo clippy -p waterui-browser-cef --all-targets --features chromium,webview -- -D warnings
+        run: cargo clippy --locked -p waterui-browser-cef --all-targets --features chromium,webview -- -D warnings
       # Dew's firmware shape, which is a first-class configuration rather than
       # a degraded one. Neither pass above compiles dew's test targets without
       # default features, and the `Features` job's `--each-feature` sweep runs
@@ -142,7 +142,7 @@ jobs:
       # library alone has always been clean here.
       - name: Clippy (dew firmware shape)
         if: inputs.full
-        run: cargo clippy -p waterui-dew --all-targets --no-default-features -- -D warnings
+        run: cargo clippy --locked -p waterui-dew --all-targets --no-default-features -- -D warnings
       # The waterui skill's snippet compile gate: every rust fence in
       # .claude/skills/waterui is transcribed into .claude/skills/waterui/skill_snippets
       # and must keep compiling. The non-default feature exposes the test/bench
@@ -150,7 +150,7 @@ jobs:
       # they address elements that do not exist by design and must never run.
       - name: Skill snippet compile gate
         if: inputs.full
-        run: cargo check -p skill_snippets --all-targets --features compile-gate-tests
+        run: cargo check --locked -p skill_snippets --all-targets --features compile-gate-tests
 
   # The web runner, compiled for the target it actually runs on.
   #
@@ -199,7 +199,7 @@ jobs:
           cache-on-failure: true
       - name: Lint the web runner for wasm32
         run: |
-          cargo clippy --target wasm32-unknown-unknown \
+          cargo clippy --locked --target wasm32-unknown-unknown \
             -p hydrolysis --features hydrolysis/web \
             -p waterui-media \
             -p waterkit-dialog \
@@ -211,7 +211,7 @@ jobs:
       # the flags are spelled. Lint it from the workspace that owns it.
       - name: Lint the kit dialog browser backend for wasm32
         working-directory: kit
-        run: cargo clippy -p waterkit-dialog --target wasm32-unknown-unknown -- -D warnings
+        run: cargo clippy --locked -p waterkit-dialog --target wasm32-unknown-unknown -- -D warnings
 
   # The workspace test run, per platform. On Linux it also carries the
   # doctests, which share its build; on macOS those go to `macos-suites`, so
@@ -261,10 +261,10 @@ jobs:
       # One full-workspace pass under default features. Every crate's own
       # optional features are the `all-features` job below (Linux) and the
       # `macos-suites` all-features pass (macOS).
-      - run: cargo nextest run --workspace --exclude '*-example' --profile ci
+      - run: cargo nextest run --locked --workspace --exclude '*-example' --profile ci
       # nextest cannot run doctests, and this workspace has plenty of them.
       - if: runner.os == 'Linux'
-        run: cargo test --doc --workspace --exclude '*-example'
+        run: cargo test --locked --doc --workspace --exclude '*-example'
       - name: Upload Test Snapshots
         if: always()
         uses: actions/upload-artifact@v4
@@ -275,7 +275,7 @@ jobs:
           retention-days: 14
 
   # Every crate's own optional features, run. This pass used to be
-  # `cargo nextest run --all-features` inside the `test` job, with neither
+  # `cargo nextest run --locked --all-features` inside the `test` job, with neither
   # `-p` nor `--workspace`: the root manifest carries both `[workspace]` and
   # `[package]`, so cargo narrowed it to the root `waterui` crate, and a
   # backend crate's tests behind its own optional features — dew's
@@ -330,7 +330,7 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Test (all features, workspace)
         run: |
-          cargo nextest run --workspace --all-features --profile ci \
+          cargo nextest run --locked --workspace --all-features --profile ci \
             --exclude '*-example' \
             --exclude waterui-core \
             --exclude waterui-ffi \
@@ -340,25 +340,25 @@ jobs:
             --exclude skill_snippets
       # `nightly` is `feature(never_type)`, a hard E0554 on stable.
       - name: Test (waterui-core, every stable feature)
-        run: cargo nextest run -p waterui-core --features std,serde --profile ci
+        run: cargo nextest run --locked -p waterui-core --features std,serde --profile ci
       # The `c-api` half with every optional C surface a runtime build can
       # carry; `android-jni` is the `Android FFI` job in ci.yml.
       - name: Test (waterui-ffi, C ABI surfaces)
-        run: cargo nextest run -p waterui-ffi --features map,chromium,webview-cef --profile ci
+        run: cargo nextest run --locked -p waterui-ffi --features map,chromium,webview-cef --profile ci
       # Every hydrolysis feature but `webview-system`, which only builds on
       # macOS (`macos-suites` runs its `real_engine_macos` target).
       - name: Test (hydrolysis, every portable feature)
         run: |
-          cargo nextest run -p hydrolysis --profile ci \
+          cargo nextest run --locked -p hydrolysis --profile ci \
             --features accessibility,inspector-signals,testing,web,winit
       # The CEF runtime shape; `compile-only` and `real-engine` exclude it.
       - name: Test (waterui-browser-cef, CEF runtime)
-        run: cargo nextest run -p waterui-browser-cef --features chromium,webview --profile ci
+        run: cargo nextest run --locked -p waterui-browser-cef --features chromium,webview --profile ci
       # Dew's firmware shape, a first-class configuration whose test targets
       # had stopped compiling entirely before the clippy pass covered them
       # (#259); this is the run that goes with that lint.
       - name: Test (dew firmware shape)
-        run: cargo nextest run -p waterui-dew --no-default-features --profile ci
+        run: cargo nextest run --locked -p waterui-dew --no-default-features --profile ci
       - name: Upload Test Snapshots
         if: always()
         uses: actions/upload-artifact@v4
@@ -405,7 +405,7 @@ jobs:
       # host-independent and the Linux job covers them.
       - name: Test (all features, workspace)
         run: |
-          cargo nextest run --workspace --all-features --profile ci \
+          cargo nextest run --locked --workspace --all-features --profile ci \
             --exclude '*-example' \
             --exclude waterui-core \
             --exclude waterui-ffi \
@@ -413,19 +413,19 @@ jobs:
             --exclude waterui-browser-cef \
             --exclude skill_snippets
       - name: Test (waterui-core, every stable feature)
-        run: cargo nextest run -p waterui-core --features std,serde --profile ci
+        run: cargo nextest run --locked -p waterui-core --features std,serde --profile ci
       - name: Test (hydrolysis, every portable feature)
         run: |
-          cargo nextest run -p hydrolysis --profile ci \
+          cargo nextest run --locked -p hydrolysis --profile ci \
             --features accessibility,inspector-signals,testing,web,winit
       # The macOS real-engine suite drives a genuine WKWebView through the
       # shared bridge contract — the macOS sibling of the WPE real-engine
       # workflow. It is `harness = false` (WKWebView is MainThreadOnly, and
       # libtest runs tests on worker threads), so nextest cannot list it;
       # `cargo test` runs the binary on the real process main thread.
-      - run: cargo test -p hydrolysis --features webview-system,winit --test real_engine_macos
+      - run: cargo test --locked -p hydrolysis --features webview-system,winit --test real_engine_macos
       # nextest cannot run doctests, and this workspace has plenty of them.
-      - run: cargo test --doc --workspace --exclude '*-example'
+      - run: cargo test --locked --doc --workspace --exclude '*-example'
       # The web view bridge has broken three times in ways no Rust-side test
       # could see, so these drive a real Chromium. Unlike the WPE sibling in
       # `browser-wpe.yml`, which compiles an engine from source for hours, CEF
@@ -448,13 +448,13 @@ jobs:
       # CEF runtime download, on a workspace this job has already built.
       - name: Lint the CEF targets
         run: |
-          cargo clippy -p waterui-browser-cef --features real-engine --all-targets -- -D warnings
-          cargo clippy -p waterui-ffi --features cef-header --all-targets -- -D warnings
+          cargo clippy --locked -p waterui-browser-cef --features real-engine --all-targets -- -D warnings
+          cargo clippy --locked -p waterui-ffi --features cef-header --all-targets -- -D warnings
       # `cargo test` rather than nextest: CEF's browser process has to own the
       # main thread, libtest runs test bodies on spawned ones, so the target is
       # `harness = false` and nextest cannot enumerate it.
       - name: Run the CEF real-engine tests
-        run: cargo test -p waterui-browser-cef --features real-engine --test real_engine
+        run: cargo test --locked -p waterui-browser-cef --features real-engine --test real_engine
       - name: Upload Test Snapshots
         if: always()
         uses: actions/upload-artifact@v4
@@ -502,9 +502,9 @@ jobs:
       - uses: taiki-e/install-action@nextest
       - name: Clippy (examples)
         if: runner.os == 'Linux'
-        run: cargo clippy -p '*-example' --all-targets -- -D warnings
-      - run: cargo nextest run -p '*-example' --profile ci
-      - run: cargo test --doc -p '*-example'
+        run: cargo clippy --locked -p '*-example' --all-targets -- -D warnings
+      - run: cargo nextest run --locked -p '*-example' --profile ci
+      - run: cargo test --locked --doc -p '*-example'
       - name: Upload Test Snapshots
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -86,9 +86,9 @@ jobs:
       # `--all-features` pass is structurally impossible — `waterui-ffi`
       # enforces "exactly one ABI" with a `compile_error!` (ffi/src/lib.rs), so
       # enabling `c-api` and `android-jni` together can never build.
-      - run: cargo nextest run --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude webview-cef-example --exclude chromium-example --profile ci
+      - run: cargo nextest run --locked --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude webview-cef-example --exclude chromium-example --profile ci
       # nextest cannot run doctests, and this workspace has plenty of them.
-      - run: cargo test --doc --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude webview-cef-example --exclude chromium-example
+      - run: cargo test --locked --doc --workspace --exclude waterui-dylib --exclude waterui-browser-cef --exclude webview-cef-example --exclude chromium-example
       - name: Upload Test Snapshots
         if: always()
         uses: actions/upload-artifact@v4
@@ -137,10 +137,10 @@ jobs:
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
       - name: Test (root crate, every feature but dynamic_linking)
-        run: cargo nextest run --features all --profile ci
+        run: cargo nextest run --locked --features all --profile ci
       - name: Test (all features, workspace)
         run: |
-          cargo nextest run --workspace --all-features --profile ci `
+          cargo nextest run --locked --workspace --all-features --profile ci `
             --exclude waterui `
             --exclude waterui-dylib `
             --exclude '*-example' `
@@ -150,10 +150,10 @@ jobs:
             --exclude waterui-browser-cef `
             --exclude skill_snippets
       - name: Test (waterui-core, every stable feature)
-        run: cargo nextest run -p waterui-core --features std,serde --profile ci
+        run: cargo nextest run --locked -p waterui-core --features std,serde --profile ci
       - name: Test (hydrolysis, every portable feature)
         run: |
-          cargo nextest run -p hydrolysis --profile ci `
+          cargo nextest run --locked -p hydrolysis --profile ci `
             --features accessibility,inspector-signals,testing,web,winit
       - name: Upload Test Snapshots
         if: always()
@@ -193,9 +193,9 @@ jobs:
           cache-on-failure: true
       # Compile the CEF backend without its binary distribution (see the test
       # job for why it cannot be linked here).
-      - run: cargo check -p waterui-browser-cef --features compile-only
+      - run: cargo check --locked -p waterui-browser-cef --features compile-only
       # Windows-only code is invisible to every other leg: a `cfg(windows)` body
       # is compiled nowhere else, so a lint that fires only there reaches
       # nobody.
       - name: Clippy
-        run: cargo clippy --workspace --exclude waterui-dylib --exclude waterui-browser-cef --all-targets -- -D warnings
+        run: cargo clippy --locked --workspace --exclude waterui-dylib --exclude waterui-browser-cef --all-targets -- -D warnings


### PR DESCRIPTION
## Summary
- Require the complete dev nightly matrix, including WebView JavaScript and test reporting, before certification.
- Run Cargo verification against committed locks and record the exact framework revision, submodules, lock hashes and scaffold metadata.
- Upload the certification and Cargo.lock to a draft prerelease, publishing only after both assets succeed. Never move an existing nightly or the stable release pointer.
- Refuse promotion of older runs that do not advance the last certified revision. No crates.io or release-plz publishing is invoked.

Fixes #460

#### Test plan
- [x] actionlint on all affected workflows.
- [x] Six temporary local checks for successful snapshots, lock/submodule identity, stale runs, immutable identities, drafts and invalid checkouts.
- [x] Verify the existing stable release and CLI binary workflows are not triggered by these tags.
- [x] git diff --check and Python syntax validation.
- [ ] Run the locked full matrix and verify the first certified snapshot on dev.