### PR TITLE
ci: check the local API with a cargo-semver-checks that honours [patch]

### DIFF
--- a/.github/actions/cargo-semver-checks/action.yml
+++ b/.github/actions/cargo-semver-checks/action.yml
@@ -1,0 +1,20 @@
+name: cargo-semver-checks
+description: >-
+  Installs the water-rs/cargo-semver-checks build. The fork writes the
+  scanned workspace's `[patch]` tables into the placeholder crate it documents
+  a local project through (#505); upstream v0.50.0 does not, so with an
+  extracted crate depending on the registry `waterui-core` the placeholder
+  resolves two cores and never gets as far as comparing APIs. release-plz runs
+  the same binary, so both callers install it from here.
+runs:
+  using: composite
+  steps:
+    # Built from the fork at a pinned commit and cached by that commit, so the
+    # compile is paid once per rev. Bump `rev` after rebasing the fork's
+    # `waterui/placeholder-inherits-patch` branch onto a newer upstream tag.
+    - uses: taiki-e/cache-cargo-install-action@v3
+      with:
+        tool: cargo-semver-checks
+        git: https://github.com/water-rs/cargo-semver-checks
+        rev: 5090c036244d69cbc53ed5d90d5468a7559c3dd0
+        locked: true

--- a/.github/actions/release-plz/action.yml
+++ b/.github/actions/release-plz/action.yml
@@ -12,9 +12,7 @@ inputs:
 runs:
   using: composite
   steps:
-    - uses: taiki-e/install-action@v2
-      with:
-        tool: cargo-semver-checks@0.50
+    - uses: ./.github/actions/cargo-semver-checks
     # Built from the fork at a pinned commit and cached by that commit, so
     # the compile is paid once per rev. Bump `rev` after rebasing the fork's
     # `waterui/commit-too-old-before-packaging` branch onto a newer upstream tag.

--- a/.github/workflows/release-preflight.yml
+++ b/.github/workflows/release-preflight.yml
@@ -49,4 +49,6 @@ jobs:
             echo "No unyanked waterui on crates.io; this release establishes the baseline."
           fi
       - if: steps.baseline.outputs.exists == 'true'
-        uses: obi1kenobi/cargo-semver-checks-action@v2
+        uses: ./.github/actions/cargo-semver-checks
+      - if: steps.baseline.outputs.exists == 'true'
+        run: cargo semver-checks check-release


### PR DESCRIPTION
Fixes #505

The release preflight's `Local API vs published baseline` job died in `cargo doc` on the placeholder crate cargo-semver-checks builds for the local `waterui`: the placeholder is its own workspace, so the root `[patch.crates-io]` never applied and `waterui-image`'s registry `waterui-core` sat beside the in-tree one. The [water-rs/cargo-semver-checks](https://github.com/water-rs/cargo-semver-checks) fork (branch `waterui/placeholder-inherits-patch`, one commit on v0.50.0, with a fixture and end-to-end test) carries the scanned workspace's `[patch]` tables into that placeholder. A new composite action installs it from a pinned rev with `taiki-e/cache-cargo-install-action`, and both the preflight job and the release-plz action (which runs the same binary) use it.

The job itself only runs on pull requests into `main`, so it exercises this change on the release PR (#500) once dev carries it.