### PR TITLE
fix(cli): keep a local-checkout project's [patch] tables in step with the checkout

### DIFF
--- a/cli/src/project_model/framework.rs
+++ b/cli/src/project_model/framework.rs
@@ -132,6 +132,73 @@ struct Certification {
     scaffold: BTreeMap<String, String>,
 }
 
+/// Make `document`'s `[patch]` tables carry `patches` in place of `previous`:
+/// the entries of `previous` are removed, those of `patches` written, and
+/// sources left empty are dropped, so a manifest moving between a channel, a
+/// local checkout and the registry never keeps a stale override.
+pub(crate) fn rewrite_patch_tables(
+    document: &mut toml_edit::DocumentMut,
+    previous: &PatchSet,
+    patches: &PatchSet,
+) -> Result<()> {
+    for (source, dependencies) in previous {
+        if let Some(table) = document
+            .get_mut("patch")
+            .and_then(|patch| patch.get_mut(source))
+            .and_then(toml_edit::Item::as_table_like_mut)
+        {
+            for name in dependencies.keys() {
+                table.remove(name);
+            }
+        }
+    }
+    let patches = toml_edit::ser::to_document(patches)?;
+    for (source, dependencies) in patches.iter() {
+        // `[patch]` and `[patch.<source>]` are written as explicit tables:
+        // indexing into a missing key would vivify an inline value and
+        // hoist `patch = { … }` above `[package]`.
+        let patch = document
+            .entry("patch")
+            .or_insert_with(toml_edit::table)
+            .as_table_mut()
+            .ok_or_else(|| eyre!("[patch] is not a table"))?;
+        patch.set_implicit(true);
+        let table = patch
+            .entry(source)
+            .or_insert_with(toml_edit::table)
+            .as_table_like_mut()
+            .ok_or_else(|| eyre!("[patch.{source}] is not a table"))?;
+        for (name, dependency) in dependencies
+            .as_table_like()
+            .expect("serialized patch dependencies are tables")
+            .iter()
+        {
+            table.insert(name, dependency.clone());
+        }
+    }
+    if let Some(patch) = document
+        .get_mut("patch")
+        .and_then(toml_edit::Item::as_table_mut)
+    {
+        let empty: Vec<String> = patch
+            .iter()
+            .filter(|(_, sources)| {
+                sources
+                    .as_table_like()
+                    .is_some_and(toml_edit::TableLike::is_empty)
+            })
+            .map(|(source, _)| source.to_owned())
+            .collect();
+        for source in empty {
+            patch.remove(&source);
+        }
+        if patch.is_empty() {
+            document.remove("patch");
+        }
+    }
+    Ok(())
+}
+
 impl ResolvedFramework {
     /// Return the selected distribution channel.
     #[must_use]
@@ -214,62 +281,7 @@ impl ResolvedFramework {
                 }
             }
         }
