### PR TITLE
Revert agent workspace skill to per-task, non-slot model

### DIFF
--- a/.claude/skills/waterui-agent-workspace/SKILL.md
+++ b/.claude/skills/waterui-agent-workspace/SKILL.md
@@ -1,28 +1,11 @@
 ---
 name: waterui-agent-workspace
-description: Manage isolated development workspaces for substantial code changes in the WaterUI repository. Use whenever an agent is asked to implement a feature, build a new capability, perform a large bug fix, refactor multiple files, modify backends or submodules, run a parallel agent task, or do any non-trivial WaterUI development that will involve writing code, running repeated builds or tests, rebasing, resolving conflicts, or merging back. For these tasks, do not edit the canonical repository directly. This skill hands out a reusable workspace slot at a fixed path with a warm Cargo target, clones WaterUI submodules safely, explains how to resolve conflicts inside the workspace, and finishes by taking the global integration lock, fast-forwarding changes back, and returning the slot to the pool for the next task.
+description: Manage isolated development workspaces for substantial code changes in /Users/lexoliu/Coding/waterui. Use whenever Codex is asked to implement a feature, build a new capability, perform a large bug fix, refactor multiple files, modify backends or submodules, run a parallel agent task, or do any non-trivial WaterUI development that will involve writing code, running repeated builds or tests, rebasing, resolving conflicts, or merging back. For these tasks, do not edit the canonical repository directly. This skill creates a local git-cloned workspace with a COW-copied Cargo target, clones WaterUI submodules safely, explains how to resolve conflicts inside the workspace, and finishes by taking the global integration lock, fast-forwarding changes back, and deleting the workspace.
 ---
 
 # WaterUI Agent Workspace
 
-Use this skill before making substantial changes to WaterUI. Treat the WaterUI checkout you are working in as the canonical source repository. For substantial work, do not edit it directly; create a private workspace first.
-
-## One Active Workspace Per Session — Hard Limit
-
-A session holds AT MOST ONE active workspace at a time. This is a hard rule,
-not a preference: every slot carries a full clone plus a tens-of-gigabytes
-Cargo `target/`, and the machine does not have the storage or CPU for several
-of them building in parallel — six concurrent slots once filled the disk and
-crashed the host. The slot model is built for SERIAL reuse: do one task, run
-`finish_workspace.sh` to merge and release the slot, then take the SAME slot
-back — warm — for the next task. That reuse is the entire point of the fixed
-slot paths. Fanning tasks out across multiple slots multiplies storage and
-build cost for no throughput gain (parallel workspace builds contend for the
-same cores and caches) and is forbidden. If a queue has many tasks, they wait
-their turn; "gated on the active workspace" is the correct state for every
-task beyond the first. Subagents count: do not spawn several agents that each
-create their own workspace — at most one build-heavy agent, holding the one
-active workspace, at a time.
+Use this skill before making substantial changes to WaterUI. Treat `/Users/lexoliu/Coding/waterui` as the canonical source repository. For substantial work, do not edit it directly; create a private workspace first.
 
 ## Run The Workflow
 
@@ -33,7 +16,7 @@ Do not use it for read-only investigation or tiny localized edits that do not ju
 2. Ensure the canonical repository and every initialized submodule are committed and clean.
 This workflow now uses `git clone`, so uncommitted tracked changes in the canonical repository are a hard stop.
 
