### PR TITLE
build(deps): take the published waterui-canvas 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12747,8 +12747,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-canvas"
-version = "0.1.0"
-source = "git+https://github.com/water-rs/canvas?rev=ed4cecc706f69f381555f3fe193134da6e0ff7fe#ed4cecc706f69f381555f3fe193134da6e0ff7fe"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3901f830ff2daec2df29f860a0b3c14973574301afa48395acdc2f6f472e001d"
 dependencies = [
  "image",
  "kurbo 0.13.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -127,13 +127,7 @@ waterui-visualizer = "0.3.0"
 waterui-form = { version = "0.3.0", path = "components/foundation/form" }
 waterui-controls = { version = "0.3.0", path = "components/foundation/controls"}
 waterui-graphics = { version = "0.3.0", path = "components/visual/graphics", default-features = false }
-# `waterui-canvas` 0.1.0 predates the `Path::arc_to` fix (#228): the standalone
-# repository forked from this one before it landed, so the published crate still
-# rounds a corner with the deflection angle, the wrong bisector, and the arc's
-# own `MoveTo` spliced into the contour. Every rounded outline and every routed
-# edge it draws comes apart (#418, #419). Pinned to the restored implementation
-# in water-rs/canvas#5; drop this once a release carrying it ships.
-waterui-canvas = { git = "https://github.com/water-rs/canvas", rev = "ed4cecc706f69f381555f3fe193134da6e0ff7fe" }
+waterui-canvas = "0.1.1"
 waterui-mermaid = { version = "0.1.0", path = "components/data/mermaid" }
 # Mermaid parsing, semantic model and diagram layout. Consumed from our fork
 # while `typed-layout-projection` is unreleased upstream: `merman-render`'s only
@@ -439,11 +433,6 @@ lto = "thin"
 # those to its own copies or the graph carries two of each and every `View`
 # is a different type on either side. Publishing ignores this table, so the
 # published crates keep their registry pins.
-# `waterui-chart` on crates.io depends on the registry `waterui-canvas`, which
-# predates the `Path::arc_to` fix the workspace pins by git rev (#228). Without
-# this entry the graph carries both copies and every canvas `Path` is a
-# different type on either side.
-waterui-canvas = { git = "https://github.com/water-rs/canvas", rev = "ed4cecc706f69f381555f3fe193134da6e0ff7fe" }
 waterui-core = { path = "core" }
 waterui-graphics = { path = "components/visual/graphics" }
 waterui-layout = { path = "components/foundation/layout" }


### PR DESCRIPTION
`waterui-canvas` 0.1.1 is on crates.io and carries the restored `Path::arc_to` (#228) and `Path::bounding_box` that the workspace pinned by git revision (#418, #419). The pin and the `[patch.crates-io]` entry that unified chart's registry copy with it are gone; the graph now carries one registry copy.

Fixes #432

Verified locally: `Cargo.lock` lists a single `waterui-canvas` 0.1.1 from the registry, and `cargo check -p waterui-mermaid --lib` (the consumer of the path bounds) compiles.