### PR TITLE
fix(cli): pin the run and package context futures on the heap

### DIFF
--- a/cli/src/terminal/commands/package.rs
+++ b/cli/src/terminal/commands/package.rs
@@ -123,7 +123,10 @@ struct PackagingContext {
 
 /// Run the package command.
 pub async fn run(shell: &Shell, args: Args) -> Result<()> {
-    let context = prepare_packaging_context(shell, &args).await?;
+    // The packaging context carries the opened project, the resolved backend and
+    // the build options; on Windows that future crosses clippy's `large_futures`
+    // threshold (16 KiB), so it is pinned on the heap instead of the caller's stack.
+    let context = Box::pin(prepare_packaging_context(shell, &args)).await?;
     print_packaging_header(
         shell,
         &context.project,

--- a/cli/src/terminal/commands/run.rs
+++ b/cli/src/terminal/commands/run.rs
@@ -365,7 +365,10 @@ const fn resolve_platform(platform_override: Option<TargetPlatform>) -> TargetPl
 
 /// Run the run command.
 pub async fn run(shell: &Shell, args: Args) -> Result<()> {
-    let context = prepare_run_context(shell, &args).await?;
+    // The run context carries the opened project, the resolved device, backend
+    // and build options; on Windows that future crosses clippy's `large_futures`
+    // threshold (16 KiB), so it is pinned on the heap instead of the caller's stack.
+    let context = Box::pin(prepare_run_context(shell, &args)).await?;
     print_run_header(shell, &context);
     check_run_toolchain(shell, context.platform, context.backend).await?;
 


### PR DESCRIPTION
Fixes #515.

The nightly on `dev` fails the Windows clippy leg with `large_futures` at the two command entry points that build a run or packaging context. Both futures embed `Project::open`, which crossed the 16 KiB threshold on Windows once #511 added the local-mode `[patch]` refresh; the other targets sit a few hundred bytes under it, so the Linux gate cannot see this.

Same fix as #503 for the preview build: pin the context future on the heap at the call site, with the reason recorded beside it.
