### PR TITLE
docs(map,graphics): use doc comments instead of literal doc attributes

### DIFF
--- a/components/data/map/src/lib.rs
+++ b/components/data/map/src/lib.rs
@@ -302,7 +302,7 @@ pub struct MapConfig {
 
 // Use configurable! with StretchAxis::Both - this provides both NativeView and View impls
 configurable!(
-    #[doc = "A map view that displays a geographic region with optional annotations."]
+    /// A map view that displays a geographic region with optional annotations.
     Map,
     MapConfig,
     StretchAxis::Both

--- a/components/visual/graphics/src/lib.rs
+++ b/components/visual/graphics/src/lib.rs
@@ -1,4 +1,4 @@
-#![doc = "Graphics primitives for `WaterUI`."]
+//! Graphics primitives for `WaterUI`.
 // Proving `Send` across `wgpu`'s generic type graph is deeper than rustc's
 // default recursion limit of 128 on the workspace's nightly toolchain, which
 // reports `overflow evaluating the requirement ...: Send` — a hard error under


### PR DESCRIPTION
## Summary
- `components/data/map/src/lib.rs`: the `configurable!` call for `Map` was the only one of the macro's 14 call sites passing documentation as `#[doc = "..."]` — switched to `///` for consistency.
- `components/visual/graphics/src/lib.rs`: the crate root used a literal `#![doc = "..."]`, the only crate in the repo doing so — switched to `//!`.

Both changes are semantically identical (doc comments desugar to `#[doc]` attributes); this only aligns with repo convention. Audited all 42 `#[doc = ...]` occurrences in the repo — the rest are legitimate macro-internal uses (`$doc` metavariables, `concat!`/`stringify!`/`include_str!`).

#### Test plan
- [x] Verified `configurable!` accepts `$(#[$meta:meta])*`, so `///` desugars identically (all 13 other call sites already use `///`)
- [x] `//!` and `#![doc = "..."]` produce identical crate docs