-3. From the canonical WaterUI checkout's repository root, run:
+3. From `/Users/lexoliu/Coding/waterui`, run:
 
 ```bash
 .claude/skills/waterui-agent-workspace/scripts/create_workspace.sh <task-slug>
@@ -41,31 +24,7 @@ This workflow now uses `git clone`, so uncommitted tracked changes in the canoni
 
 Use a short lowercase hyphenated slug such as `layout-cache-fix`.
 
-This hands you a **slot** — a workspace at a fixed, reused path
-(`$WATERUI_AGENT_WORKSPACE_ROOT/slot-1`, `slot-2`, ...) rather than a fresh
-timestamped clone. If a FREE slot exists (nothing has it checked out on an
-`agent/` branch), the script fast-forwards it onto canonical and hands it to
-you already warm — no clone, no `target/` copy. Only when every slot is
-taken does it clone a brand new one. This is a performance fix, not a
-behavior change: everything below about branches, submodules, and merging
-back works identically whichever way the slot was obtained. See "The Slot
-Model" below for why this matters and what makes a slot reusable.
-
 4. Change into the printed workspace path and do all subsequent edits, builds, and tests there.
-
-Verification ownership inside the workspace:
-
-- Once you choose this isolated workspace, you own the state of that workspace for the duration of the task.
-- Do not describe a verification blocker as "not introduced by this turn", "pre-existing in this workspace", or similar blame-shifting language. In this workflow, that still means you have not yet brought the workspace to a verifiable state.
-- If a requested test, build, or review is blocked by a compile error, failing dependency edge, broken local file, or other issue inside the current editable WaterUI workspace, fix that blocker first when it is part of the editable codebase and required to complete the user's requested verification.
-- Do not stop at reporting the blocker unless the required next change would violate an explicit repository rule or requires user product direction. Otherwise, continue until the originally requested verification actually runs.
-- When you must report incomplete verification, say plainly that you have not finished because the workspace is not yet back to a verifiable state, then continue repairing it instead of framing the failure as someone else's change.
-
-WaterUI submodule boundary:
-
-- `backends/apple`, `backends/android`, `kit`, and `utils/nami` are first-party WaterUI repositories managed through this workspace flow, not third-party upstream crates.
-- When the task requires changes inside those submodules, make those changes in the agent workspace and commit them on the workspace submodule branch.
-- Do not treat compile failures inside those submodules as "upstream crate" issues that must be deferred by default. They are part of the editable WaterUI codebase.
 
 5. While the workspace is active, keep rebasing it onto the canonical repository when needed.
 Resolve conflicts inside the workspace, never in the canonical repository.
@@ -88,25 +47,7 @@ If the canonical superproject and the workspace both changed the same submodule 
 
 Run it from anywhere inside the agent workspace, not from the canonical repository.
 
-**Run it before you push the topic branch and open the pull request**, in the
-order `AGENTS.md` gives: finish, then push, then open the PR. It fast-forwards
-the local canonical `dev` onto the agent branch, which is only possible while
-canonical is *behind* that branch. Once the pull request has merged, `dev`
-contains the work as a merge commit and is therefore ahead of the branch, so the
-fast-forward can never succeed and the script stops with `superproject cannot be
-fast-forwarded`. Releasing the slot then has to be done by hand: confirm with
-`git log origin/dev..HEAD` that nothing is unmerged, put the superproject and
-every submodule back on their integration branch, and delete the spent agent
-branches in the superproject *and* in each submodule.
-
-**Then rebase the topic branch onto `origin/dev` — GitHub's — before opening the
-pull request, and check that `git log origin/dev..HEAD` lists only your own
-commits.** `create_workspace.sh` branches from the *local canonical* `dev`, and
-that is routinely ahead of GitHub while anyone has a pull request in flight or a
-superseded commit sitting on it. Whatever it carries becomes part of your pull
-request: a diff touching files you never opened, and someone else's failing test
-attributed to your change. Once the topic branch is pushed, leave canonical `dev`
-at `origin/dev` so the next workspace does not inherit the same passengers.
+An agent should only have one active workspace at a time; finish the current workspace before creating another. The total number of workspaces is not limited across agents or tasks, but each workspace is created on demand for one task and deleted on finish.
 
 7. Never use `git worktree` for this repository.
 
@@ -114,108 +55,28 @@ at `origin/dev` so the next workspace does not inherit the same passengers.
 
 Override the default source or workspace paths only through `WATERUI_AGENT_SOURCE_REPO` or `WATERUI_AGENT_WORKSPACE_ROOT` when the machine layout changes.
 
-Whether reused or freshly cloned, a workspace is not only branched at the
-superproject level. The script activates each configured submodule and
-creates the same `agent/<slug>/<timestamp>` branch inside each initialized
-submodule so backend work does not happen on detached HEADs.
+The created workspace is not only branched at the superproject level. The script clones each configured submodule from the local canonical checkout, activates it in the new workspace, and creates the same `agent/<slug>/<timestamp>` branch inside each initialized submodule so backend work does not happen on detached HEADs.
 
-A brand new slot is created with `git clone`, so Git naturally skips ignored
-and untracked build debris such as `.worktrees` and `.water`. After cloning,
-the script uses APFS COW copy for the repository `target/` directory so Rust
-builds stay warm without sharing Cargo locks. A reused slot skips both steps
-entirely — it already has a clone and an already-warm `target/`.
+The workspace is created with `git clone`, so Git naturally skips ignored and untracked build debris such as `.worktrees` and `.water`. After cloning, the script uses APFS COW copy for the repository `target/` directory so Rust builds stay warm without sharing Cargo locks.
 
 The finish step is serialized across all agent workspaces with a lock on the canonical repository. Only one agent may merge back at a time.
-
-## The Slot Model
-
-A workspace lives at a fixed, reused path — a **slot** — instead of a fresh
-timestamped clone every time. This exists to fix a real cost: Cargo folds a
-crate's filesystem path into `-C metadata` for every workspace-member crate
-(it has to, so two same-named crates at different paths never collide in the
-build graph). A brand new path therefore means a brand new metadata hash for
-every WaterUI crate on every task — every workspace crate looks unbuilt and
-recompiles from scratch, incremental caches from the previous task are
-unreachable, and sccache cannot help either, because its cache key includes
-that same metadata. Only registry dependencies, whose path is identical
-everywhere, ever hit warm cache. Reusing the same path keeps `-C metadata`
-identical across tasks, so both Cargo's own incremental cache and sccache
-come back warm — this is the entire reason `create_workspace.sh` now hands
-out slots instead of cloning fresh every time.
-
-A slot's state is entirely self-describing — the same principle
-`ensure_workspace_context` already uses to tell a workspace from the
-canonical checkout — so nothing external tracks which slots are in use:
-
-- **FREE**: the superproject is checked out on the canonical integration
-  branch (never an `agent/` branch) and the whole tree, submodules included,
-  has no local changes. `create_workspace.sh` scans existing slots for the
-  first FREE one, fast-forwards it onto canonical (superproject, then each
-  submodule's own configured integration branch, then hard-aligns each
-  submodule checkout to the exact commit canonical's tree now records for
-  it), and switches it to the new `agent/<slug>/<timestamp>` branch — no
-  clone, no `target/` copy.
-- **BUSY**: some workspace has it checked out on an `agent/` branch, possibly
-  with uncommitted work. This is the routine state for a slot mid-task;
-  `create_workspace.sh` skips it silently and looks at the next one.
-- **CORRUPT**: looks FREE (right branch, clean) but its history has diverged
-  from canonical instead of being a pure ancestor of it, so it cannot be
-  fast-forwarded. This should not happen from ordinary use of these scripts —
-  a FREE slot is untouched by anything else — so it is treated as an anomaly:
-  `create_workspace.sh` warns, names the slot, and tries the next one rather
-  than failing the whole run. **Recovery is manual**: delete the corrupt
-  slot's directory (`rm -rf $WATERUI_AGENT_WORKSPACE_ROOT/slot-N`). The next
-  `create_workspace.sh` either reclaims that now-missing slot number for a
-  fresh clone or uses a different slot — nothing needs to track the gap.
-
-`finish_workspace.sh` is what makes a slot FREE again: after the merge lands
-on canonical, it switches the slot's superproject and every submodule back
-onto their configured integration branches, fast-forwards each from
-canonical, and deletes the spent `agent/` branch — leaving the slot clean,
-on the integration branch, and still warm. This replaces the old behaviour
-of deleting the workspace outright; deletion only still happens for a
-**legacy timestamped workspace** (a `<timestamp>-<slug>` path from before the
-slot model), recognised by its basename not matching `slot-<N>`. Both kinds
-of workspace can exist side by side under the same `$WATERUI_AGENT_WORKSPACE_ROOT` — `finish_workspace.sh` picks the right ending for whichever one it is handed.
 
 ## What The Script Enforces
 
 The create script fails immediately if any of the following are true:
 
 - It is not run from the canonical source repository.
+- The canonical repository or any canonical submodule has uncommitted tracked changes, staged changes, or untracked non-ignored files.
 - Cargo resolves any `build.target-dir`.
-- A brand new slot is needed and the source or workspace filesystem is not APFS.
-
-Uncommitted changes in the canonical checkout do not stop it, and are reported
-rather than obeyed: a workspace is built from committed state, so whatever is
-in someone's working tree has no bearing on what lands in it. Requiring a clean
-tree here protected nothing while letting one agent's half-finished edit stop
-every other agent from starting.
-
-The APFS requirement, and the volume check below, apply only when a brand new
-slot actually needs to be cloned and its `target/` copied — a reused slot
-copies nothing, so it never pays either check, even on a workspace root that
-would otherwise fail them.
-
-A workspace root on a different volume than the source repository is allowed
-(the usual answer when the boot disk is out of space) but only warns: APFS
-clonefile cannot span volumes, so the `target/` copy degrades from
-copy-on-write to a full byte copy — creation is slower and the copy occupies
-real disk space instead of sharing blocks. The difference is large enough to
-change behaviour: seconds against tens of minutes. A root on a removable volume
-costs more than time, because a workspace is unusable while that volume is
-detached and `finish_workspace.sh` can wedge on it — see below. This cost is
-paid once per slot; every later reuse of that same slot pays nothing.
+- The workspace root is not on the same filesystem as the source repository.
+- The source or workspace filesystem is not APFS.
 - Any configured submodule is missing, is not a Git worktree, or does not keep its gitdir under the source repository metadata.
-- A brand new slot's destination path already exists (should not happen — slot numbers are only ever handed out once).
+- The destination path already exists.
 - The task slug is not lowercase hyphenated text.
 
 The finish script fails immediately if any of the following are true:
 
-- It is not run from inside an agent workspace. A workspace is recognised by
-  what the checkout is — a clone whose `origin` is a local path to another
-  checkout, sitting on an `agent/` branch — never by where it sits, so
-  moving `WATERUI_AGENT_WORKSPACE_ROOT` does not strand existing workspaces.
+- It is not run from an agent workspace under `WATERUI_AGENT_WORKSPACE_ROOT`.
 - Another agent is already merging back into the canonical repository.
 - The workspace superproject or any workspace submodule has uncommitted changes.
 - The canonical repository superproject or any canonical submodule has uncommitted changes.
@@ -228,114 +89,13 @@ For WaterUI's backend submodules, "configured integration branch" means `dev`. I
 
 The sync script fails immediately if any of the following are true:
 
-- It is not run from inside an agent workspace (same recognition rule as the
-  finish script: local-path `origin` plus an `agent/` branch).
+- It is not run from an agent workspace under `WATERUI_AGENT_WORKSPACE_ROOT`.
 - Another agent is currently running `finish_workspace.sh` against the canonical repository.
 - The workspace superproject or any workspace submodule has uncommitted changes.
 - The canonical repository superproject or any canonical submodule has uncommitted changes.
 - The workspace branch does not start with `agent/`.
 - Any workspace submodule is on a different branch from the workspace superproject.
 - A submodule rebase or superproject rebase stops for conflicts.
-
-## When Merging Back Is Blocked
-
-Finish and sync do require a clean canonical checkout, because they write to it.
-That state is routine here and it is almost never yours: several sessions share
-the one checkout, and its uncommitted files usually belong to an agent still
-working in it.
-
-Treat another session's working tree as untouchable. Do not stash it, revert it,
-commit it, or move it aside "just for a moment" — the file you take away is
-live, not stale. Stashing to unblock a merge cost a commit: the owning session
-ran `git add` during the seconds its file was stashed, and the commit it
-produced described a fix while containing only half of it. Restoring the stash
-then resurrected a diagnostic edit that session had already tried and discarded,
-which it caught only by reading the diff line by line.
-
-Say something instead. The sessions are addressable, and asking is cheaper than
-waiting blindly:
-
-1. `mcp__ccd_session_mgmt__list_sessions` — the owner is normally the running
-   session whose title matches the dirty paths, near the top of the list.
-2. `mcp__ccd_session_mgmt__send_message` — name the exact paths blocking you and
-   ask that session to commit or stash them itself. It knows whether its own
-   work is in a committable state; you do not.
-3. Wait on the condition rather than polling by hand — a background `until`
-   loop over `git status --porcelain` wakes you once, when it clears.
-
-If nothing owns the changes — a session that has since exited — ask the user
-rather than deciding for them.
-
-## When Finish Does Not Return
-
-`finish_workspace.sh` holds a global integration lock under
-`~/.waterui-agent/locks/` from before the merge until it exits, so while it runs
-no other agent can merge. It releases the lock from an `EXIT INT TERM` trap.
-
-Never conclude it succeeded because its effects appeared. Returning the slot
-to FREE (or, for a legacy workspace, `delete_workspace`) is the last thing it
-does, so the commits land on canonical well before the script is done. One run
-whose legacy workspace sat on a USB volume that dropped off the bus left its
-`rm -rf` in uninterruptible disk wait for eighty minutes; the merge had
-landed, canonical was clean, and every other agent's finish failed with "another
-agent is already integrating" the whole time. A slot's tail step is ordinary
-git plumbing rather than a directory-tree delete, so it is far less likely to
-wedge the same way — but the lock is still the only thing that answers "is it
-really done," not whether the merge's effects are already visible on canonical.
-
-The lock records its holder, so this is a question you can answer rather than
-infer — from either side. The lock directory contains `pid`, `source-repo` and
-`workspace-root`:
-
-    ls ~/.waterui-agent/locks/    # empty means nobody holds it
-    ps -p "$(cat ~/.waterui-agent/locks/*.lock/pid)" -o pid,command
-
-Ask for the command, not just whether the pid exists. A run killed with `kill
--9`, or lost to a power cut, never reaches its trap and leaves the lock behind,
-and by then the kernel may have handed that pid number to something unrelated —
-so a bare `ps -p` reports "alive" for a lock whose owner is long dead, and
-nobody dares clear it. The answer is only trustworthy if the command column
-says `finish_workspace.sh`.
-
-Run it after your own finish to confirm the script really exited, and run it
-when yours is refused to see whether the holder is a live merge or a wedged one.
-It is how the eighty-minute stall above was diagnosed — by the blocked session,
-not by the one holding the lock.
-
-A lock held by a wedged run cannot be cleared with `kill -TERM`: zsh defers the
-trap until the foreground command returns, and a process in uninterruptible wait
-never returns. Force-unmounting the volume lets the `rm` fail, after which the
-script finishes and cleans up after itself. `kill -9` skips the trap, so the
-lock directory must then be removed by hand.
-
-## Moving The Workspace Root
-
-`WATERUI_AGENT_WORKSPACE_ROOT` may change between sessions — typically to an
-external volume when the boot disk fills up. What to know when it does:
-
-- Existing workspaces — slots and legacy alike — stay where they were created
-  and remain fully usable: sync and finish recognise a workspace by its own
-  evidence (local-path `origin`, `agent/` branch), not by its location, so no
-  environment override is needed for them.
-- `create_workspace.sh` only scans for FREE slots under the *current*
-  `$WATERUI_AGENT_WORKSPACE_ROOT`. Slots left behind under an old root are not
-  found or reused after the root moves — they just sit there, warm and idle.
-  They are still perfectly usable directly (`cd` in and run the canonical
-  checkout's scripts by absolute path, as below) or can be deleted to reclaim
-  the disk space.
-- Exception: a workspace **cloned before that recognition rule landed**
-  carries a pre-fix script copy that still path-matches against the current
-  root, and running its own `sync_workspace.sh`/`finish_workspace.sh` dies
-  with "run this script from an agent workspace, not the canonical
-  repository". The scripts decide context from the working directory, not
-  from their own path — so run the **canonical checkout's** script by
-  absolute path while `cd`'d inside the workspace, and it works without any
-  override. (Prefixing `WATERUI_AGENT_WORKSPACE_ROOT=<old root>` onto the
-  stale copy also works, but fixes nothing going forward.)
-- A root on another volume must still be APFS, and every brand new slot
-  cloned there pays a full `target/` copy instead of a COW clone (see above)
-  — a one-time cost per slot, not per task. If the boot disk has room again,
-  prefer a root on the source repository's own volume.
 
 ## After Creation
 
@@ -344,12 +104,11 @@ external volume when the boot disk fills up. What to know when it does:
 - Rebase and resolve conflicts only inside the workspace.
 - When the canonical repository advances, run `sync_workspace.sh` from the workspace before trying to finish.
 - Do not merge back until the workspace and every changed submodule are fully committed and clean.
-- Run `finish_workspace.sh` to fast-forward submodules first, then fast-forward the superproject, then release the slot back to the pool (or delete the workspace directory, for a legacy non-slot workspace).
+- Run `finish_workspace.sh` to fast-forward submodules first, then fast-forward the superproject, then delete the workspace directory.
 - If finish fails because the canonical repository moved ahead, stop and rebase or respawn the workspace. Do not force a merge inside the canonical repository.
 
 ## Resource
 
-- `scripts/create_workspace.sh`: Scan existing slots for a FREE one and, if found, fast-forward and reuse it; otherwise clone a brand new slot with local `git clone`, clone each submodule from the canonical checkout, and copy `target/` with APFS COW. Either way, switch the superproject plus each initialized submodule onto matching `agent/<slug>/<timestamp>` branches.
+- `scripts/create_workspace.sh`: Create the isolated workspace with local `git clone`, clone each submodule from the canonical checkout, copy `target/` with APFS COW, and switch the superproject plus each initialized submodule onto matching `agent/<slug>/<timestamp>` branches.
 - `scripts/sync_workspace.sh`: Rebase workspace submodules onto their configured integration branches, commit any rebased submodule pointer updates inside the workspace, then rebase the workspace superproject onto the canonical branch.
-- `scripts/finish_workspace.sh`: Acquire the canonical integration lock, fast-forward each configured submodule, fast-forward the superproject, then return the slot to FREE (switch superproject and submodules back to their integration branches, fast-forward them, delete the spent agent branches) — or delete the workspace outright for a legacy non-slot workspace.
-- `references/waterui-runtime-semantics.md`: WaterUI-specific guidance for fine-grained rebuild semantics, `GpuSurface` renderer ownership, and the rule that visual tests require direct image reading rather than heuristics.
+- `scripts/finish_workspace.sh`: Acquire the canonical integration lock, fast-forward each configured submodule, fast-forward the superproject, and delete the workspace on success.

--- a/.claude/skills/waterui-agent-workspace/scripts/common.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/common.sh
@@ -1,73 +1,21 @@
 #!/bin/zsh
 
-# Per-machine locations. Each is overridable through the matching WATERUI_AGENT_*
-# environment variable when a machine's layout differs; the defaults are derived
-# so nothing user- or agent-specific is frozen into the repository.
-typeset -gr WORKSPACE_ROOT="${WATERUI_AGENT_WORKSPACE_ROOT:-${HOME}/.waterui-agent/workspaces}"
-typeset -gr LOCK_ROOT="${WATERUI_AGENT_LOCK_ROOT:-${HOME}/.waterui-agent/locks}"
+typeset -gr SOURCE_REPO="${WATERUI_AGENT_SOURCE_REPO:-/Users/lexoliu/Coding/waterui}"
+typeset -gr WORKSPACE_ROOT="${WATERUI_AGENT_WORKSPACE_ROOT:-/Users/lexoliu/.waterui-agent/workspaces}"
 typeset -gr BRANCH_PREFIX="${WATERUI_AGENT_BRANCH_PREFIX:-agent}"
-
-# The canonical source repository, derived from git context rather than hardcoded:
-# - run from the canonical checkout (e.g. create_workspace.sh), it is this
-#   repository's top level;
-# - run from inside an agent workspace clone (sync/finish), the canonical source
-#   is that clone's `origin`, which create_workspace.sh points back here.
-# Outside any git repository it resolves empty, leaving the per-script context
-# checks to report the problem clearly.
-#
-# Which of the two we are in is decided by what the checkout *is*, not by where
-# it sits. A workspace was cloned from a checkout on this machine, so its origin
-# is a local path to another working tree; the canonical checkout's origin is
-# the remote it is published to. Asking WORKSPACE_ROOT instead — as this did —
-# means the answer changes when WATERUI_AGENT_WORKSPACE_ROOT changes, and every
-# workspace created under the old value is then read as the canonical
-# repository, so sync and finish refuse to run and the work inside them is
-# stranded with no way to merge it back.
-_waterui_resolve_source_repo() {
-  local top origin
-  if ! top="$(git rev-parse --show-toplevel 2>/dev/null)"; then
-    return 0
-  fi
-  origin="$(git -C "$top" remote get-url origin 2>/dev/null)" || origin=""
-  if [[ -n "$origin" && -d "$origin" ]] &&
-    git -C "$origin" rev-parse --show-toplevel >/dev/null 2>&1; then
-    print -- "$origin"
-  else
-    print -- "$top"
-  fi
-}
-typeset -gr SOURCE_REPO="${WATERUI_AGENT_SOURCE_REPO:-$(_waterui_resolve_source_repo)}"
-
-warn() {
-  print -u2 -- "warning: $*"
-}
+typeset -gr LOCK_ROOT="${WATERUI_AGENT_LOCK_ROOT:-/Users/lexoliu/.waterui-agent/locks/waterui-agent-workspace}"
 
 die() {
   print -u2 -- "error: $*"
   exit 1
 }
 
-# Runs a command, saying nothing unless it fails — and saying everything if it
-# does.
-#
-# Discarding both streams outright is what these calls used to do, and it makes
-# a failure undiagnosable: `git clone` reporting "Input/output error" from a
-# dying disk surfaced only as "failed to clone canonical repository", which sent
-# the reader looking for a git problem that was not there. Letting stderr
-# through instead is no good either, because git narrates success on stderr too
-# ("Switched to a new branch ..."). So: hold the output, drop it when the
-# command succeeds, print it when it does not.
-run_quietly() {
-  local output
-
-  if ! output="$("$@" 2>&1)"; then
-    [[ -z "$output" ]] || print -u2 -- "$output"
-    return 1
-  fi
-}
-
 require_command() {
   command -v "$1" >/dev/null 2>&1 || die "missing required command: $1"
+}
+
+ensure_nightly_cargo() {
+  cargo -V | rg -q 'nightly' || die "nightly cargo is required to inspect Cargo configuration"
 }
 
 canonical_dir() {
@@ -97,29 +45,12 @@ ensure_apfs() {
   print -- "$info" | rg -q '^ *Type \(Bundle\): +apfs$' || die "filesystem for $target is not APFS"
 }
 
-# `git clone --local` hardlinks the source object store into the clone, which
-# cannot span volumes. A cross-volume workspace root copies the objects instead;
-# same-volume roots keep the cheap hardlinks. `reference` must be a path that
-# already exists on the destination volume.
-local_clone_options() {
-  local source="$1"
-  local reference="$2"
-
-  if [[ "$(device_id "$source")" == "$(device_id "$reference")" ]]; then
-    print -- "--local"
-  else
-    print -- "--local --no-hardlinks"
-  fi
-}
-
 clone_superproject_locally() {
   local source_root="$1"
   local destination="$2"
   local source_branch="$3"
-  local clone_options
 
-  clone_options="$(local_clone_options "$source_root" "${destination:h}")"
-  run_quietly git clone ${=clone_options} --branch "$source_branch" --single-branch "$source_root" "$destination" || die "failed to clone canonical repository into $destination"
+  git clone --local --branch "$source_branch" --single-branch "$source_root" "$destination" >/dev/null 2>&1 || die "failed to clone canonical repository into $destination"
 }
 
 submodule_gitlink_commit() {
@@ -140,84 +71,26 @@ clone_submodules_locally() {
   local source_submodule
   local destination_submodule
   local desired_commit
-  local clone_options
 
-  clone_options="$(local_clone_options "$source_root" "$destination_root")"
   while IFS=$'\t' read -r name submodule_relpath; do
     [[ -n "${name:-}" ]] || continue
     source_submodule="${source_root}/${submodule_relpath}"
     destination_submodule="${destination_root}/${submodule_relpath}"
     desired_commit="$(submodule_gitlink_commit "$destination_root" "$submodule_relpath")"
 
-    run_quietly git -C "$destination_root" submodule init -- "$submodule_relpath" || die "failed to initialize submodule config for ${submodule_relpath}"
-    run_quietly git clone ${=clone_options} --no-checkout "$source_submodule" "$destination_submodule" || die "failed to clone submodule ${submodule_relpath}"
-    run_quietly git -C "$destination_submodule" checkout "$desired_commit" || die "failed to checkout ${desired_commit} in submodule ${submodule_relpath}"
-    run_quietly git -C "$destination_root" submodule absorbgitdirs -- "$submodule_relpath" || die "failed to absorb gitdir for submodule ${submodule_relpath}"
+    git -C "$destination_root" submodule init -- "$submodule_relpath" >/dev/null 2>&1 || die "failed to initialize submodule config for ${submodule_relpath}"
+    git clone --local --no-checkout "$source_submodule" "$destination_submodule" >/dev/null 2>&1 || die "failed to clone submodule ${submodule_relpath}"
+    git -C "$destination_submodule" checkout "$desired_commit" >/dev/null 2>&1 || die "failed to checkout ${desired_commit} in submodule ${submodule_relpath}"
+    git -C "$destination_root" submodule absorbgitdirs -- "$submodule_relpath" >/dev/null 2>&1 || die "failed to absorb gitdir for submodule ${submodule_relpath}"
   done < <(submodule_records "$source_root")
-}
-
-# The canonical `target/` is a live cache, and an unrelated build (Xcode, Gradle,
-# `water run`) may be writing into it while a workspace is created. rustc's
-# per-CGU object files exist only for the duration of one invocation, so a copy
-# can enumerate an entry that is gone by the time it is read. That lost race is
-# harmless — the entry is a build temporary and cargo rebuilds whatever is
-# missing — so it is retried, and the retry no longer enumerates the vanished
-# entry. Any other failure, a full destination volume above all, is fatal at
-# once rather than retried. Each attempt copies directory *contents* so a retry
-# lands on the same path instead of nesting inside the partial copy.
-copy_target_entry() {
-  local source="$1"
-  local destination="$2"
-  local attempt
-  local errors
-  local line
-
-  for attempt in 1 2 3; do
-    if [[ -d "$source" && ! -L "$source" ]]; then
-      mkdir -p "$destination"
-      errors="$(LC_ALL=C cp -cR "$source/." "$destination" 2>&1 >/dev/null)" && return 0
-    else
-      errors="$(LC_ALL=C cp -cR "$source" "$destination" 2>&1 >/dev/null)" && return 0
-    fi
-
-    [[ -n "$errors" ]] || die "failed to copy ${source} into ${destination}"
-    for line in ${(f)errors}; do
-      [[ "$line" == *': No such file or directory' ]] ||
-        die "failed to copy ${source} into ${destination}: ${line}"
-    done
-  done
-
-  warn "left ${source:t} out of the warm target cache: it kept vanishing under the copy, so another build is writing to ${source:h}"
 }
 
 copy_target_cow() {
   local source_root="$1"
   local destination_root="$2"
-  local source_target="${source_root}/target"
-  local destination_target="${destination_root}/target"
-  local top
-  local child
 
-  [[ -d "$source_target" ]] || return 0
-  mkdir -p "$destination_target"
-  # Copy entry-by-entry instead of one `cp -cR target` so the per-profile
-  # `incremental/` caches can be skipped: they are the largest and
-  # fastest-diverging piece of `target/` (tens of GB), every workspace build
-  # rewrites them immediately (turning shared COW blocks into real copies),
-  # and sccache already covers the cold recompiles they would have saved.
-  # With N concurrent workspaces this is the difference between sharing one
-  # dependency cache and carrying N diverging full copies.
-  for top in "$source_target"/*(DN); do
-    if [[ -d "$top" && ! -L "$top" ]]; then
-      mkdir -p "${destination_target}/${top:t}"
-      for child in "$top"/*(DN); do
-        [[ "${child:t}" == "incremental" ]] && continue
-        copy_target_entry "$child" "${destination_target}/${top:t}/${child:t}"
-      done
-    else
-      copy_target_entry "$top" "${destination_target}/${top:t}"
-    fi
-  done
+  [[ -d "${source_root}/target" ]] || return 0
+  cp -cR "${source_root}/target" "${destination_root}/target" || die "failed to copy target directory into ${destination_root}"
 }
 
 submodule_records() {
@@ -262,15 +135,6 @@ ensure_repo_and_submodules_clean() {
   done < <(submodule_records "$SOURCE_REPO")
 }
 
-# The same question as a yes-or-no, for callers that want to mention the state
-# rather than refuse to run.
-#
-# Asking it through the checking form keeps one definition of "clean": `die`
-# ends the subshell rather than this script, so the exit status answers.
-repo_and_submodules_are_clean() {
-  (ensure_repo_and_submodules_clean "$1" "canonical repository") >/dev/null 2>&1
-}
-
 activate_all_submodules() {
   local repo_root="$1"
   git -C "$repo_root" config submodule.active . || die "failed to activate submodules in workspace"
@@ -281,9 +145,9 @@ ensure_branch() {
   local branch_name="$2"
 
   if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch_name"; then
-    run_quietly git -C "$repo_root" switch "$branch_name" || die "failed to switch to existing branch $branch_name in $repo_root"
+    git -C "$repo_root" switch "$branch_name" >/dev/null 2>&1 || die "failed to switch to existing branch $branch_name in $repo_root"
   else
-    run_quietly git -C "$repo_root" switch -c "$branch_name" || die "failed to create branch $branch_name in $repo_root"
+    git -C "$repo_root" switch -c "$branch_name" >/dev/null 2>&1 || die "failed to create branch $branch_name in $repo_root"
   fi
 }
 
@@ -302,39 +166,12 @@ branch_submodules() {
   done < <(submodule_records "$repo_root")
 }
 
-# Refuse to run while every slot would share one target directory.
-#
-# Read the setting the way cargo resolves it, rather than through
-# `cargo -Z unstable-options config get`: that subcommand is nightly-only, and
-# requiring nightly to be the *active* toolchain broke both scripts once the
-# repository standardised on stable. Nothing else here needs a nightly cargo.
-#
-# `CARGO_TARGET_DIR` wins over the config files, and among those cargo merges
-# `$CARGO_HOME/config.toml` with every `.cargo/config.toml` from the working
-# directory upward, nearest first.
 ensure_no_shared_target_dir() {
-  local search config
+  local configured_target
 
-  if [[ -n "${CARGO_TARGET_DIR:-}" ]]; then
-    die "CARGO_TARGET_DIR is set ($CARGO_TARGET_DIR); unset it before creating agent workspaces"
+  if configured_target="$(cargo -Z unstable-options config get build.target-dir 2>/dev/null)"; then
+    die "cargo build.target-dir is configured (${configured_target//$'\n'/ }); remove it before creating agent workspaces"
   fi
-
-  search="$PWD"
-  while true; do
-    for config in "$search/.cargo/config.toml" "$search/.cargo/config"; do
-      if [[ -f "$config" ]] && rg -q '^\s*target-dir\s*=' "$config"; then
-        die "cargo target-dir is configured in $config; remove it before creating agent workspaces"
-      fi
-    done
-    [[ "$search" == "/" ]] && break
-    search="$(dirname "$search")"
-  done
-
-  for config in "${CARGO_HOME:-$HOME/.cargo}/config.toml" "${CARGO_HOME:-$HOME/.cargo}/config"; do
-    if [[ -f "$config" ]] && rg -q '^\s*target-dir\s*=' "$config"; then
-      die "cargo target-dir is configured in $config; remove it before creating agent workspaces"
-    fi
-  done
 }
 
 validate_slug() {
@@ -370,12 +207,12 @@ ensure_branch_available() {
   local branch_name="$2"
 
   if git -C "$repo_root" show-ref --verify --quiet "refs/heads/$branch_name"; then
-    run_quietly git -C "$repo_root" switch "$branch_name" || die "failed to switch to ${branch_name} in $repo_root"
+    git -C "$repo_root" switch "$branch_name" >/dev/null 2>&1 || die "failed to switch to ${branch_name} in $repo_root"
     return
   fi
 
   if git -C "$repo_root" show-ref --verify --quiet "refs/remotes/origin/$branch_name"; then
-    run_quietly git -C "$repo_root" switch -c "$branch_name" --track "origin/$branch_name" || die "failed to create local branch ${branch_name} in $repo_root"
+    git -C "$repo_root" switch -c "$branch_name" --track "origin/$branch_name" >/dev/null 2>&1 || die "failed to create local branch ${branch_name} in $repo_root"
     return
   fi
 
@@ -410,44 +247,8 @@ merge_branch_ff_only() {
   local label="$4"
 
   git -C "$source_repo" show-ref --verify --quiet "refs/heads/$source_branch" || die "${label} source branch ${source_branch} does not exist in $source_repo"
-  run_quietly git -C "$destination_repo" fetch "$source_repo" "$source_branch" || die "failed to fetch ${label} branch ${source_branch} from $source_repo"
-  run_quietly git -C "$destination_repo" merge --ff-only FETCH_HEAD || die "failed to fast-forward merge ${label} from ${source_repo}; update or rebase the workspace first"
-}
-
-# Canonical's own submodule branches must sit on the same lineage as the commits
-# the canonical superproject pins. They drift apart in one routine way: a
-# finished workspace fast-forwards a canonical submodule branch to the commit
-# its pull request carried, and that pull request is then rebuilt on a moved
-# integration branch because another one bumped the same submodule first. The
-# abandoned lineage is left on the branch, `git submodule update` does not
-# notice (it detaches at the pin without touching the branch), and every
-# workspace afterwards fails its `--ff-only` merge with an error that reads as
-# though the workspace were at fault. Check canonical before touching a slot,
-# and name the repair.
-ensure_canonical_submodule_lineage() {
-  local source_root="$1"
-  local name
-  local submodule_relpath
-  local canonical_submodule
-  local target_branch
-  local pinned_commit
-  local branch_commit
-
-  while IFS=$'\t' read -r name submodule_relpath; do
-    [[ -n "${name:-}" ]] || continue
-    canonical_submodule="${source_root}/${submodule_relpath}"
-    target_branch="$(configured_submodule_branch "$source_root" "$name")"
-    [[ -n "$target_branch" ]] || die "submodule ${submodule_relpath} has no configured integration branch in .gitmodules"
-
-    git -C "$canonical_submodule" show-ref --verify --quiet "refs/heads/${target_branch}" || die "canonical submodule ${submodule_relpath} has no ${target_branch} branch"
-    branch_commit="$(git -C "$canonical_submodule" rev-parse "refs/heads/${target_branch}")" || die "failed to resolve ${target_branch} in $canonical_submodule"
-    pinned_commit="$(submodule_gitlink_commit "$source_root" "$submodule_relpath")"
-
-    git -C "$canonical_submodule" merge-base --is-ancestor "$pinned_commit" "$branch_commit" >/dev/null 2>&1 && continue
-    git -C "$canonical_submodule" merge-base --is-ancestor "$branch_commit" "$pinned_commit" >/dev/null 2>&1 && continue
-
-    die "canonical submodule ${submodule_relpath} has drifted: its ${target_branch} is at ${branch_commit} while the superproject pins ${pinned_commit}, and neither contains the other. The workspace is fine; canonical is wrong. Repair with: git -C ${canonical_submodule} branch -f ${target_branch} ${pinned_commit}"
-  done < <(submodule_records "$source_root")
+  git -C "$destination_repo" fetch "$source_repo" "$source_branch" >/dev/null 2>&1 || die "failed to fetch ${label} branch ${source_branch} from $source_repo"
+  git -C "$destination_repo" merge --ff-only FETCH_HEAD >/dev/null 2>&1 || die "failed to fast-forward merge ${label} from ${source_repo}; update or rebase the workspace first"
 }
 
 ensure_fast_forward_possible() {
@@ -476,228 +277,18 @@ workspace_contains_source_layout() {
   done < <(submodule_records "$SOURCE_REPO")
 }
 
-# --- Slot model ---------------------------------------------------------
-#
-# Workspaces used to live at a fresh timestamped path every time, which meant
-# every `create_workspace.sh` handed Cargo a directory it had never seen
-# before. Cargo folds the package path into `-C metadata` for every
-# workspace-member crate (it has to: two crates with the same name at
-# different paths must not collide in the build graph), so a new path means a
-# new metadata hash for every WaterUI crate, which means every workspace
-# crate looks unbuilt and recompiles from scratch — incremental caches from
-# the last task are unreachable, and even sccache cannot help, because its
-# cache key includes that same metadata. Only registry dependencies, whose
-# path is the same everywhere, ever hit warm cache.
-#
-# The fix is to stop generating fresh paths. A slot is a workspace at a fixed
-# path — `$WORKSPACE_ROOT/slot-1`, `slot-2`, ... — that persists across tasks
-# instead of being deleted when one finishes. Reusing a slot means the path,
-# and therefore `-C metadata`, and therefore every crate's build cache key,
-# is identical to the last time that slot was used: Cargo's own incremental
-# cache (never discarded now — `copy_target_cow` still skips `incremental/`,
-# but only when *seeding* a brand new slot) and sccache both come back warm.
-#
-# A slot's state is entirely self-describing, the same philosophy
-# `ensure_workspace_context` already uses to tell a workspace from the
-# canonical checkout: nothing external tracks which slots are in use.
-#   - FREE: the superproject is checked out on the canonical integration
-#     branch (never an `agent/` branch) and the whole tree, submodules
-#     included, has no local changes. `slot_is_free` below is the read-only
-#     check for this and never fetches or mutates anything.
-#   - BUSY: some agent workspace flow switched it to `agent/<slug>/<ts>` and
-#     may have uncommitted work in progress. The same branch-prefix evidence
-#     `ensure_workspace_context` reads is what makes a slot BUSY — claiming a
-#     slot and claiming "this checkout is an agent workspace" are the same
-#     act.
-#   - CORRUPT: looks like a FREE candidate (right branch, clean) but its
-#     history diverged from canonical instead of being a pure ancestor of it,
-#     so it cannot be fast-forwarded. This should not happen from ordinary
-#     use of these scripts — a FREE slot is untouched by anything else — so
-#     it is treated as an anomaly: warn, skip it, try the next slot. Recovery
-#     is manual: delete the slot directory. The next `create_workspace.sh`
-#     either reuses that now-missing number for a fresh clone or leaves it
-#     alone and uses a different slot; either way nothing needs to track the
-#     gap.
-
-# A slot directory basename, as opposed to a legacy timestamped workspace
-# path (`<timestamp>-<slug>`) from before this model existed. `finish_workspace.sh`
-# keys its post-merge behaviour off this: a slot is returned to FREE, a
-# legacy workspace is still deleted.
-is_slot_workspace() {
-  local workspace_root="$1"
-  [[ "${workspace_root:t}" == slot-<1-> ]]
-}
-
-# Every slot directory under `workspace_root`, sorted by slot number. A slot
-# recovered from CORRUPT state is removed by deleting its directory (see
-# SKILL.md), which leaves a gap in the numbering rather than a contiguous
-# run — so slots are found by listing what is actually on disk, never by
-# counting upward until the first miss.
-existing_slot_paths() {
-  local workspace_root="$1"
-  local path
-
-  setopt local_options numericglobsort
-  for path in "${workspace_root}"/slot-<1->(N/); do
-    print -- "$path"
-  done
-}
-
-# The lowest unused slot number under `workspace_root`, so a deleted
-# (recovered) slot's number is reused before the pool grows.
-new_slot_path() {
-  local workspace_root="$1"
-  local n=1
-
-  while [[ -e "${workspace_root}/slot-${n}" ]]; do
-    n=$((n + 1))
-  done
-  print -- "${workspace_root}/slot-${n}"
-}
-
-# Read-only FREE check — see the slot model comment above. Never fetches or
-# mutates, so it is cheap to run over every slot on every
-# `create_workspace.sh` call.
-slot_is_free() {
-  local slot="$1"
-  local integration_branch="$2"
-  local branch
-
-  (workspace_contains_source_layout "$slot") >/dev/null 2>&1 || return 1
-  branch="$(git -C "$slot" rev-parse --abbrev-ref HEAD 2>/dev/null)" || return 1
-  [[ "$branch" == "$integration_branch" ]] || return 1
-  repo_and_submodules_are_clean "$slot"
-}
-
-# Brings a FREE slot up to date with canonical and claims it for `branch_name`.
-#
-# Two passes. The first only inspects: the superproject and every submodule
-# must sit on their configured integration branch and be fast-forwardable
-# onto canonical. Nothing is touched until all of them pass, so a slot that
-# cannot be claimed is left exactly as it was found and stays FREE for the
-# next scan (a claim that mutated as it went used to strand slots with some
-# submodules already moved and the rest still on their old branch). The
-# second pass fast-forwards the superproject and then each submodule's
-# integration branch, staying on the branch the whole time — every canonical
-# commit that advances a submodule pointer is paired with the submodule's own
-# advance, so the branch tip must now equal the gitlink the superproject
-# records; anything else is a canonical inconsistency and fails loudly rather
-# than being papered over with a detached checkout. Finally the superproject
-# and every submodule are branched to `branch_name`.
-#
-# Runs entirely inside a captured subshell: any step's failure (typically a
-# fast-forward refused because the slot diverged from canonical) reaches the
-# caller as a plain exit status rather than tearing down the whole script, so
-# a CORRUPT slot can be skipped in favour of the next one instead of killing
-# `create_workspace.sh` outright.
-_claim_free_slot_impl() {
-  local slot="$1"
-  local source_root="$2"
-  local integration_branch="$3"
-  local branch_name="$4"
-  local name
-  local submodule_relpath
-  local submodule_path
-  local canonical_submodule
-  local target_branch
-  local actual_branch
-  local desired_commit
-  local actual_commit
-
-  ensure_fast_forward_possible "$slot" "$source_root" "$integration_branch" "superproject"
-
-  while IFS=$'\t' read -r name submodule_relpath; do
-    [[ -n "${name:-}" ]] || continue
-    submodule_path="${slot}/${submodule_relpath}"
-    canonical_submodule="${source_root}/${submodule_relpath}"
-    target_branch="$(configured_submodule_branch "$source_root" "$name")"
-    [[ -n "$target_branch" ]] || die "submodule ${submodule_relpath} has no configured integration branch in .gitmodules"
-
-    actual_branch="$(current_branch "$submodule_path")" || die "slot submodule ${submodule_relpath} is not on a branch"
-    [[ "$actual_branch" == "$target_branch" ]] || die "slot submodule ${submodule_relpath} is on ${actual_branch}, expected ${target_branch}"
-
-    ensure_fast_forward_possible "$submodule_path" "$canonical_submodule" "$target_branch" "submodule ${submodule_relpath}"
-  done < <(submodule_records "$source_root")
-
-  merge_branch_ff_only "$slot" "$source_root" "$integration_branch" "superproject"
-
-  while IFS=$'\t' read -r name submodule_relpath; do
-    [[ -n "${name:-}" ]] || continue
-    submodule_path="${slot}/${submodule_relpath}"
-    canonical_submodule="${source_root}/${submodule_relpath}"
-    target_branch="$(configured_submodule_branch "$source_root" "$name")"
-
-    merge_branch_ff_only "$submodule_path" "$canonical_submodule" "$target_branch" "submodule ${submodule_relpath}"
-
-    desired_commit="$(submodule_gitlink_commit "$slot" "$submodule_relpath")"
-    actual_commit="$(git -C "$submodule_path" rev-parse HEAD)" || die "failed to resolve HEAD of submodule ${submodule_relpath}"
-    [[ "$actual_commit" == "$desired_commit" ]] || die "submodule ${submodule_relpath} branch ${target_branch} is at ${actual_commit} but the superproject records ${desired_commit}; canonical is inconsistent"
-  done < <(submodule_records "$source_root")
-
-  ensure_branch "$slot" "$branch_name"
-  branch_submodules "$slot" "$branch_name"
-}
-
-claim_free_slot() {
-  local slot="$1"
-  local source_root="$2"
-  local integration_branch="$3"
-  local branch_name="$4"
-  local output
-
-  if output="$(_claim_free_slot_impl "$slot" "$source_root" "$integration_branch" "$branch_name" 2>&1)"; then
-    [[ -z "$output" ]] || print -u2 -- "$output"
-    return 0
-  fi
-
-  warn "slot ${slot:t} looked FREE but would not fast-forward cleanly onto canonical (diverged garbage?); skipping it"
-  [[ -z "$output" ]] || print -u2 -- "$output"
-  return 1
-}
-
-# Scans every existing slot for one this task can use, claiming the first
-# FREE one that fast-forwards cleanly. Prints the claimed slot path and
-# returns 0, or prints nothing and returns 1 if every slot is BUSY or
-# CORRUPT.
-find_and_claim_free_slot() {
-  local workspace_root="$1"
-  local source_root="$2"
-  local integration_branch="$3"
-  local branch_name="$4"
-  local slot
-
-  for slot in $(existing_slot_paths "$workspace_root"); do
-    slot_is_free "$slot" "$integration_branch" || continue
-    if claim_free_slot "$slot" "$source_root" "$integration_branch" "$branch_name"; then
-      print -- "$slot"
-      return 0
-    fi
-  done
-
-  return 1
-}
-
 ensure_workspace_context() {
   local current_root
   local expected_source
-  local current_branch
+  local workspace_root
 
   current_root="$(git rev-parse --show-toplevel 2>/dev/null)" || die "run this script from an agent workspace"
   current_root="$(canonical_dir "$current_root")"
   expected_source="$(canonical_dir "$SOURCE_REPO")"
+  workspace_root="$(canonical_dir "$WORKSPACE_ROOT")"
 
   [[ "$current_root" != "$expected_source" ]] || die "run this script from an agent workspace, not the canonical repository"
-
-  # Being a clone of a local checkout is not on its own enough to earn the
-  # things finish_workspace does — fast-forwarding the canonical repository from
-  # here, then deleting this directory. Someone's own second clone would qualify
-  # on origin alone. The branch create_workspace.sh puts a workspace on is the
-  # other half of the evidence, and unlike a location it travels with the
-  # checkout.
-  current_branch="$(git -C "$current_root" rev-parse --abbrev-ref HEAD 2>/dev/null)" ||
-    die "workspace has no checked-out branch"
-  [[ "$current_branch" == "${BRANCH_PREFIX}/"* ]] ||
-    die "not an agent workspace: expected a ${BRANCH_PREFIX}/ branch, found ${current_branch}"
+  [[ "$current_root" == "${workspace_root}/"* ]] || die "workspace must live under $WORKSPACE_ROOT"
 
   print -- "$current_root"
 }
@@ -716,56 +307,6 @@ ensure_workspace_branch_consistency() {
     submodule_branch="$(current_branch "$submodule_path")"
     [[ "$submodule_branch" == "$workspace_branch" ]] || die "submodule ${submodule_relpath} is on ${submodule_branch}, expected ${workspace_branch}"
   done < <(submodule_records "$SOURCE_REPO")
-}
-
-# Whether a lock directory has an owner that is still doing the work the lock
-# is for.
-#
-# The recorded pid existing is not enough. A run killed with `kill -9`, or lost
-# to a power cut, never reaches its trap, and by the time anyone looks the kernel
-# may have handed that pid number to something unrelated — so the command has to
-# match too. Anything else is a lock nobody can end, which is a worse failure
-# than the one the lock exists to prevent.
-lock_has_live_owner() {
-  local lock_dir="$1"
-  local owner_pattern="$2"
-  local pid
-
-  pid="$(cat "${lock_dir}/pid" 2>/dev/null)" || return 1
-  [[ -n "$pid" ]] || return 1
-  ps -p "$pid" -o command= 2>/dev/null | rg -q "$owner_pattern"
-}
-
-# Claims `lock_dir` with a `mkdir`-based lock: refuses if a live process
-# matching `owner_pattern` already holds it, reclaims it (with a warning) if
-# the recorded holder is gone. Shared by the integration lock
-# (finish_workspace.sh, one merge into canonical at a time) and the slot claim
-# lock (create_workspace.sh, one slot selection at a time) — same stale-pid
-# problem, same fix, two different holders to look for.
-acquire_lock() {
-  local lock_dir="$1"
-  local owner_pattern="$2"
-  local busy_message="$3"
-
-  if ! mkdir "$lock_dir" 2>/dev/null; then
-    if lock_has_live_owner "$lock_dir" "$owner_pattern"; then
-      die "${busy_message} (holder pid $(cat "${lock_dir}/pid" 2>/dev/null))"
-    fi
-    # Nobody is behind it. Clear it and race for it again: whoever loses the
-    # second `mkdir` has a live winner and is refused, so reclaiming cannot hand
-    # the lock to two runs at once.
-    warn "clearing a lock whose holder is gone (pid $(cat "${lock_dir}/pid" 2>/dev/null))"
-    rm -rf "$lock_dir"
-    mkdir "$lock_dir" 2>/dev/null || die "$busy_message"
-  fi
-  print -- "$$" >"${lock_dir}/pid"
-  print -- "$lock_dir"
-}
-
-release_lock() {
-  local lock_dir="${1:-}"
-  [[ -n "$lock_dir" && -d "$lock_dir" ]] || return 0
-  rm -rf "$lock_dir"
 }
 
 integration_lock_dir_for_source() {
@@ -792,42 +333,17 @@ acquire_integration_lock() {
   local lock_dir
 
   lock_dir="$(integration_lock_dir_for_source "$source_root")"
-  lock_dir="$(acquire_lock "$lock_dir" 'finish_workspace\.sh' "another agent is already integrating into $source_root")"
-  print -- "$WORKSPACE_ROOT" >"${lock_dir}/workspace-root"
-  print -- "$source_root" >"${lock_dir}/source-repo"
+  mkdir "$lock_dir" 2>/dev/null || die "another agent is already integrating into $source_root"
+  print -- "$$" > "${lock_dir}/pid"
+  print -- "$WORKSPACE_ROOT" > "${lock_dir}/workspace-root"
+  print -- "$source_root" > "${lock_dir}/source-repo"
   print -- "$lock_dir"
 }
 
 release_integration_lock() {
-  release_lock "$1"
-}
-
-slot_claim_lock_dir_for_workspace_root() {
-  local workspace_root="$1"
-  local lock_root
-  local lock_key
-
-  mkdir -p "$LOCK_ROOT" || die "failed to create lock root: $LOCK_ROOT"
-  lock_root="$(canonical_dir "$LOCK_ROOT")"
-  lock_key="$(print -n -- "${workspace_root}:slot-claim" | shasum -a 256 | awk '{ print $1 }')"
-  print -- "${lock_root}/${lock_key}.lock"
-}
-
-# Held only across slot *selection* — scanning existing slots for a FREE one
-# and claiming it, or branching a brand new one — never across the slow
-# `target/` seed copy a new slot still needs. Two `create_workspace.sh` runs
-# racing on the same machine would otherwise both see the same FREE slot and
-# both try to switch it onto their own agent branch.
-acquire_slot_claim_lock() {
-  local workspace_root="$1"
-  local lock_dir
-
-  lock_dir="$(slot_claim_lock_dir_for_workspace_root "$workspace_root")"
-  acquire_lock "$lock_dir" 'create_workspace\.sh' "another agent is already claiming a workspace slot under $workspace_root"
-}
-
-release_slot_claim_lock() {
-  release_lock "$1"
+  local lock_dir="${1:-}"
+  [[ -n "$lock_dir" && -d "$lock_dir" ]] || return 0
+  rm -rf "$lock_dir"
 }
 
 rebase_current_branch_onto_source_branch() {
@@ -836,6 +352,6 @@ rebase_current_branch_onto_source_branch() {
   local source_branch="$3"
   local label="$4"
 
-  run_quietly git -C "$workspace_repo" fetch "$source_repo" "$source_branch" || die "failed to fetch ${label} branch ${source_branch} from $source_repo"
-  run_quietly git -C "$workspace_repo" rebase FETCH_HEAD || die "rebase stopped in ${label}; resolve conflicts inside the workspace and continue or abort manually"
+  git -C "$workspace_repo" fetch "$source_repo" "$source_branch" >/dev/null 2>&1 || die "failed to fetch ${label} branch ${source_branch} from $source_repo"
+  git -C "$workspace_repo" rebase FETCH_HEAD >/dev/null 2>&1 || die "rebase stopped in ${label}; resolve conflicts inside the workspace and continue or abort manually"
 }

--- a/.claude/skills/waterui-agent-workspace/scripts/create_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/create_workspace.sh
@@ -15,37 +15,14 @@ ensure_canonical_repo_context() {
   [[ "$current_root" == "$expected_root" ]] || die "run this script from $SOURCE_REPO"
 }
 
-# Clones a brand new slot from canonical the same way this workflow always
-# has: local `git clone` of the superproject and every submodule, activated,
-# then branched to `branch_name`. Only reached when no existing slot is FREE.
-create_new_slot() {
-  local source_root="$1"
-  local slot="$2"
-  local integration_branch="$3"
-  local branch_name="$4"
-
-  print -u2 -- "creating local git clone at $slot"
-  clone_superproject_locally "$source_root" "$slot" "$integration_branch"
-  clone_submodules_locally "$source_root" "$slot"
-  activate_all_submodules "$slot"
-  # Branch before warming `target/`: the branches are what make the workspace
-  # usable, the cache copy is the long step that can still fail, and a workspace
-  # left sitting on the canonical branch silently violates the agent-branch
-  # workflow.
-  ensure_branch "$slot" "$branch_name"
-  branch_submodules "$slot" "$branch_name"
-}
-
 main() {
   local slug="$1"
   local source_root
-  local integration_branch
+  local source_branch
   local workspace_root
   local timestamp
+  local destination
   local branch_name
-  local claim_lock
-  local slot
-  local is_new_slot
   local source_device
   local workspace_device
 
@@ -54,83 +31,44 @@ main() {
   require_command df
   require_command diskutil
   require_command git
-  require_command ps
   require_command rg
   require_command awk
-  require_command shasum
 
+  ensure_nightly_cargo
   validate_slug "$slug"
   ensure_canonical_repo_context
   ensure_no_shared_target_dir
 
   source_root="$(canonical_dir "$SOURCE_REPO")"
-  integration_branch="$(current_branch "$source_root")"
+  source_branch="$(current_branch "$source_root")"
   ensure_source_submodules_ready "$source_root"
-  ensure_canonical_submodule_lineage "$source_root"
-
-  # A workspace is built from committed state — `git clone` copies refs, and each
-  # submodule is checked out at the gitlink recorded in HEAD — so whatever is
-  # uncommitted in the canonical checkout has no bearing on what lands here.
-  # Refusing to run therefore protected nothing, while meaning one agent's
-  # half-finished edit stopped every other agent from *starting*, on a repository
-  # several sessions share. Say what will be left behind and carry on.
-  # `finish_workspace.sh` still requires a clean canonical: that one writes to it.
-  if ! repo_and_submodules_are_clean "$source_root"; then
-    warn "canonical repository has uncommitted changes; this workspace starts from committed HEAD and does not include them"
-  fi
-
+  ensure_repo_and_submodules_clean "$source_root" "canonical repository"
   mkdir -p "$WORKSPACE_ROOT"
   workspace_root="$(canonical_dir "$WORKSPACE_ROOT")"
 
+  source_device="$(device_id "$source_root")"
+  workspace_device="$(device_id "$workspace_root")"
+  [[ "$source_device" == "$workspace_device" ]] || die "workspace root must be on the same filesystem as $SOURCE_REPO"
+
+  ensure_apfs "$source_root"
+  ensure_apfs "$workspace_root"
+
   timestamp="$(date '+%Y%m%d-%H%M%S')"
+  destination="${workspace_root}/${timestamp}-${slug}"
   branch_name="${BRANCH_PREFIX}/${slug}/${timestamp}"
 
-  # See the slot model comment in common.sh for why reuse is the point. The
-  # claim lock only needs to cover slot *selection* — scanning for FREE,
-  # then switching one to `branch_name` — so it is released the moment that
-  # is done, whether the claimed slot was an existing one or a brand new one,
-  # and never held across the slow `target/` seed copy below.
-  claim_lock="$(acquire_slot_claim_lock "$workspace_root")"
-  trap 'release_slot_claim_lock "$claim_lock"' EXIT INT TERM
+  [[ ! -e "$destination" ]] || die "destination already exists: $destination"
 
-  is_new_slot=0
-  if slot="$(find_and_claim_free_slot "$workspace_root" "$source_root" "$integration_branch" "$branch_name")"; then
-    print -u2 -- "reusing warm slot $slot"
-  else
-    is_new_slot=1
-    slot="$(new_slot_path "$workspace_root")"
-    print -u2 -- "no reusable slot; creating $slot"
+  print -u2 -- "creating local git clone at $destination"
+  clone_superproject_locally "$source_root" "$destination" "$source_branch"
 
-    # APFS is required only where a copy actually happens: seeding a brand new
-    # slot's `target/` with `cp -c`. Reusing a slot copies nothing, so a reused
-    # slot never pays this check, even on a workspace root that would fail it.
-    ensure_apfs "$source_root"
-    ensure_apfs "$workspace_root"
+  clone_submodules_locally "$source_root" "$destination"
+  activate_all_submodules "$destination"
+  copy_target_cow "$source_root" "$destination"
+  ensure_branch "$destination" "$branch_name"
+  branch_submodules "$destination" "$branch_name"
 
-    # A slot on the same volume as the source repository clones `target/` with
-    # APFS copy-on-write, which is why the default workspace root lives under
-    # $HOME. A different volume is still allowed — it is the usual answer when
-    # the boot disk is out of space — but clonefile cannot span volumes, so
-    # `cp -c` degrades to a full byte copy: slower to create, and the copy
-    # occupies real space instead of sharing blocks. This is a one-time cost
-    # per slot; every later reuse of this same slot pays nothing.
-    source_device="$(device_id "$source_root")"
-    workspace_device="$(device_id "$workspace_root")"
-    if [[ "$source_device" != "$workspace_device" ]]; then
-      warn "workspace root is on a different volume than ${SOURCE_REPO}; target/ will be copied in full rather than cloned"
-    fi
-
-    create_new_slot "$source_root" "$slot" "$integration_branch" "$branch_name"
-  fi
-
-  release_slot_claim_lock "$claim_lock"
-  trap - EXIT INT TERM
-
-  if [[ "$is_new_slot" -eq 1 ]]; then
-    copy_target_cow "$source_root" "$slot"
-  fi
-
-  print -- "$slot"
+  print -- "$destination"
 }
 
 [[ $# -eq 1 ]] || die "usage: create_workspace.sh <task-slug>"

--- a/.claude/skills/waterui-agent-workspace/scripts/finish_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/finish_workspace.sh
@@ -70,90 +70,13 @@ preflight_fast_forward_merges() {
   ensure_fast_forward_possible "$source_root" "$workspace_root" "$workspace_branch" "superproject"
 }
 
-# Returns a slot to FREE once its work has landed on canonical, instead of
-# deleting it — that is the whole point of the slot model (see common.sh):
-# the clone and its `target/` stay put, warm, for the next task to reuse.
-#
-# By this point `merge_submodules_back` and the superproject fast-forward
-# already landed the work on canonical, with both canonical submodules and the
-# canonical superproject left checked out on their integration branches — so
-# each is a ready-made fast-forward source. For each submodule: switch the
-# slot off the now-merged agent branch onto its own configured integration
-# branch (creating it at the agent branch's tip the first time a slot is
-# freed, which is exactly canonical's new tip since the merge just made them
-# equal; fast-forwarding an already-existing local branch the next time),
-# fast-forward it from canonical to be sure, then delete the spent agent
-# branch. Same shape for the superproject, done last.
-release_slot_to_free() {
-  local workspace_root="$1"
-  local source_root="$2"
-  local integration_branch="$3"
-  local workspace_branch="$4"
-  local name
-  local submodule_relpath
-  local submodule_path
-  local canonical_submodule
-  local target_branch
-
-  while IFS=$'\t' read -r name submodule_relpath; do
-    [[ -n "${name:-}" ]] || continue
-    submodule_path="${workspace_root}/${submodule_relpath}"
-    canonical_submodule="${source_root}/${submodule_relpath}"
-    target_branch="$(configured_submodule_branch "$source_root" "$name")"
-    [[ -n "$target_branch" ]] || die "submodule ${submodule_relpath} has no configured integration branch in .gitmodules"
-
-    ensure_branch "$submodule_path" "$target_branch"
-    merge_branch_ff_only "$submodule_path" "$canonical_submodule" "$target_branch" "submodule ${submodule_relpath}"
-    run_quietly git -C "$submodule_path" branch -D "$workspace_branch" || die "failed to delete spent agent branch ${workspace_branch} in submodule ${submodule_relpath}"
-  done < <(submodule_records "$source_root")
-
-  ensure_branch "$workspace_root" "$integration_branch"
-  merge_branch_ff_only "$workspace_root" "$source_root" "$integration_branch" "superproject"
-  run_quietly git -C "$workspace_root" branch -D "$workspace_branch" || die "failed to delete spent agent branch ${workspace_branch} in superproject"
-
-  print -u2 -- "slot ${workspace_root:t} released back to the pool, warm and FREE"
-}
-
-# Removes a legacy timestamped workspace once its work has landed. Slots (see
-# common.sh) are returned to FREE instead — this path only survives for
-# workspaces created before the slot model, which are recognised by not
-# matching the `slot-<N>` basename pattern.
-#
-# By this point the merge is already in the canonical repository, so a failure
-# here costs a directory, not any work — and it must not read as though the
-# integration failed. `rm -rf` gives up outright when the tree grows a file while
-# it is being walked, which a build, an editor or the file-system indexer can all
-# still be doing seconds after the last command returned, so retry before
-# concluding anything is actually stuck.
 delete_workspace() {
   local workspace_root="$1"
   local source_root
-  local attempt
-  local survivors
 
   source_root="$(canonical_dir "$SOURCE_REPO")"
   cd "$source_root"
-
-  for attempt in 1 2 3 4 5; do
-    if rm -rf "$workspace_root" 2>/dev/null && [[ ! -e "$workspace_root" ]]; then
-      return 0
-    fi
-    sleep "$attempt"
-  done
-
-  survivors="$(find "$workspace_root" -type f 2>/dev/null | head -5)"
-  print -u2 -- ""
-  print -u2 -- "integration SUCCEEDED: the workspace branch is merged and the lock is released."
-  print -u2 -- "Only the cleanup failed — ${workspace_root} could not be removed after 5 attempts,"
-  print -u2 -- "which means something is still writing into it. Nothing is lost; remove it with:"
-  print -u2 -- ""
-  print -u2 -- "  rm -rf ${workspace_root}"
-  if [[ -n "$survivors" ]]; then
-    print -u2 -- ""
-    print -u2 -- "Files still present (first 5):"
-    print -u2 -- "$survivors"
-  fi
-  return 1
+  rm -rf "$workspace_root"
 }
 
 main() {
@@ -172,13 +95,13 @@ main() {
   require_command rm
   require_command shasum
 
+  ensure_nightly_cargo
   ensure_no_shared_target_dir
 
   source_root="$(canonical_dir "$SOURCE_REPO")"
   workspace_root="$(ensure_workspace_context)"
   workspace_contains_source_layout "$workspace_root"
   ensure_source_submodules_ready "$source_root"
-  ensure_canonical_submodule_lineage "$source_root"
   activate_all_submodules "$source_root"
   activate_all_submodules "$workspace_root"
 
@@ -198,12 +121,7 @@ main() {
 
   merge_submodules_back "$source_root" "$workspace_root" "$workspace_branch"
   merge_branch_ff_only "$source_root" "$workspace_root" "$workspace_branch" "superproject"
-
-  if is_slot_workspace "$workspace_root"; then
-    release_slot_to_free "$workspace_root" "$source_root" "$source_branch" "$workspace_branch"
-  else
-    delete_workspace "$workspace_root"
-  fi
+  delete_workspace "$workspace_root"
 }
 
 [[ $# -eq 0 ]] || die "usage: finish_workspace.sh"

--- a/.claude/skills/waterui-agent-workspace/scripts/sync_workspace.sh
+++ b/.claude/skills/waterui-agent-workspace/scripts/sync_workspace.sh
@@ -70,7 +70,7 @@ commit_submodule_pointer_updates_if_needed() {
     return 0
   fi
 
-  run_quietly git -C "$workspace_root" commit -m "$commit_message" || die "failed to commit rebased submodule pointers in workspace"
+  git -C "$workspace_root" commit -m "$commit_message" >/dev/null 2>&1 || die "failed to commit rebased submodule pointers in workspace"
 }
 
 sync_submodules() {
@@ -116,7 +116,6 @@ main() {
   workspace_root="$(ensure_workspace_context)"
   workspace_contains_source_layout "$workspace_root"
   ensure_source_submodules_ready "$source_root"
-  ensure_canonical_submodule_lineage "$source_root"
   activate_all_submodules "$source_root"
   activate_all_submodules "$workspace_root"
   ensure_no_integration_lock "$source_root"


### PR DESCRIPTION
Lands the canonical-checkout commit that reverts the agent workspace skill from fixed warm slots back to per-task, deletable workspaces under `~/.waterui-agent/workspaces`. The commit was made directly on the local `dev` branch, which cannot be pushed; this pull request carries the exact commit so local `dev` fast-forwards after the merge.

- `create_workspace.sh` and `finish_workspace.sh` return to timestamped workspaces that are created for one task and deleted on finish.
- The FREE/BUSY/CORRUPT slot logic is removed from `common.sh`.
- `SKILL.md` documents the per-task lifecycle and points at the `.claude/skills/waterui-agent-workspace` scripts.