### PR TITLE
ci(linux): refresh only Ubuntu's archive before installing packages

### DIFF
--- a/.github/actions/refresh-apt-index/action.yml
+++ b/.github/actions/refresh-apt-index/action.yml
@@ -1,0 +1,21 @@
+name: Refresh the Ubuntu APT index
+description: >
+  Refreshes the package index for Ubuntu's own archive and nothing else. The
+  runner image also carries third-party sources (Google Chrome, Microsoft,
+  the GitHub CLI) that no job here installs from, and a plain `apt-get update`
+  fails the step whenever one of those mirrors serves a stale index — a
+  nightly lost every Linux leg to a Chrome "Hash Sum mismatch" (#487). Every
+  package this repository installs comes from the Ubuntu archive, so that is
+  the only index worth resolving against.
+
+runs:
+  using: composite
+  steps:
+    - name: Refresh the Ubuntu package index
+      shell: bash
+      # Ubuntu 24.04 declares its archive in deb822 form at this path; apt
+      # picks the parser from the `.sources` extension.
+      run: >
+        sudo apt-get update
+        -o Dir::Etc::SourceList=/etc/apt/sources.list.d/ubuntu.sources
+        -o Dir::Etc::SourceParts=/dev/null

--- a/.github/actions/setup-linux-deps/action.yml
+++ b/.github/actions/setup-linux-deps/action.yml
@@ -21,6 +21,12 @@ inputs:
       CC/CXX values. Leave empty for jobs that use the runner default.
     required: false
     default: ""
+  extra-packages:
+    description: >
+      Further Ubuntu packages one job needs on top of the shared list, so the
+      job installs them through the same cached, verified path.
+    required: false
+    default: ""
 
 runs:
   using: composite
@@ -32,9 +38,7 @@ runs:
     # list below, the baked index still names a .deb that has left the pool,
     # every fetch 404s, and `apt-fast` exits 0 anyway — leaving that step green
     # with nothing installed. Resolve against an index that matches the mirror.
-    - name: Refresh APT package index
-      shell: bash
-      run: sudo apt-get update
+    - uses: ./.github/actions/refresh-apt-index
 
     - name: Compute package list
       id: pkgs
@@ -56,6 +60,9 @@ runs:
         fi
         if [ -n "${{ inputs.gcc-version }}" ]; then
           packages="$packages gcc-${{ inputs.gcc-version }} g++-${{ inputs.gcc-version }}"
+        fi
+        if [ -n "${{ inputs.extra-packages }}" ]; then
+          packages="$packages ${{ inputs.extra-packages }}"
         fi
         echo "packages=$packages" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/browser-wpe.yml
+++ b/.github/workflows/browser-wpe.yml
@@ -57,24 +57,20 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
       # The smoke run at the end of `build-runtime.sh` renders the staged
       # runtime through wgpu, so this leg needs the software Vulkan stack too.
+      # The runtime is bundled but not self-contained: it launches its web
+      # processes through the host's bubblewrap sandbox, which is why
+      # `WpeRuntimePaths::validate` insists on both tools. `build-runtime.sh`
+      # installs them itself, so they are here for what a cache hit needs.
       - uses: ./.github/actions/setup-linux-deps
         with:
           gpu: "true"
           gcc-version: "12"
+          extra-packages: bubblewrap unzip xdg-dbus-proxy
       - uses: Swatinem/rust-cache@v2
         with:
           shared-key: browser-wpe
           cache-on-failure: true
       - uses: taiki-e/install-action@nextest
-
-      # The runtime is bundled but not self-contained: it launches its web
-      # processes through the host's bubblewrap sandbox, which is why
-      # `WpeRuntimePaths::validate` insists on both tools. `build-runtime.sh`
-      # installs them itself, so this step is what a cache hit needs.
-      - name: Install the runtime's host requirements
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y --no-install-recommends bubblewrap unzip xdg-dbus-proxy
 
       # Keyed on everything that decides what the artifact contains: the pinned
       # WPE version and packaging in `runtime/`, and the bridge in `native/`.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,8 @@ jobs:
       # Only the license check below needs a native dependency (nasm, for a
       # build script) and it never runs a GUI/audio/video stack, so this job
       # does not need the full setup-linux-deps package list.
-      - run: sudo apt-get update && sudo apt-get install -y nasm
+      - uses: ./.github/actions/refresh-apt-index
+      - run: sudo apt-get install -y nasm
       # Restore-only: this job and Features share `ci-ubuntu`, and two jobs
       # saving the same key race for the reservation, so one of them always
       # loses and uploads nothing. Features owns the write because it builds


### PR DESCRIPTION
ci(linux): refresh only Ubuntu's archive before installing packages

Every Linux leg of nightly run 34383968940 failed in the same place:
`apt-get update` inside setup-linux-deps, on a "Hash Sum mismatch" from
Google Chrome's apt mirror. That source ships baked into the runner image
and no job here installs anything from it, yet a stale index there fails
the step before a single package of ours is resolved.

Refresh the index for Ubuntu's own archive only, through one small action
shared by the deps setup, the hygiene job's nasm install, and the WPE
lane, which now takes its host tools through the same cached, verified
package path instead of a second `apt-get update` of its own.

Fixes #487
