### PR TITLE
ci: take the cargo-semver-checks fork that parses tool metadata

### DIFF
--- a/.github/actions/cargo-semver-checks/action.yml
+++ b/.github/actions/cargo-semver-checks/action.yml
@@ -16,5 +16,5 @@ runs:
       with:
         tool: cargo-semver-checks
         git: https://github.com/water-rs/cargo-semver-checks
-        rev: 5090c036244d69cbc53ed5d90d5468a7559c3dd0
+        rev: 14c730d774ab26be35df7378295447ddcb6125db
         locked: true


### PR DESCRIPTION
Fixes #513

Bumps the water-rs/cargo-semver-checks rev to 14c730d7: the previous rev parsed the workspace root manifest with a unit metadata type, so `[package.metadata.waterui]` made it fail before the `[patch]` tables were read. The new rev parses free-form metadata; its fixture now carries both `[workspace.metadata.*]` and `[package.metadata.*]` tables and the end-to-end test passes.