### PR TITLE
build(deps): vello_cpu 0.2 and the remaining tooling bumps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -154,12 +154,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "adler32"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aae1277d39aeec15cb388266ecc24b11c80469deae6067e17a1a7aa9e5c1f234"
-
-[[package]]
 name = "aes"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -876,7 +870,7 @@ dependencies = [
  "addr2line",
  "cfg-if 1.0.4",
  "libc",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "object",
  "rustc-demangle",
  "windows-link 0.2.1",
@@ -1502,9 +1496,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_toml"
-version = "1.0.0"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa61aec073ec94791433ddf3df2323ff9d1711557c2a0eefb0f99cb4f8dca520"
+checksum = "82f4b26e751e711a5302649417f2da046dce6391b2ea30a4820f37462314f0b9"
 dependencies = [
  "semver",
  "serde",
@@ -1541,9 +1535,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.67"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e17dd265a7d0f31ef544e1b20e03add05d3b45b491b633b10d67145d2acc1a38"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -2548,16 +2542,6 @@ name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
-
-[[package]]
-name = "deflate"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73770f8e1fe7d64df17ca66ad28994a0a623ea497fa69486e14984e715c5d174"
-dependencies = [
- "adler32",
- "byteorder",
-]
 
 [[package]]
 name = "defmt"
@@ -3627,9 +3611,9 @@ dependencies = [
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.11"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "fixed_decimal"
@@ -3664,7 +3648,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
  "zlib-rs",
 ]
 
@@ -3716,15 +3700,6 @@ name = "foldhash"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
-
-[[package]]
-name = "font-types"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b38ad915f6dadd993ced50848a8291a543bd41ca62bc10740d5e64e2ab4cfd7"
-dependencies = [
- "bytemuck",
-]
 
 [[package]]
 name = "font-types"
@@ -3799,20 +3774,6 @@ dependencies = [
  "indexmap 2.14.0",
  "kurbo 0.12.0",
  "log",
-]
-
-[[package]]
-name = "fontdb"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "457e789b3d1202543297a350643cf459f836cade38934e7a4cf6a39e7cde2905"
-dependencies = [
- "fontconfig-parser",
- "log",
- "memmap2",
- "slotmap",
- "tinyvec",
- "ttf-parser",
 ]
 
 [[package]]
@@ -4415,23 +4376,6 @@ dependencies = [
 
 [[package]]
 name = "glifo"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d99fc21d493812643aae86d53b7bbd02f376434a90317e8a790bc209fdd6605e"
-dependencies = [
- "bytemuck",
- "foldhash 0.2.0",
- "hashbrown 0.17.1",
- "log",
- "peniko",
- "png 0.18.1",
- "skrifa 0.42.1",
- "smallvec",
- "vello_common 0.0.9",
-]
-
-[[package]]
-name = "glifo"
 version = "0.3.0"
 source = "git+https://github.com/lexoliu/vello?rev=d68d9e9825bcd1ffee762323881c13a2e7a3f639#d68d9e9825bcd1ffee762323881c13a2e7a3f639"
 dependencies = [
@@ -4440,9 +4384,10 @@ dependencies = [
  "hashbrown 0.17.1",
  "log",
  "peniko",
+ "png",
  "skrifa 0.44.0",
  "smallvec",
- "vello_common 0.2.0",
+ "vello_common",
 ]
 
 [[package]]
@@ -4781,6 +4726,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hayro-jpeg2000"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c75ab947623ef4ccaa7acf0579edf7cbb5a73838e3839a7be73335e522f433a1"
+dependencies = [
+ "fearless_simd",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4969,7 +4923,7 @@ dependencies = [
  "objc2-quartz-core 0.3.2",
  "objc2-web-kit",
  "parley",
- "png 0.18.1",
+ "png",
  "pollster 1.0.1",
  "rayon",
  "rustc-hash 2.1.3",
@@ -5114,12 +5068,13 @@ dependencies = [
 
 [[package]]
 name = "icns"
-version = "0.3.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5ccfbad7e08da70a5b48a924994a5afd93125ce5d45a3b0ba0b8da7bda59a40"
+checksum = "467efeb2c1e570cebb9863f9173447f8fe92303d66adc97cb89ac824b60e7a0f"
 dependencies = [
  "byteorder",
- "png 0.16.8",
+ "hayro-jpeg2000",
+ "png",
 ]
 
 [[package]]
@@ -5625,7 +5580,7 @@ dependencies = [
  "image-webp",
  "moxcms",
  "num-traits",
- "png 0.18.1",
+ "png",
  "tiff",
  "zune-core",
  "zune-jpeg",
@@ -5648,12 +5603,6 @@ dependencies = [
  "byteorder-lite",
  "quick-error 2.0.1",
 ]
-
-[[package]]
-name = "imagesize"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09e54e57b4c48b40f7aec75635392b12b3421fa26fe8b4332e63138ed278459c"
 
 [[package]]
 name = "imagesize"
@@ -6895,15 +6844,6 @@ name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
-
-[[package]]
-name = "miniz_oxide"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "791daaae1ed6889560f8c4359194f56648355540573244a5448a83ba1ecc7435"
-dependencies = [
- "adler32",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -8776,18 +8716,6 @@ dependencies = [
 
 [[package]]
 name = "png"
-version = "0.16.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3287920cb847dee3de33d301c463fba14dda99db24214ddf93f83d3021f4c6"
-dependencies = [
- "bitflags 1.3.2",
- "crc32fast",
- "deflate",
- "miniz_oxide 0.3.7",
-]
-
-[[package]]
-name = "png"
 version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
@@ -8796,7 +8724,7 @@ dependencies = [
  "crc32fast",
  "fdeflate",
  "flate2",
- "miniz_oxide 0.8.9",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -9254,23 +9182,13 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.39.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4ed38b89c2c77ff968c524145ad65fb010f38af5c7a224b53b81d47ac2daa81"
-dependencies = [
- "bytemuck",
- "font-types 0.11.3",
-]
-
-[[package]]
-name = "read-fonts"
 version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "046a7d674daf459825b32f5062056d6882db0d2f5a479fbd76ccfc870ac18709"
 dependencies = [
  "bytemuck",
  "core_maths",
- "font-types 0.12.4",
+ "font-types",
  "once_cell",
 ]
 
@@ -9281,7 +9199,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "005c8acf251756c478b0bf402885bfd88a1476020c4c7e6060edc1aa68da38ea"
 dependencies = [
  "bytemuck",
- "font-types 0.12.4",
+ "font-types",
  "once_cell",
 ]
 
@@ -9432,10 +9350,11 @@ checksum = "19b30a45b0cd0bcca8037f3d0dc3421eaf95327a17cad11964fb8179b4fc4832"
 
 [[package]]
 name = "resvg"
-version = "0.47.0"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9be183ad6a216aa96f33e4c8033b0988b8b3ea6fd2359d19af5bac4643fd8e81"
+checksum = "67e3803f97b999e80cbf7c6ecdd07a8102204d92e1633cf48783720c521196bd"
 dependencies = [
+ "bytemuck",
  "gif",
  "image-webp",
  "log",
@@ -9443,7 +9362,7 @@ dependencies = [
  "rgb",
  "svgtypes",
  "tiny-skia 0.12.0",
- "usvg 0.47.0",
+ "usvg",
  "zune-jpeg",
 ]
 
@@ -9723,24 +9642,6 @@ name = "rustversion"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf54715a573b99ac80df0bc206da022bcd442c974952c7b9720069370852e21f"
-
-[[package]]
-name = "rustybuzz"
-version = "0.20.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd3c7c96f8a08ee34eff8857b11b49b07d71d1c3f4e88f8a88d4c9e9f90b1702"
-dependencies = [
- "bitflags 2.13.1",
- "bytemuck",
- "core_maths",
- "log",
- "smallvec",
- "ttf-parser",
- "unicode-bidi-mirroring",
- "unicode-ccc",
- "unicode-properties",
- "unicode-script",
-]
 
 [[package]]
 name = "ryu"
@@ -10227,16 +10128,6 @@ dependencies = [
  "waterui-particle",
  "waterui-testing",
  "waterui-url",
-]
-
-[[package]]
-name = "skrifa"
-version = "0.42.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c34617370ae968efb7161bb2beb517d9084659aae19e24b89e3db25b46e4564"
-dependencies = [
- "bytemuck",
- "read-fonts 0.39.2",
 ]
 
 [[package]]
@@ -11117,7 +11008,7 @@ dependencies = [
  "bytemuck",
  "cfg-if 1.0.4",
  "log",
- "png 0.18.1",
+ "png",
  "tiny-skia-path 0.12.0",
 ]
 
@@ -11532,9 +11423,6 @@ name = "ttf-parser"
 version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2df906b07856748fa3f6e0ad0cbaa047052d4a7dd609e231c4f72cee8c36f31"
-dependencies = [
- "core_maths",
-]
 
 [[package]]
 name = "tungstenite"
@@ -11672,18 +11560,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
-name = "unicode-bidi-mirroring"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dfa6e8c60bb66d49db113e0125ee8711b7647b5579dc7f5f19c42357ed039fe"
-
-[[package]]
-name = "unicode-ccc"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce61d488bcdc9bc8b5d1772c404828b17fc481c0a582b5581e95fb233aef503e"
-
-[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11700,12 +11576,6 @@ name = "unicode-linebreak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b09c83c3c29d37506a3e260c08c03743a6bb66a9cd432c6934ab501a190571f"
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-script"
@@ -11818,34 +11688,6 @@ dependencies = [
 
 [[package]]
 name = "usvg"
-version = "0.47.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d46cf96c5f498d36b7a9693bc6a7075c0bb9303189d61b2249b0dc3d309c07de"
-dependencies = [
- "base64 0.22.1",
- "data-url",
- "flate2",
- "fontdb 0.23.0",
- "imagesize 0.14.0",
- "kurbo 0.13.1",
- "log",
- "pico-args",
- "roxmltree 0.21.1",
- "rustybuzz",
- "simplecss",
- "siphasher",
- "strict-num",
- "svgtypes",
- "tiny-skia-path 0.12.0",
- "ttf-parser",
- "unicode-bidi",
- "unicode-script",
- "unicode-vo",
- "xmlwriter",
-]
-
-[[package]]
-name = "usvg"
 version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "977d0a4abdef933f424a99fe09f95576e089b90aebc6f016a3bc813762493e91"
@@ -11853,9 +11695,9 @@ dependencies = [
  "base64 0.23.1",
  "data-url",
  "flate2",
- "fontdb 0.24.0",
+ "fontdb",
  "harfrust",
- "imagesize 0.15.0",
+ "imagesize",
  "kurbo 0.13.1",
  "log",
  "pico-args",
@@ -11960,30 +11802,13 @@ dependencies = [
  "futures-intrusive",
  "log",
  "peniko",
- "png 0.18.1",
+ "png",
  "skrifa 0.44.0",
  "static_assertions",
  "thiserror 2.0.20",
  "vello_encoding",
  "vello_shaders",
  "wgpu",
-]
-
-[[package]]
-name = "vello_common"
-version = "0.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d672facaa2d697285a786cd9d44d614cd2ce54cdc022504bf339f8fff3b750"
-dependencies = [
- "bytemuck",
- "fearless_simd",
- "guillotiere",
- "hashbrown 0.17.1",
- "log",
- "peniko",
- "png 0.18.1",
- "smallvec",
- "thiserror 2.0.20",
 ]
 
 [[package]]
@@ -11996,21 +11821,22 @@ dependencies = [
  "guillotiere",
  "log",
  "peniko",
+ "png",
  "smallvec",
  "thiserror 2.0.20",
 ]
 
 [[package]]
 name = "vello_cpu"
-version = "0.0.9"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "588691169aed86b5c8fb487266afee01323234e6fd0a3f2aaec0eaa8e4007f23"
+checksum = "ace506ca414548966fcf3c283be94eb1cad8254de488791ee698bf438b0890a9"
 dependencies = [
  "bytemuck",
- "glifo 0.1.1",
+ "glifo",
  "hashbrown 0.17.1",
- "png 0.18.1",
- "vello_common 0.0.9",
+ "png",
+ "vello_common",
 ]
 
 [[package]]
@@ -12031,11 +11857,11 @@ version = "0.2.0"
 source = "git+https://github.com/lexoliu/vello?rev=d68d9e9825bcd1ffee762323881c13a2e7a3f639#d68d9e9825bcd1ffee762323881c13a2e7a3f639"
 dependencies = [
  "bytemuck",
- "glifo 0.3.0",
+ "glifo",
  "hashbrown 0.17.1",
  "log",
  "thiserror 2.0.20",
- "vello_common 0.2.0",
+ "vello_common",
  "vello_sparse_shaders",
  "wgpu",
 ]
@@ -12925,7 +12751,7 @@ dependencies = [
  "waterui-assets-planner",
  "waterui-inspector-protocol",
  "waterui-preview-protocol",
- "which 8.0.5",
+ "which 8.0.6",
  "whoami",
  "zenwave",
  "zip 8.6.0",
@@ -13091,7 +12917,7 @@ dependencies = [
  "filtrate",
  "filtrate-core",
  "futures",
- "glifo 0.3.0",
+ "glifo",
  "image",
  "keyboard-types",
  "kurbo 0.13.1",
@@ -13102,13 +12928,13 @@ dependencies = [
  "parking_lot",
  "pastey 0.2.3",
  "peniko",
- "png 0.18.1",
+ "png",
  "pollster 1.0.1",
  "rayon",
  "shaderloom",
  "tracing",
  "vello",
- "vello_common 0.2.0",
+ "vello_common",
  "vello_cpu",
  "vello_hybrid",
  "waterui",
@@ -13614,7 +13440,7 @@ dependencies = [
  "peniko",
  "pollster 1.0.1",
  "tracing",
- "usvg 0.48.1",
+ "usvg",
  "waterui",
  "waterui-core",
  "waterui-graphics",
@@ -14229,9 +14055,9 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.5"
+version = "8.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f3ef584124b911bcc3875c2f1472e80f24361ceb789bd1c62b3e9a3df9ff43c"
+checksum = "bae2f2b2b816647a1cab1acc91f5bd20812d53cb344382635ec2181940c8034f"
 dependencies = [
  "libc",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -247,7 +247,7 @@ quick-xml = "0.42"
 # find at runtime; without it MathCAT looks for a `Rules` directory on disk.
 mathcat = { version = "0.7.5", features = ["include-zip"] }
 toml = "1.1.3"
-vello_cpu = { version = "0.0.9", default-features = false }
+vello_cpu = { version = "0.2.0", default-features = false }
 lyon = "1.0"
 wgpu-hal = { version = "29.0.4", features = ["gles", "metal"] }
 # Must match the `glow` version wgpu-hal links against, or GLES handles from

--- a/backends/dew/Cargo.toml
+++ b/backends/dew/Cargo.toml
@@ -135,6 +135,7 @@ waterui-math.workspace = true
 # of those wrappers used to abort dew's dispatch. Test-only, like the scene
 # crates above and for the same reason.
 waterui-chart.workspace = true
+# Tracks the version vello_cpu links, or `Level` is a different type on either side.
 fearless_simd = { version = "0.4", features = ["force_support_fallback"] }
 executor-core.workspace = true
 native-executor.workspace = true

--- a/backends/dew/src/board.rs
+++ b/backends/dew/src/board.rs
@@ -18,14 +18,13 @@ use std::collections::VecDeque;
 
 use crate::accessibility::{AccessibilityActionRequest, AccessibilityTreeUpdate};
 use peniko::Blob;
-use vello_cpu::RenderSettings;
 use waterui_backend_core::input::TouchPhase;
 use waterui_backend_core::time::Instant;
 
 #[cfg(feature = "host")]
 use crate::display::BufferDisplay;
 use crate::display::DisplayFlush;
-use crate::painter::target_render_settings;
+use crate::painter::{RenderProfile, target_render_profile};
 
 /// Where a board's text faces come from.
 ///
@@ -92,8 +91,8 @@ pub trait Board {
     fn now(&self) -> Instant;
 
     /// CPU rasterization profile for this board.
-    fn render_settings(&self) -> RenderSettings {
-        target_render_settings()
+    fn render_profile(&self) -> RenderProfile {
+        target_render_profile()
     }
 
     /// The fonts text on this board shapes with.

--- a/backends/dew/src/lib.rs
+++ b/backends/dew/src/lib.rs
@@ -106,6 +106,7 @@ pub use display::BufferDisplay;
 pub use display::{DisplayFlush, Rgb565Display, Rgb565Sink};
 pub use display_list::{Clip, ClipRegion, DisplayList, DrawCommand, PlacedCommand};
 pub use painter::Painter;
+pub use painter::RenderProfile;
 #[cfg(feature = "host")]
 pub use runtime::render_view_png;
 pub use runtime::{DewRuntime, Frame};

--- a/backends/dew/src/painter.rs
+++ b/backends/dew/src/painter.rs
@@ -14,7 +14,7 @@
 //! painter as an opaque recording rather than as display-list commands.
 
 use kurbo::{Affine, Rect, Shape};
-use vello_cpu::{Pixmap, RenderContext, RenderMode, RenderSettings, Resources};
+use vello_cpu::{Pixmap, RasterizerSettings, RenderContext, RenderMode, RenderSettings, Resources};
 use waterui_graphics::scene2d_cpu::{CpuImageCache, replay_recording};
 
 use crate::compositor::DeviceRegion;
@@ -28,7 +28,7 @@ use crate::stats::FrameWork;
 #[derive(Debug)]
 pub struct Painter {
     resources: Resources,
-    settings: RenderSettings,
+    profile: RenderProfile,
     images: CpuImageCache,
     scratch: Vec<ScratchSlot>,
 }
@@ -47,6 +47,7 @@ struct ScratchSlot {
     height: u16,
     context: RenderContext,
     pixmap: Pixmap,
+    rasterizer: RasterizerSettings,
 }
 
 /// Distinct region sizes kept alive for reuse, least recently used evicted.
@@ -55,19 +56,35 @@ struct ScratchSlot {
 /// pathological size storm cannot hoard band-sized buffers.
 const SCRATCH_SLOTS: usize = 8;
 
+/// How a board rasterizes: what its render contexts are created with (SIMD
+/// level, worker threads) and the pipeline every region is rendered through.
+#[derive(Debug, Clone, Copy)]
+pub struct RenderProfile {
+    /// Settings each scratch render context is created with.
+    pub context: RenderSettings,
+    /// Settings each region is rasterized with.
+    pub rasterizer: RasterizerSettings,
+}
+
+impl Default for RenderProfile {
+    fn default() -> Self {
+        target_render_profile()
+    }
+}
+
 impl Default for Painter {
     fn default() -> Self {
-        Self::new(target_render_settings())
+        Self::new(target_render_profile())
     }
 }
 
 impl Painter {
-    /// Creates a painter with empty caches and explicit target settings.
+    /// Creates a painter with empty caches and an explicit render profile.
     #[must_use]
-    pub fn new(settings: RenderSettings) -> Self {
+    pub fn new(profile: RenderProfile) -> Self {
         Self {
             resources: Resources::new(),
-            settings,
+            profile,
             images: CpuImageCache::new(),
             scratch: Vec::new(),
         }
@@ -92,8 +109,9 @@ impl Painter {
             self.scratch.push(ScratchSlot {
                 width,
                 height,
-                context: RenderContext::new_with(width, height, self.settings),
+                context: RenderContext::new_with(width, height, self.profile.context),
                 pixmap: Pixmap::new(width, height),
+                rasterizer: self.profile.rasterizer,
             });
         }
         let slot = self
@@ -231,8 +249,16 @@ impl Painter {
             }
         }
         ctx.flush();
-        slot.context.render_to_pixmap(resources, &mut slot.pixmap);
+        slot.render(resources);
         &slot.pixmap
+    }
+}
+
+impl ScratchSlot {
+    /// Rasterizes the recorded scene into the slot's pixmap.
+    fn render(&mut self, resources: &mut Resources) {
+        self.context
+            .render_with(&mut self.pixmap, resources, self.rasterizer);
     }
 }
 
@@ -262,14 +288,17 @@ fn push_clip_layers(ctx: &mut RenderContext, clip: Option<&Clip>, shift: Affine)
 }
 
 /// Sets the context paint, converting and caching image brushes once.
-pub(crate) fn target_render_settings() -> RenderSettings {
-    RenderSettings {
-        render_mode: if cfg!(target_arch = "xtensa") {
-            RenderMode::OptimizeQuality
-        } else {
-            RenderMode::OptimizeSpeed
+pub(crate) fn target_render_profile() -> RenderProfile {
+    RenderProfile {
+        context: RenderSettings::default(),
+        rasterizer: RasterizerSettings {
+            render_mode: if cfg!(target_arch = "xtensa") {
+                RenderMode::OptimizeQuality
+            } else {
+                RenderMode::OptimizeSpeed
+            },
+            ..RasterizerSettings::default()
         },
-        ..Default::default()
     }
 }
 

--- a/backends/dew/src/runtime.rs
+++ b/backends/dew/src/runtime.rs
@@ -77,7 +77,7 @@ impl<B: Board> DewRuntime<B> {
         band_height: u32,
         build_root: impl Fn() -> AnyView + 'static,
     ) -> Self {
-        let render_settings = board.render_settings();
+        let render_profile = board.render_profile();
         let fonts = board.fonts();
         let signals = waterui_backend_core::frame_signals::FrameSignals::new(board.now());
         let (width, height) = board.display().size();
@@ -90,7 +90,7 @@ impl<B: Board> DewRuntime<B> {
         renderer.fonts().install(&mut env);
         Self {
             renderer,
-            painter: Painter::new(render_settings),
+            painter: Painter::new(render_profile),
             scheduler: BandScheduler::new(width, height, band_height),
             board,
             env,

--- a/backends/dew/tests/fallback_probe.rs
+++ b/backends/dew/tests/fallback_probe.rs
@@ -4,13 +4,18 @@
 
 use kurbo::{Affine, Rect, Shape};
 use peniko::Color;
-use vello_cpu::{Level, Pixmap, RenderContext, RenderMode, RenderSettings, Resources};
+use vello_cpu::{
+    Level, Pixmap, RasterizerSettings, RenderContext, RenderMode, RenderSettings, Resources,
+};
 
 fn render_banded(mode: RenderMode) {
     let settings = RenderSettings {
         level: Level::Fallback(fearless_simd::Fallback::new()),
         num_threads: 0,
+    };
+    let rasterizer = RasterizerSettings {
         render_mode: mode,
+        ..RasterizerSettings::default()
     };
     let mut resources = Resources::new();
     // Full screen plus the three stacked fills, rendered band-by-band with
@@ -29,7 +34,7 @@ fn render_banded(mode: RenderMode) {
         }
         ctx.flush();
         let mut pixmap = Pixmap::new(96, 16);
-        ctx.render_to_pixmap(&mut resources, &mut pixmap);
+        ctx.render_with(&mut pixmap, &mut resources, rasterizer);
         assert_eq!(pixmap.data()[8 * 96 + 48].a, 255, "band {band_y} rendered");
     }
 }

--- a/backends/dew/tests/vending_performance.rs
+++ b/backends/dew/tests/vending_performance.rs
@@ -22,14 +22,14 @@ use std::time::{Duration, Instant as StdInstant};
 
 use nami::{Binding, binding};
 use peniko::Blob;
-use vello_cpu::{Level, RenderMode, RenderSettings};
+use vello_cpu::{Level, RasterizerSettings, RenderMode, RenderSettings};
 use waterui::prelude::*;
 use waterui_backend_core::input::TouchPhase;
 use waterui_backend_core::time::Instant;
 use waterui_core::AnyView;
 use waterui_dew::{
     Board, ChipBudget, DeviceRegion, DewRuntime, FontSources, FrameWork, PointerSample, Provenance,
-    Rgb565Display, Rgb565Sink,
+    RenderProfile, Rgb565Display, Rgb565Sink,
 };
 use waterui_layout::frame::Frame;
 
@@ -262,16 +262,21 @@ impl Board for SimulatedEmbeddedBoard {
         Instant::now()
     }
 
-    fn render_settings(&self) -> RenderSettings {
-        RenderSettings {
-            // No SIMD and no worker threads: an ESP32-class core has neither.
-            level: Level::fallback(),
-            num_threads: 0,
-            // The pipeline the target actually runs. `painter.rs` forces the
-            // f32 path on Xtensa because the Xtensa LLVM backend miscompiles
-            // vello_cpu's u8/u16 fine kernels, so simulating the faster u8
-            // path would measure code the chip will never execute.
-            render_mode: RenderMode::OptimizeQuality,
+    fn render_profile(&self) -> RenderProfile {
+        RenderProfile {
+            context: RenderSettings {
+                // No SIMD and no worker threads: an ESP32-class core has neither.
+                level: Level::fallback(),
+                num_threads: 0,
+            },
+            rasterizer: RasterizerSettings {
+                // The pipeline the target actually runs. `painter.rs` forces the
+                // f32 path on Xtensa because the Xtensa LLVM backend miscompiles
+                // vello_cpu's u8/u16 fine kernels, so simulating the faster u8
+                // path would measure code the chip will never execute.
+                render_mode: RenderMode::OptimizeQuality,
+                ..RasterizerSettings::default()
+            },
         }
     }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -43,7 +43,7 @@ cargo_metadata = "0.23.1"
 # writes PNG plus the Windows ICO container. `default-formats` additionally
 # pulls `image`'s AVIF *encoder* (ravif -> rav1e), which nothing here calls.
 image = { version = "0.25", default-features = false, features = ["png", "jpeg", "webp", "ico"] }
-cargo_toml = "1.0.0"
+cargo_toml = "1.0.1"
 color-eyre = { version = "0.6.5", features = ["issue-url"]}
 include_dir = "0.7.4"
 futures.workspace = true
@@ -64,7 +64,7 @@ tracing.workspace = true
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 semver = "1.0"
 serialport = "4"
-which = "8.0.5"
+which = "8.0.6"
 notify = { version = "8", default-features = false, features = ["macos_kqueue"] }
 
 # Terminal UI dependencies
@@ -91,7 +91,7 @@ zip = { version = "8.6", default-features = false, features = ["deflate"] }
 roxmltree = "0.21"            # Android SDK repository XML parsing
 fs_extra = "1.3"
 askama = "0.16"
-resvg = "0.47.0"
+resvg = "0.48.1"
 ttf-parser = "0.25"
 ignore = "0.4"
 remove_dir_all = "1.0"
@@ -120,7 +120,7 @@ nix = { version = "0.31", features = ["signal"] }
 # `.icns` encoding for hand-assembled app bundles. Only the macOS packaging path
 # builds one, and that path is itself `#[cfg(target_os = "macos")]`, so the
 # dependency does not belong in a Linux or Windows build of the CLI.
-icns = "0.3"
+icns = "0.4"
 
 [target.'cfg(not(target_vendor = "apple"))'.dependencies]
 zenwave = { workspace = true, features = ["rustls"] }

--- a/components/platform/browser-cef/Cargo.toml
+++ b/components/platform/browser-cef/Cargo.toml
@@ -83,7 +83,7 @@ harness = false
 required-features = ["real-engine"]
 
 [build-dependencies]
-cc = "1.2"
+cc = "1.4"
 
 [package.metadata.cargo-machete]
 ignored = ["cc", "cef-dll-sys"]

--- a/components/visual/graphics/src/scene/scene2d_cpu.rs
+++ b/components/visual/graphics/src/scene/scene2d_cpu.rs
@@ -12,7 +12,10 @@ use core::fmt;
 
 use kurbo::{Affine, BezPath, Rect, Shape, Stroke};
 use peniko::{BlendMode, Brush, Fill, ImageBrush, StyleRef};
-use vello_cpu::{Image, ImageSource, RenderContext, RenderMode, RenderSettings, Resources};
+use vello_cpu::{
+    Image, ImageSource, PixmapMut, RasterizerSettings, RenderContext, RenderMode, RenderSettings,
+    Resources,
+};
 
 use crate::scene2d::{GlyphRun, Scene2D, SceneRecording};
 
@@ -365,12 +368,15 @@ impl Rasterizer {
             clippy::cast_possible_truncation,
             reason = "`new` already proved both sides fit in a u16"
         )]
-        self.ctx.render_to_buffer(
+        let target = PixmapMut::new(self.width as u16, self.height as u16, &mut data)
+            .expect("`data` holds exactly width * height * 4 bytes");
+        self.ctx.render_with(
+            target,
             &mut self.resources,
-            &mut data,
-            self.width as u16,
-            self.height as u16,
-            RenderMode::OptimizeSpeed,
+            RasterizerSettings {
+                render_mode: RenderMode::OptimizeSpeed,
+                ..RasterizerSettings::default()
+            },
         );
         RgbaBitmap {
             width: self.width,


### PR DESCRIPTION
Advances #405 (does not close it: vello 0.10 and wgpu 30 are still owed).

- **vello_cpu 0.0.9 → 0.2.0.** Rendering now takes a `PixmapMut` target with `RasterizerSettings` per call instead of a `RenderMode` baked into the context. The Scene2D CPU rasterizer renders through `PixmapMut`; dew's `Board::render_profile` hands the painter a `RenderProfile` (the `RenderSettings` contexts are created with plus the `RasterizerSettings` every region is rendered with), so the Xtensa f32-pipeline choice lives where vello_cpu now reads it. dew's `fearless_simd` tracks the version vello_cpu links (0.4), or `Level` is a different type on either side.
- icns 0.4, resvg 0.48.1, cargo_toml 1.0.1, which 8.0.6 (cli); cc 1.4 (browser-cef).

**Why vello stays on 0.9 here:** `waterui-map-gpu 0.1.0` on crates.io consumes vello 0.9 and hands its `Scene` to `waterui-graphics`, so bumping vello in-tree splits the type (two `vello::Scene`s, checked). It moves once map-gpu is re-released against the new graphics crate after the foundation release. wgpu 30 waits on vello itself: v0.10.0 still pins wgpu 29. The Mali select-clamp patch is already rebased for that day (lexoliu/vello `waterui/v0.10.0-select-clamp`, 92d5b798).

Verified: `cargo check --workspace --all-targets`; clippy on graphics, dew and cli; nextest for graphics and dew (174 + 116 tests).