### PR TITLE
fix(examples): let the image example reach the network on Android

### DIFF
--- a/examples/image/Water.toml
+++ b/examples/image/Water.toml
@@ -4,3 +4,7 @@ waterui_path = "../.."
 type = "playground"
 name = "Image Example"
 bundle_identifier = "dev.waterui.examples.image"
+
+[permissions.internet]
+enable = true
+description = "Loads the demo photos from picsum.photos"


### PR DESCRIPTION
Fixes #506

`examples/image/Water.toml` now declares `[permissions.internet]`, so the generated Android manifest asks for `android.permission.INTERNET` and the demo photos can resolve picsum.photos. Pre-existing; found while verifying #497 on the Pixel.