-        for (source, dependencies) in previous_patches {
-            if let Some(table) = document
-                .get_mut("patch")
-                .and_then(|patch| patch.get_mut(source))
-                .and_then(toml_edit::Item::as_table_like_mut)
-            {
-                for name in dependencies.keys() {
-                    table.remove(name);
-                }
-            }
-        }
-        let patches = toml_edit::ser::to_document(&self.patches)?;
-        for (source, dependencies) in patches.iter() {
-            // `[patch]` and `[patch.<source>]` are written as explicit tables:
-            // indexing into a missing key would vivify an inline value and
-            // hoist `patch = { … }` above `[package]`.
-            let patch = document
-                .entry("patch")
-                .or_insert_with(toml_edit::table)
-                .as_table_mut()
-                .ok_or_else(|| eyre!("[patch] is not a table"))?;
-            patch.set_implicit(true);
-            let table = patch
-                .entry(source)
-                .or_insert_with(toml_edit::table)
-                .as_table_like_mut()
-                .ok_or_else(|| eyre!("[patch.{source}] is not a table"))?;
-            for (name, dependency) in dependencies
-                .as_table_like()
-                .expect("serialized patch dependencies are tables")
-                .iter()
-            {
-                table.insert(name, dependency.clone());
-            }
-        }
-        if let Some(patch) = document
-            .get_mut("patch")
-            .and_then(toml_edit::Item::as_table_mut)
-        {
-            let empty: Vec<String> = patch
-                .iter()
-                .filter(|(_, sources)| {
-                    sources
-                        .as_table_like()
-                        .is_some_and(toml_edit::TableLike::is_empty)
-                })
-                .map(|(source, _)| source.to_owned())
-                .collect();
-            for source in empty {
-                patch.remove(&source);
-            }
-            if patch.is_empty() {
-                document.remove("patch");
-            }
-        }
-        Ok(())
+        rewrite_patch_tables(document, previous_patches, &self.patches)
     }
 
     fn update_dependencies(&self, dependencies: &mut dyn toml_edit::TableLike) -> Result<()> {

--- a/cli/src/project_model/project.rs
+++ b/cli/src/project_model/project.rs
@@ -715,6 +715,10 @@ pub enum FailToOpenProject {
     /// The selected framework could not be validated for this CLI.
     #[error("Framework compatibility check failed: {0}")]
     Framework(eyre::Report),
+    /// The project's `[patch]` tables could not be brought in line with the
+    /// local checkout's.
+    #[error("Failed to refresh the [patch] tables from the local checkout: {0}")]
+    LocalPatches(eyre::Report),
 
     /// Missing crate name in Cargo.toml.
     #[error("Invalid Cargo.toml: missing crate name")]
@@ -1289,6 +1293,37 @@ impl Project {
         Self::open_with_mode(path, OpenMode::PreviewBuild).await
     }
 
+    /// Make a local-checkout project's `[patch]` tables the checkout's.
+    ///
+    /// Cargo applies `[patch]` only from the workspace it builds, so a project
+    /// on a `waterui_path` carries a copy of the checkout's tables, and the
+    /// copy has to follow the checkout: a fork pin moves, an entry is added or
+    /// dropped, and a project scaffolded earlier would otherwise build a graph
+    /// the checkout no longer produces, silently. The manifest is rewritten
+    /// only when the tables differ, so an up-to-date project stays untouched.
+    async fn refresh_local_patches(project_root: &Path, waterui_path: &Path) -> eyre::Result<()> {
+        let project_root = project_root.to_path_buf();
+        let waterui_path = waterui_path.to_path_buf();
+        unblock(move || {
+            let cargo_path = project_root.join("Cargo.toml");
+            let text = std::fs::read_to_string(&cargo_path)?;
+            let current = CargoManifest::from_slice(text.as_bytes())?.patch;
+            let next = templates::local_framework_patches(&project_root, &waterui_path)?;
+            if current == next {
+                return Ok(());
+            }
+            let mut document: toml_edit::DocumentMut = text.parse()?;
+            crate::framework::rewrite_patch_tables(&mut document, &current, &next)?;
+            std::fs::write(&cargo_path, document.to_string())?;
+            info!(
+                path = %cargo_path.display(),
+                "Refreshed the [patch] tables from the local checkout"
+            );
+            Ok(())
+        })
+        .await
+    }
+
     #[allow(clippy::too_many_lines)]
     async fn open_with_mode(
         path: impl AsRef<Path>,
@@ -1312,6 +1347,9 @@ impl Project {
             validate_local_cli(&path.join(local))
                 .await
                 .map_err(FailToOpenProject::Framework)?;
+            Self::refresh_local_patches(&path, Path::new(local))
+                .await
+                .map_err(FailToOpenProject::LocalPatches)?;
         }
         info!(
             path = %path.display(),
@@ -2291,6 +2329,62 @@ mod scaffold_tests {
         assert!(
             assets.join("README.md").is_file(),
             "a tracked file keeps the assets directory present in git"
+        );
+    }
+}
+
+#[cfg(test)]
+mod local_patch_tests {
+    use std::path::Path;
+
+    use super::Project;
+
+    /// A project on a `waterui_path` mirrors the checkout's `[patch]` tables
+    /// every time it opens: entries the checkout dropped disappear, moved ones
+    /// follow, and a project already in line is left byte-for-byte alone.
+    #[test]
+    fn a_local_checkout_project_follows_the_checkouts_patch_tables() {
+        let directory = tempfile::tempdir().expect("temp dir");
+        let checkout = directory.path().join("waterui");
+        std::fs::create_dir_all(&checkout).expect("checkout dir");
+        std::fs::write(
+            checkout.join("Cargo.toml"),
+            include_str!("../../tests/fixtures/local_checkout_patches.toml"),
+        )
+        .expect("checkout manifest");
+        let app = directory.path().join("app");
+        std::fs::create_dir_all(&app).expect("project dir");
+        let cargo_path = app.join("Cargo.toml");
+        std::fs::write(
+            &cargo_path,
+            "[package]\nname = \"app\"\nversion = \"0.1.0\"\n\n[dependencies]\nwaterui = { path = \"../waterui\" }\n\n[patch.crates-io]\nwaterui-core = { path = \"../elsewhere/core\" }\nstale = { path = \"../elsewhere/stale\" }\n",
+        )
+        .expect("project manifest");
+
+        smol::block_on(Project::refresh_local_patches(
+            &app,
+            Path::new("../waterui"),
+        ))
+        .expect("tables refresh");
+        let refreshed = std::fs::read_to_string(&cargo_path).expect("refreshed manifest");
+        let manifest = cargo_toml::Manifest::from_str(&refreshed).expect("manifest parses");
+        let crates_io = &manifest.patch["crates-io"];
+        let cargo_toml::Dependency::Detailed(core) = &crates_io["waterui-core"] else {
+            panic!("the core patch is a path dependency");
+        };
+        assert_eq!(core.path.as_deref(), Some("../waterui/core"));
+        assert!(!crates_io.contains_key("stale"));
+        assert!(crates_io.contains_key("vello"));
+        assert!(refreshed.starts_with("[package]"));
+
+        smol::block_on(Project::refresh_local_patches(
+            &app,
+            Path::new("../waterui"),
+        ))
+        .expect("second refresh");
+        assert_eq!(
+            std::fs::read_to_string(&cargo_path).expect("manifest after the second refresh"),
+            refreshed
         );
     }
 }


### PR DESCRIPTION
Fixes #509

`Project::open` now makes a local-mode project's `[patch]` tables equal to the checkout's every time the project opens, through the same table writer a channel switch uses (`framework::rewrite_patch_tables`, extracted from `ResolvedFramework::update_manifest`), rewriting the manifest only when they differ. Entries the checkout dropped disappear, moved pins follow, and an up-to-date project is left byte-for-byte alone.

Verified with a unit test on the #499 fixture and on a real playground: after adding an entry to the checkout's table, `water package` rewrote the playground's `Cargo.toml` to carry it.