### PR TITLE
feat(ffi): capture Android view subtrees into the filter pipeline through AHardwareBuffer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12834,6 +12834,7 @@ dependencies = [
 name = "waterui-ffi"
 version = "0.3.0"
 dependencies = [
+ "ash",
  "async-channel",
  "base64 0.22.1",
  "cbindgen",
@@ -12911,6 +12912,7 @@ dependencies = [
 name = "waterui-graphics"
 version = "0.3.0"
 dependencies = [
+ "ash",
  "bytemuck",
  "divan",
  "encase",
@@ -12941,6 +12943,7 @@ dependencies = [
  "waterui-core",
  "waterui-testing",
  "wgpu",
+ "wgpu-hal",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -250,6 +250,12 @@ toml = "1.1.3"
 vello_cpu = { version = "0.2.0", default-features = false }
 lyon = "1.0"
 wgpu-hal = { version = "29.0.4", features = ["gles", "metal"] }
+# The Vulkan bindings `wgpu-hal` itself links. Android view capture imports an
+# `AHardwareBuffer` as a raw `VkImage`, which means calling
+# `VK_ANDROID_external_memory_android_hardware_buffer` on the very `ash::Device`
+# `wgpu_hal::vulkan::Device::raw_device()` hands back, so the two must resolve to
+# one `ash`: a second major would make that a different `ash::Device` type.
+ash = "0.38"
 # Must match the `glow` version wgpu-hal links against, or GLES handles from
 # `wgpu::hal::gles` fail to unify with locally created ones.
 # Tracks whatever `wgpu-hal` links, not the newest release: the GTK backend

--- a/components/visual/graphics/Cargo.toml
+++ b/components/visual/graphics/Cargo.toml
@@ -47,6 +47,8 @@ gpu = [
     "dep:mp4parse",
     "dep:shaderloom",
     "dep:naga",
+    "dep:ash",
+    "dep:wgpu-hal",
 ]
 
 [dependencies]
@@ -83,6 +85,15 @@ rayon = { version = "1.12", optional = true }
 mp4parse = { version = "0.17", optional = true }
 shaderloom = { workspace = true, optional = true }
 num-traits = { version = "0.2", default-features = false }
+
+[target.'cfg(target_os = "android")'.dependencies]
+# Android view capture reads a captured subtree out of an `AHardwareBuffer`,
+# which needs `VK_ANDROID_external_memory_android_hardware_buffer` and
+# `VK_EXT_queue_family_foreign` enabled on the device. wgpu does not enable
+# either, so the device is opened through the HAL adapter instead of
+# `Adapter::request_device`, and that is spelled in `ash`/`wgpu-hal` terms.
+ash = { workspace = true, optional = true }
+wgpu-hal = { workspace = true, features = ["vulkan"], optional = true }
 
 [build-dependencies]
 naga = { version = "30.0.0", features = ["wgsl-in"], optional = true }

--- a/components/visual/graphics/src/gpu/shared_context.rs
+++ b/components/visual/graphics/src/gpu/shared_context.rs
@@ -284,15 +284,22 @@ impl SharedGpuContext {
         let adapter_features = adapter.features();
         let required_features = required_media_features(adapter_features);
         let required_limits = required_device_limits(&adapter.limits());
+        let descriptor = wgpu::DeviceDescriptor {
+            label: Some("WaterUI GPU runtime device"),
+            required_features,
+            required_limits,
+            memory_hints: wgpu::MemoryHints::Performance,
+            experimental_features: wgpu::ExperimentalFeatures::default(),
+            trace: wgpu::Trace::default(),
+        };
+        // Android opens its device through the HAL so the external-memory
+        // extensions view capture imports `AHardwareBuffer`s with are enabled;
+        // that path talks to `vkCreateDevice` directly and has nothing to await.
+        #[cfg(target_os = "android")]
+        let (device, queue) = open_android_device(&adapter, &descriptor)?;
+        #[cfg(not(target_os = "android"))]
         let (device, queue) = adapter
-            .request_device(&wgpu::DeviceDescriptor {
-                label: Some("WaterUI GPU runtime device"),
-                required_features,
-                required_limits,
-                memory_hints: wgpu::MemoryHints::Performance,
-                experimental_features: wgpu::ExperimentalFeatures::default(),
-                trace: wgpu::Trace::default(),
-            })
+            .request_device(&descriptor)
             .await
             .map_err(|error| SharedContextError::DeviceCreationFailed(error.to_string()))?;
 
@@ -350,6 +357,92 @@ async fn request_adapter(
             force_fallback_adapter: false,
         })
         .await
+}
+
+/// The Vulkan device extensions Android view capture is built on.
+///
+/// [`VK_ANDROID_external_memory_android_hardware_buffer`][ahb] is what turns the
+/// `AHardwareBuffer` a captured view subtree was rendered into by `HardwareRenderer`
+/// into a `VkImage` this device can read; [`VK_EXT_queue_family_foreign`][foreign] is
+/// what lets that image's ownership be acquired from — and released back to — the
+/// Android framework, which owns the buffer between frames.
+///
+/// [ahb]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_ANDROID_external_memory_android_hardware_buffer.html
+/// [foreign]: https://registry.khronos.org/vulkan/specs/latest/man/html/VK_EXT_queue_family_foreign.html
+#[cfg(target_os = "android")]
+const ANDROID_CAPTURE_DEVICE_EXTENSIONS: [&core::ffi::CStr; 2] = [
+    ash::android::external_memory_android_hardware_buffer::NAME,
+    ash::ext::queue_family_foreign::NAME,
+];
+
+/// Opens the Android GPU device with the view-capture extensions enabled.
+///
+/// `wgpu::Adapter::request_device` enables only the extensions wgpu itself needs,
+/// and there is no descriptor field for asking for more, so the device is built
+/// through the HAL adapter: `open_with_callback` hands the extension list to a
+/// callback before `vkCreateDevice` sees it, and the resulting `OpenDevice` is
+/// then adopted by wgpu with `create_device_from_hal`, which is what keeps the
+/// device a perfectly ordinary `wgpu::Device` for everything else.
+///
+/// Both extensions are mandatory on every Android device that reports Vulkan 1.1
+/// (Android CDD), so an adapter without them is a hard error naming the missing
+/// extension rather than a capture path that silently is not there.
+#[cfg(target_os = "android")]
+fn open_android_device(
+    adapter: &wgpu::Adapter,
+    descriptor: &wgpu::DeviceDescriptor<'_>,
+) -> Result<(wgpu::Device, wgpu::Queue), SharedContextError> {
+    use wgpu_hal::api::Vulkan;
+
+    // SAFETY: the HAL adapter is only borrowed to open a device from it. Nothing
+    // here destroys it, and the guard is dropped before this function returns.
+    let hal_adapter = unsafe { adapter.as_hal::<Vulkan>() }.ok_or_else(|| {
+        SharedContextError::DeviceCreationFailed(
+            "WaterUI renders through Vulkan on Android, and this adapter is not a Vulkan adapter"
+                .to_owned(),
+        )
+    })?;
+
+    let capabilities = hal_adapter.physical_device_capabilities();
+    for extension in ANDROID_CAPTURE_DEVICE_EXTENSIONS {
+        if !capabilities.supports_extension(extension) {
+            return Err(SharedContextError::DeviceCreationFailed(format!(
+                "the Vulkan driver does not support {}, which WaterUI needs to read a captured \
+                 view subtree out of an AHardwareBuffer",
+                extension.to_string_lossy()
+            )));
+        }
+    }
+
+    // SAFETY: the callback only appends extensions this adapter was just proven to
+    // support, and removes nothing, which is `open_with_callback`'s contract. The
+    // device it returns is handed straight to `create_device_from_hal` below, so
+    // wgpu takes ownership of it exactly once.
+    let open_device = unsafe {
+        hal_adapter.open_with_callback(
+            descriptor.required_features,
+            &descriptor.required_limits,
+            &descriptor.memory_hints,
+            Some(Box::new(
+                |args: wgpu_hal::vulkan::CreateDeviceCallbackArgs<'_, '_, '_>| {
+                    for extension in ANDROID_CAPTURE_DEVICE_EXTENSIONS {
+                        // wgpu may already have asked for one of these for its own
+                        // reasons, and a repeated name is a `vkCreateDevice`
+                        // validation error rather than a no-op.
+                        if !args.extensions.contains(&extension) {
+                            args.extensions.push(extension);
+                        }
+                    }
+                },
+            )),
+        )
+    }
+    .map_err(|error| SharedContextError::DeviceCreationFailed(error.to_string()))?;
+
+    // SAFETY: `open_device` was opened from this very adapter, with the features and
+    // limits `descriptor` names, and has not been used for anything else.
+    unsafe { adapter.create_device_from_hal::<Vulkan>(open_device, descriptor) }
+        .map_err(|error| SharedContextError::DeviceCreationFailed(error.to_string()))
 }
 
 #[cfg(target_os = "android")]

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -66,6 +66,10 @@ ndk-context = "0.1.1"
 jni = "0.22.4"
 ndk-sys = "0.6"
 wgpu-hal = { workspace = true, features = ["vulkan"], optional = true }
+# The Vulkan side of Android view capture: an `AHardwareBuffer` handed over from
+# Kotlin is imported as a raw `VkImage` on the very `ash::Device` wgpu-hal owns,
+# and copied into the wgpu capture texture from there.
+ash = { workspace = true, optional = true }
 
 [target.'cfg(any(target_os = "ios", target_os = "macos"))'.dependencies]
 tracing-oslog = "0.3"
@@ -98,6 +102,7 @@ gpu = [
     "dep:waterui-svg",
     "dep:wgpu",
     "dep:wgpu-hal",
+    "dep:ash",
     "dep:waterui-video-gpu",
     "dep:objc2-metal",
     "dep:pollster",

--- a/ffi/src/components/mod.rs
+++ b/ffi/src/components/mod.rs
@@ -37,10 +37,12 @@ pub use platform::{dynamic, icon, webview};
 pub use typography::text;
 #[cfg(all(feature = "android-jni", feature = "gpu"))]
 pub(crate) use visual::gpu_runtime;
+#[cfg(all(target_os = "android", feature = "gpu"))]
+pub use visual::hardware_buffer;
 pub use visual::picture;
 pub use visual::view_renderer;
-#[cfg(all(feature = "c-api", feature = "gpu"))]
-pub use visual::{applied_filter, view_effect};
+#[cfg(feature = "gpu")]
+pub use visual::{applied_filter, capture_format, view_effect};
 #[cfg(feature = "gpu")]
 pub use visual::{gpu_surface, gpu_surface_input};
 

--- a/ffi/src/components/visual/applied_filter.rs
+++ b/ffi/src/components/visual/applied_filter.rs
@@ -98,13 +98,7 @@ impl IntoFFI for waterui_core::Metadata<AppliedFilter> {
 }
 
 // Generate waterui_metadata_applied_filter_id() and waterui_force_as_metadata_applied_filter()
-ffi_metadata!(
-    AppliedFilter,
-    WuiAppliedFilter,
-    applied_filter,
-    all(),
-    any()
-);
+ffi_metadata!(AppliedFilter, WuiAppliedFilter, applied_filter);
 
 /// Opaque state held by the native backend for one semantic applied filter.
 pub struct WuiAppliedFilterState {
@@ -135,6 +129,9 @@ pub struct WuiAppliedFilterState {
     /// Latest output dimensions resolved from snapped filter state.
     resolved_output_width: u32,
     resolved_output_height: u32,
+    /// Vulkan imports of the Android capture buffers handed to this filter.
+    #[cfg(target_os = "android")]
+    hardware_buffer_imports: super::hardware_buffer::HardwareBufferImports,
     /// Host-owned effect clock; media effects may bypass this API with explicit timing.
     frame_clock: EffectFrameClock,
 }
@@ -342,6 +339,9 @@ pub unsafe extern "C" fn waterui_applied_filter_create(
     // SAFETY: the caller contract requires `env` to be a valid handle alive for this
     // call; it is only borrowed.
     let runtime = super::gpu_runtime::gpu_runtime(&unsafe { &*env }.0);
+    #[cfg(target_os = "android")]
+    let hardware_buffer_imports =
+        super::hardware_buffer::HardwareBufferImports::new(runtime.clone());
     let redraw_handle = filter.redraw_handle();
     Box::into_raw(Box::new(WuiAppliedFilterState {
         runtime,
@@ -359,6 +359,8 @@ pub unsafe extern "C" fn waterui_applied_filter_create(
         output_height: 0,
         resolved_output_width: 0,
         resolved_output_height: 0,
+        #[cfg(target_os = "android")]
+        hardware_buffer_imports,
         frame_clock: EffectFrameClock::new(),
     }))
 }
@@ -506,6 +508,11 @@ pub unsafe extern "C" fn waterui_applied_filter_detach(state: *mut WuiAppliedFil
         .output_surface
         .take()
         .expect("waterui_applied_filter_detach: output surface is already detached");
+    // Before the capture texture goes: the imported buffers are raw Vulkan
+    // objects wgpu does not defer the destruction of, so they are released here
+    // rather than left to outlive the target they were captured for.
+    #[cfg(target_os = "android")]
+    state.hardware_buffer_imports.clear();
     state.output_config = None;
     state.capture_texture = None;
     state.capture_format = None;
@@ -812,6 +819,117 @@ pub unsafe extern "C" fn waterui_applied_filter_prepare_capture(
         .capture_format
         .expect("waterui_applied_filter_prepare_capture: presentation target is detached");
     assert_setup_input_format(state, capture_format);
+}
+
+/// The pixel layout this filter's capture buffers must be allocated with (Android only).
+///
+/// The Android backend reads this after attaching and allocates its
+/// `ImageReader` from it, so the `AHardwareBuffer` it captures the subtree into
+/// is copy-compatible with the capture texture the filter samples.
+///
+/// # Safety
+///
+/// `state` must be a valid pointer from `waterui_applied_filter_create` with an
+/// attached target.
+///
+/// # Panics
+///
+/// Panics if `state` is detached, or if its capture format has no
+/// `AHardwareBuffer` layout.
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_applied_filter_capture_format(
+    state: *const WuiAppliedFilterState,
+) -> super::capture_format::WuiCaptureFormat {
+    // SAFETY: the caller contract requires `state` to be a valid handle that stays
+    // alive for this call; it is only borrowed.
+    let state = unsafe { crate::borrow_ffi(state) };
+    let format = state
+        .capture_format
+        .expect("waterui_applied_filter_capture_format: presentation target is detached");
+    super::capture_format::capture_buffer_format(format)
+}
+
+/// The pixel layout this filter's capture buffers must be allocated with (Android only).
+///
+/// # Safety
+///
+/// `state` must be a valid pointer from `waterui_applied_filter_create` with an
+/// attached target.
+///
+/// # Panics
+///
+/// Always panics: `AHardwareBuffer` capture only exists on Android.
+#[cfg(not(target_os = "android"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_applied_filter_capture_format(
+    _state: *const WuiAppliedFilterState,
+) -> super::capture_format::WuiCaptureFormat {
+    panic!("waterui_applied_filter_capture_format: only supported on Android");
+}
+
+/// Copies a captured `AHardwareBuffer` into the capture texture (Android only).
+///
+/// The buffer is the one `HardwareRenderer` drew the filtered subtree into. It
+/// is imported once per distinct buffer and copied on the GPU; the returned
+/// fence is what tells the backend the copy is finished, so it must be consumed
+/// by `waterui_gpu_capture_fence_on_complete` and the `Image` the buffer came
+/// from closed only from that completion.
+///
+/// # Safety
+///
+/// - `state` must be a valid pointer from `waterui_applied_filter_create` with an
+///   attached target, and `waterui_applied_filter_prepare_capture` must have run
+///   for this frame's size.
+/// - `buffer` must be a live `AHardwareBuffer` for the duration of this call.
+///
+/// # Panics
+///
+/// Panics if `state` is detached, or if the buffer's size or layout does not
+/// match the capture texture.
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_applied_filter_set_capture_hardware_buffer(
+    state: *mut WuiAppliedFilterState,
+    buffer: *mut c_void,
+) -> *mut super::gpu_surface::WuiGpuCaptureFence {
+    // SAFETY: the caller contract requires `state` to be a valid handle, alive and
+    // not otherwise borrowed for this call; the exclusive borrow ends here.
+    let state = unsafe { crate::borrow_ffi_mut(state) };
+    let capture_texture = state.capture_texture.take().expect(
+        "waterui_applied_filter_set_capture_hardware_buffer: presentation target is detached",
+    );
+    // SAFETY: the caller contract makes `buffer` a live `AHardwareBuffer` for this
+    // call, which is when the import takes its own reference on it.
+    let fence = unsafe {
+        super::hardware_buffer::copy_hardware_buffer_into_texture(
+            &mut state.hardware_buffer_imports,
+            buffer.cast(),
+            &capture_texture,
+            "waterui_applied_filter_set_capture_hardware_buffer",
+        )
+    };
+    state.capture_texture = Some(capture_texture);
+    fence
+}
+
+/// Copies a captured `AHardwareBuffer` into the capture texture (Android only).
+///
+/// # Safety
+///
+/// `state` must be a valid pointer from `waterui_applied_filter_create` with an
+/// attached target, and `buffer` a live `AHardwareBuffer`.
+///
+/// # Panics
+///
+/// Always panics: `AHardwareBuffer` capture only exists on Android.
+#[cfg(not(target_os = "android"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_applied_filter_set_capture_hardware_buffer(
+    _state: *mut WuiAppliedFilterState,
+    _buffer: *mut c_void,
+) -> *mut super::gpu_surface::WuiGpuCaptureFence {
+    panic!("waterui_applied_filter_set_capture_hardware_buffer: only supported on Android");
 }
 
 /// Get a pointer to the Metal texture backing the capture texture (Apple only).

--- a/ffi/src/components/visual/applied_filter.rs
+++ b/ffi/src/components/visual/applied_filter.rs
@@ -132,6 +132,9 @@ pub struct WuiAppliedFilterState {
     /// Vulkan imports of the Android capture buffers handed to this filter.
     #[cfg(target_os = "android")]
     hardware_buffer_imports: super::hardware_buffer::HardwareBufferImports,
+    /// Pipelines for drawing surfaces nested in the captured subtree back into it.
+    #[cfg(target_os = "android")]
+    capture_compositor: super::capture_composite::CaptureCompositor,
     /// Host-owned effect clock; media effects may bypass this API with explicit timing.
     frame_clock: EffectFrameClock,
 }
@@ -361,6 +364,8 @@ pub unsafe extern "C" fn waterui_applied_filter_create(
         resolved_output_height: 0,
         #[cfg(target_os = "android")]
         hardware_buffer_imports,
+        #[cfg(target_os = "android")]
+        capture_compositor: super::capture_composite::CaptureCompositor::default(),
         frame_clock: EffectFrameClock::new(),
     }))
 }
@@ -930,6 +935,93 @@ pub unsafe extern "C" fn waterui_applied_filter_set_capture_hardware_buffer(
     _buffer: *mut c_void,
 ) -> *mut super::gpu_surface::WuiGpuCaptureFence {
     panic!("waterui_applied_filter_set_capture_hardware_buffer: only supported on Android");
+}
+
+/// Draws a `GpuSurface` nested in the captured subtree into the capture (Android only).
+///
+/// HWUI records a `SurfaceView` as a cleared hole, so a GPU surface inside a
+/// filtered subtree is missing from the buffer the subtree was captured into.
+/// The backend calls this once per nested surface, between handing over the
+/// captured buffer and rendering the filter, with the rectangle the surface
+/// occupies inside the captured content in capture pixels. The surface renders
+/// one frame of its own and it is drawn into the capture at that rectangle.
+///
+/// Everything runs on one queue in call order, so the capture copy, the
+/// composites and the filter render need no fence between them.
+///
+/// # Safety
+///
+/// - `filter` must be a valid pointer from `waterui_applied_filter_create` with
+///   an attached target, and `waterui_applied_filter_prepare_capture` must have
+///   run for this frame's size.
+/// - `surface` must be a valid pointer from `waterui_gpu_surface_create` that
+///   has been attached at least once, so it has an established renderer format.
+/// - Both must be used from the thread that created them.
+///
+/// # Panics
+///
+/// Panics if the filter is detached, if the surface has never been attached, or
+/// if the placement is empty.
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_applied_filter_composite_gpu_surface(
+    filter: *mut WuiAppliedFilterState,
+    surface: *mut super::gpu_surface::WuiGpuSurfaceState,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    scale: f64,
+) {
+    // SAFETY: the caller contract requires `filter` to be a valid handle, alive and
+    // not otherwise borrowed for this call; the exclusive borrow ends here.
+    let filter = unsafe { crate::borrow_ffi_mut(filter) };
+    // SAFETY: the caller contract requires `surface` to be a valid handle for a
+    // different state, alive and not otherwise borrowed for this call.
+    let surface = unsafe { crate::borrow_ffi_mut(surface) };
+    let capture_texture = filter
+        .capture_texture
+        .take()
+        .expect("waterui_applied_filter_composite_gpu_surface: presentation target is detached");
+    super::capture_composite::composite_gpu_surface(
+        &mut filter.capture_compositor,
+        surface,
+        &capture_texture,
+        super::capture_composite::CompositePlacement {
+            x,
+            y,
+            width,
+            height,
+            scale,
+        },
+        "waterui_applied_filter_composite_gpu_surface",
+    );
+    filter.capture_texture = Some(capture_texture);
+}
+
+/// Draws a `GpuSurface` nested in the captured subtree into the capture (Android only).
+///
+/// # Safety
+///
+/// `filter` and `surface` must be valid state pointers from their matching
+/// constructors.
+///
+/// # Panics
+///
+/// Always panics: nested-surface compositing only exists on Android, because
+/// only there does the capture arrive with the surface missing from it.
+#[cfg(not(target_os = "android"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_applied_filter_composite_gpu_surface(
+    _filter: *mut WuiAppliedFilterState,
+    _surface: *mut super::gpu_surface::WuiGpuSurfaceState,
+    _x: i32,
+    _y: i32,
+    _width: u32,
+    _height: u32,
+    _scale: f64,
+) {
+    panic!("waterui_applied_filter_composite_gpu_surface: only supported on Android");
 }
 
 /// Get a pointer to the Metal texture backing the capture texture (Apple only).

--- a/ffi/src/components/visual/capture_composite.rs
+++ b/ffi/src/components/visual/capture_composite.rs
@@ -1,0 +1,313 @@
+//! Drawing surfaces nested inside a captured view subtree back into it.
+//!
+//! Android's HWUI records a `SurfaceView` as a cleared hole, so a `GpuSurface`
+//! that lives inside an `AppliedFilter` or `ViewEffect` subtree is simply absent
+//! from the buffer the subtree was captured into: the filter would receive a
+//! transparent rectangle where the surface's picture belongs, and the surface's
+//! own layer would keep presenting to the window on its own.
+//!
+//! So the surface is asked for its frame separately, into a texture of its own
+//! ([`super::gpu_surface::render_composite_source`]), and that texture is drawn
+//! into the capture at the rectangle the surface occupies — the same thing the
+//! Apple path does with its capture compositor, expressed in wgpu.
+//!
+//! Everything here runs on the queue the capture copy and the filter render run
+//! on, in that order, so no extra fence is involved: the buffer copy lands
+//! first, the composites follow, and the filter reads the finished capture.
+
+use std::collections::HashMap;
+
+use super::gpu_surface::{WuiGpuSurfaceState, composite_runtime, render_composite_source};
+
+/// Where a nested surface's frame lands in the capture it is drawn into.
+#[derive(Clone, Copy, Debug)]
+pub struct CompositePlacement {
+    /// Left edge in capture pixels, measured from the captured subtree's origin.
+    ///
+    /// Signed because a surface inside a scrolled container legitimately starts
+    /// left of or above the captured content; the shader clips what falls
+    /// outside the capture rather than the placement being invalid.
+    pub x: i32,
+    /// Top edge in capture pixels, measured from the captured subtree's origin.
+    pub y: i32,
+    /// Width in capture pixels.
+    pub width: u32,
+    /// Height in capture pixels.
+    pub height: u32,
+    /// Capture pixels per logical unit, which is the surface's own scale.
+    pub scale: f64,
+}
+
+/// The pipelines one capture target draws its nested surfaces with.
+///
+/// Held by the capture target that owns the destination texture, so the shader
+/// is compiled once per target format and reused for every nested surface and
+/// every frame. Everything is created on first use: a subtree with no nested
+/// surface never pays for any of it.
+#[derive(Default)]
+pub struct CaptureCompositor {
+    sampler: Option<wgpu::Sampler>,
+    bind_group_layout: Option<wgpu::BindGroupLayout>,
+    uniforms: Option<wgpu::Buffer>,
+    pipelines: HashMap<wgpu::TextureFormat, wgpu::RenderPipeline>,
+}
+
+/// What one composite draw needs from the cache, borrowed for that draw.
+struct CompositeResources<'a> {
+    pipeline: &'a wgpu::RenderPipeline,
+    bind_group_layout: &'a wgpu::BindGroupLayout,
+    sampler: &'a wgpu::Sampler,
+    uniforms: &'a wgpu::Buffer,
+}
+
+/// Floats in the `Placement` uniform: a `vec4` rectangle and a `vec2` size,
+/// padded out to the 16-byte alignment WGSL gives the struct.
+const PLACEMENT_UNIFORM_FIELDS: usize = 8;
+
+/// The same uniform's size in bytes.
+const PLACEMENT_UNIFORM_BYTES: usize = PLACEMENT_UNIFORM_FIELDS * size_of::<f32>();
+
+impl CaptureCompositor {
+    /// Compiles what a draw into `format` needs, reusing whatever already exists.
+    fn resources(
+        &mut self,
+        device: &wgpu::Device,
+        format: wgpu::TextureFormat,
+    ) -> CompositeResources<'_> {
+        let bind_group_layout = self.bind_group_layout.get_or_insert_with(|| {
+            device.create_bind_group_layout(&wgpu::BindGroupLayoutDescriptor {
+                label: Some("Capture Composite Bind Group Layout"),
+                entries: &[
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 0,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Texture {
+                            sample_type: wgpu::TextureSampleType::Float { filterable: true },
+                            view_dimension: wgpu::TextureViewDimension::D2,
+                            multisampled: false,
+                        },
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 1,
+                        visibility: wgpu::ShaderStages::FRAGMENT,
+                        ty: wgpu::BindingType::Sampler(wgpu::SamplerBindingType::Filtering),
+                        count: None,
+                    },
+                    wgpu::BindGroupLayoutEntry {
+                        binding: 2,
+                        visibility: wgpu::ShaderStages::VERTEX,
+                        ty: wgpu::BindingType::Buffer {
+                            ty: wgpu::BufferBindingType::Uniform,
+                            has_dynamic_offset: false,
+                            min_binding_size: wgpu::BufferSize::new(PLACEMENT_UNIFORM_BYTES as u64),
+                        },
+                        count: None,
+                    },
+                ],
+            })
+        });
+        let sampler = self.sampler.get_or_insert_with(|| {
+            device.create_sampler(&wgpu::SamplerDescriptor {
+                label: Some("Capture Composite Sampler"),
+                mag_filter: wgpu::FilterMode::Linear,
+                min_filter: wgpu::FilterMode::Linear,
+                ..Default::default()
+            })
+        });
+        let uniforms = self.uniforms.get_or_insert_with(|| {
+            device.create_buffer(&wgpu::BufferDescriptor {
+                label: Some("Capture Composite Placement"),
+                size: PLACEMENT_UNIFORM_BYTES as u64,
+                usage: wgpu::BufferUsages::UNIFORM | wgpu::BufferUsages::COPY_DST,
+                mapped_at_creation: false,
+            })
+        });
+        let pipeline = self
+            .pipelines
+            .entry(format)
+            .or_insert_with(|| create_pipeline(device, bind_group_layout, format));
+        CompositeResources {
+            pipeline,
+            bind_group_layout,
+            sampler,
+            uniforms,
+        }
+    }
+}
+
+/// Builds the pipeline that draws a composite source into a `format` target.
+fn create_pipeline(
+    device: &wgpu::Device,
+    bind_group_layout: &wgpu::BindGroupLayout,
+    format: wgpu::TextureFormat,
+) -> wgpu::RenderPipeline {
+    let module = device.create_shader_module(wgpu::ShaderModuleDescriptor {
+        label: Some("Capture Composite Shader"),
+        source: wgpu::ShaderSource::Wgsl(include_str!("capture_composite.wgsl").into()),
+    });
+    let layout = device.create_pipeline_layout(&wgpu::PipelineLayoutDescriptor {
+        label: Some("Capture Composite Pipeline Layout"),
+        bind_group_layouts: &[Some(bind_group_layout)],
+        immediate_size: 0,
+    });
+    device.create_render_pipeline(&wgpu::RenderPipelineDescriptor {
+        label: Some("Capture Composite Pipeline"),
+        layout: Some(&layout),
+        vertex: wgpu::VertexState {
+            module: &module,
+            entry_point: Some("vs_main"),
+            buffers: &[],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        },
+        fragment: Some(wgpu::FragmentState {
+            module: &module,
+            entry_point: Some("fs_main"),
+            targets: &[Some(wgpu::ColorTargetState {
+                format,
+                // A GPU surface presents premultiplied alpha, and the capture it
+                // is drawn into is transparent wherever HWUI punched its hole,
+                // so the surface composites over the capture exactly as its own
+                // layer would have composited over the window.
+                blend: Some(wgpu::BlendState::PREMULTIPLIED_ALPHA_BLENDING),
+                write_mask: wgpu::ColorWrites::ALL,
+            })],
+            compilation_options: wgpu::PipelineCompilationOptions::default(),
+        }),
+        primitive: wgpu::PrimitiveState::default(),
+        depth_stencil: None,
+        multisample: wgpu::MultisampleState::default(),
+        multiview_mask: None,
+        cache: None,
+    })
+}
+
+/// Renders `surface` and draws its frame into `target` at `placement`.
+///
+/// `scope` names the FFI entry point this was reached through, so a contract
+/// violation says which one.
+///
+/// # Panics
+///
+/// Panics if `placement` is empty, or if the surface has never been attached
+/// and so has no renderer format to be captured in.
+pub fn composite_gpu_surface(
+    compositor: &mut CaptureCompositor,
+    surface: &mut WuiGpuSurfaceState,
+    target: &wgpu::Texture,
+    placement: CompositePlacement,
+    scope: &'static str,
+) {
+    assert!(
+        placement.width > 0 && placement.height > 0,
+        "{scope}: a nested surface occupies no pixels at {}x{}",
+        placement.width,
+        placement.height
+    );
+    assert!(
+        placement.scale.is_finite() && placement.scale > 0.0,
+        "{scope}: scale must be a positive, finite device-pixel ratio, got {}",
+        placement.scale
+    );
+
+    // Both textures live on the one environment-owned runtime the whole view
+    // tree shares, so the surface's device is the capture's device. The runtime
+    // is cloned out first because rendering the surface borrows its state.
+    let runtime = composite_runtime(surface);
+    let gpu = runtime.context();
+
+    let source =
+        render_composite_source(surface, placement.width, placement.height, placement.scale);
+    let source_view = source.create_view(&wgpu::TextureViewDescriptor {
+        label: Some("Capture Composite Source View"),
+        ..Default::default()
+    });
+
+    let resources = compositor.resources(&gpu.device, target.format());
+    gpu.queue.write_buffer(
+        resources.uniforms,
+        0,
+        &placement_uniform(placement, target.width(), target.height()),
+    );
+
+    let bind_group = gpu.device.create_bind_group(&wgpu::BindGroupDescriptor {
+        label: Some("Capture Composite Bind Group"),
+        layout: resources.bind_group_layout,
+        entries: &[
+            wgpu::BindGroupEntry {
+                binding: 0,
+                resource: wgpu::BindingResource::TextureView(&source_view),
+            },
+            wgpu::BindGroupEntry {
+                binding: 1,
+                resource: wgpu::BindingResource::Sampler(resources.sampler),
+            },
+            wgpu::BindGroupEntry {
+                binding: 2,
+                resource: resources.uniforms.as_entire_binding(),
+            },
+        ],
+    });
+
+    let target_view = target.create_view(&wgpu::TextureViewDescriptor {
+        label: Some("Capture Composite Target View"),
+        ..Default::default()
+    });
+    let mut encoder = gpu
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("Capture Composite Encoder"),
+        });
+    {
+        let mut pass = encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+            label: Some("Capture Composite Pass"),
+            color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+                view: &target_view,
+                depth_slice: None,
+                resolve_target: None,
+                ops: wgpu::Operations {
+                    // The capture the subtree was drawn into is what everything
+                    // outside this surface's rectangle keeps.
+                    load: wgpu::LoadOp::Load,
+                    store: wgpu::StoreOp::Store,
+                },
+            })],
+            depth_stencil_attachment: None,
+            timestamp_writes: None,
+            occlusion_query_set: None,
+            multiview_mask: None,
+        });
+        pass.set_pipeline(resources.pipeline);
+        pass.set_bind_group(0, &bind_group, &[]);
+        pass.draw(0..6, 0..1);
+    }
+    gpu.queue.submit([encoder.finish()]);
+}
+
+/// The `Placement` uniform's bytes, in the layout the shader declares.
+fn placement_uniform(
+    placement: CompositePlacement,
+    target_width: u32,
+    target_height: u32,
+) -> [u8; PLACEMENT_UNIFORM_BYTES] {
+    #[expect(
+        clippy::cast_precision_loss,
+        reason = "a placement is a view rectangle in pixels, far below f32's exact integer range"
+    )]
+    let fields: [f32; PLACEMENT_UNIFORM_FIELDS] = [
+        placement.x as f32,
+        placement.y as f32,
+        placement.width as f32,
+        placement.height as f32,
+        target_width as f32,
+        target_height as f32,
+        0.0,
+        0.0,
+    ];
+    let mut bytes = [0_u8; PLACEMENT_UNIFORM_BYTES];
+    for (index, field) in fields.into_iter().enumerate() {
+        let offset = index * size_of::<f32>();
+        bytes[offset..offset + size_of::<f32>()].copy_from_slice(&field.to_ne_bytes());
+    }
+    bytes
+}

--- a/ffi/src/components/visual/capture_composite.wgsl
+++ b/ffi/src/components/visual/capture_composite.wgsl
@@ -1,0 +1,61 @@
+// Draws one rendered GPU surface into a captured view subtree.
+//
+// Android's HWUI records a SurfaceView as a cleared hole, so a GpuSurface
+// inside a filtered subtree is missing from the captured buffer and is drawn
+// back into it here, at the rectangle the surface occupies.
+//
+// The destination rectangle is carried per draw rather than set as a viewport,
+// so a surface that hangs over the edge of the capture is clipped by the
+// rasterizer instead of being invalid.
+
+struct Placement {
+    // Destination rectangle in target pixels: origin in `xy`, size in `zw`.
+    rect: vec4<f32>,
+    // The capture texture's own size in pixels.
+    // Named for what it holds: `target` alone is a WGSL reserved keyword.
+    target_size: vec2<f32>,
+}
+
+@group(0) @binding(0) var t_source: texture_2d<f32>;
+@group(0) @binding(1) var s_source: sampler;
+@group(0) @binding(2) var<uniform> placement: Placement;
+
+struct VertexOutput {
+    @builtin(position) position: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+}
+
+@vertex
+fn vs_main(@builtin(vertex_index) vertex_index: u32) -> VertexOutput {
+    // The unit square as two triangles; the same value indexes the destination
+    // rectangle and the source texture, both of which have their origin at the
+    // top left.
+    var corners = array<vec2<f32>, 6>(
+        vec2<f32>(0.0, 0.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(0.0, 1.0),
+        vec2<f32>(1.0, 0.0),
+        vec2<f32>(1.0, 1.0),
+    );
+
+    let corner = corners[vertex_index];
+    let pixel = placement.rect.xy + corner * placement.rect.zw;
+
+    var output: VertexOutput;
+    output.position = vec4<f32>(
+        pixel.x / placement.target_size.x * 2.0 - 1.0,
+        1.0 - pixel.y / placement.target_size.y * 2.0,
+        0.0,
+        1.0,
+    );
+    output.uv = corner;
+    return output;
+}
+
+@fragment
+fn fs_main(input: VertexOutput) -> @location(0) vec4<f32> {
+    // An explicit mip level keeps this valid for unfilterable float formats,
+    // which the HDR capture path uses.
+    return textureSampleLevel(t_source, s_source, input.uv, 0.0);
+}

--- a/ffi/src/components/visual/capture_format.rs
+++ b/ffi/src/components/visual/capture_format.rs
@@ -1,0 +1,122 @@
+//! The pixel layouts a captured view subtree crosses the FFI in.
+//!
+//! `AppliedFilter` and `ViewEffect` are handed their input by the platform:
+//! Apple renders the subtree straight into the wgpu capture texture through an
+//! `MTLTexture`, while Android renders it into an `AHardwareBuffer` that
+//! `super::hardware_buffer` imports and copies. Only Android has to be told
+//! which layout to allocate, but the vocabulary it is told in is ordinary wgpu
+//! reasoning and lives here, so the C header declares the same signatures on
+//! every platform.
+
+/// The pixel layout an Android capture buffer must be allocated with.
+///
+/// The backend allocates its `ImageReader` from this after attaching, so the
+/// buffer it hands back is copy-compatible with the capture texture the filter
+/// samples. The discriminants are the values the JNI binding returns as an
+/// `Int`, and are part of the Kotlin contract.
+#[repr(u32)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum WuiCaptureFormat {
+    /// Four 8-bit unsigned channels: `AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM`,
+    /// which is `android.graphics.PixelFormat.RGBA_8888`.
+    Rgba8Unorm = 0,
+    /// Four 16-bit half-float channels:
+    /// `AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT`, which is
+    /// `android.graphics.PixelFormat.RGBA_FP16`.
+    Rgba16Float = 1,
+}
+
+/// The buffer layout a capture texture of `format` must be filled from.
+///
+/// The capture texture's format is chosen from the output surface's
+/// capabilities, so it is sRGB-encoded whenever the surface offers that. An
+/// `AHardwareBuffer` has no sRGB variant — `HardwareRenderer` writes
+/// sRGB-encoded bytes into a plain `RGBA_8888` buffer, exactly as Apple's
+/// capture writes them into a `BGRA8Unorm_sRGB` texture — so the two differ only
+/// in whether the sampler decodes, which is what leaves them copy-compatible.
+///
+/// # Panics
+///
+/// Panics when the capture texture's format has no `AHardwareBuffer` layout at
+/// all. A BGRA surface format is the realistic case: Android's `ImageReader`
+/// cannot allocate a BGRA buffer, so there is nothing to capture into.
+#[must_use]
+pub fn capture_buffer_format(format: wgpu::TextureFormat) -> WuiCaptureFormat {
+    match format {
+        wgpu::TextureFormat::Rgba8Unorm | wgpu::TextureFormat::Rgba8UnormSrgb => {
+            WuiCaptureFormat::Rgba8Unorm
+        }
+        wgpu::TextureFormat::Rgba16Float => WuiCaptureFormat::Rgba16Float,
+        other => panic!(
+            "Android view capture cannot fill a {other:?} texture: no AHardwareBuffer layout \
+             matches it"
+        ),
+    }
+}
+
+/// The wgpu format a `ViewEffect` samples an imported buffer of `format` as.
+///
+/// `HardwareRenderer` writes sRGB-encoded pixels, so the 8-bit layout is read
+/// back through an sRGB texture and decoded by the sampler — the same thing the
+/// Apple path gets from its `BGRA8Unorm_sRGB` capture texture. Half-float
+/// buffers already hold linear values and are read as they are.
+#[must_use]
+pub const fn effect_input_texture_format(format: WuiCaptureFormat) -> wgpu::TextureFormat {
+    match format {
+        WuiCaptureFormat::Rgba8Unorm => wgpu::TextureFormat::Rgba8UnormSrgb,
+        WuiCaptureFormat::Rgba16Float => wgpu::TextureFormat::Rgba16Float,
+    }
+}
+
+/// Creates the texture a `ViewEffect` copies its captured input into.
+///
+/// Cleared once through wgpu for the same reason the `AppliedFilter` capture
+/// texture is: wgpu zero-clears a texture it has never written the first time it
+/// is sampled, which would wipe the first captured frame.
+#[must_use]
+pub fn create_effect_input_texture(
+    device: &wgpu::Device,
+    queue: &wgpu::Queue,
+    format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+) -> wgpu::Texture {
+    let texture = device.create_texture(&wgpu::TextureDescriptor {
+        label: Some("ViewEffect Capture Texture"),
+        size: wgpu::Extent3d {
+            width,
+            height,
+            depth_or_array_layers: 1,
+        },
+        mip_level_count: 1,
+        sample_count: 1,
+        dimension: wgpu::TextureDimension::D2,
+        format,
+        usage: wgpu::TextureUsages::TEXTURE_BINDING
+            | wgpu::TextureUsages::RENDER_ATTACHMENT
+            | wgpu::TextureUsages::COPY_DST,
+        view_formats: &[],
+    });
+    let view = texture.create_view(&wgpu::TextureViewDescriptor::default());
+    let mut encoder = device.create_command_encoder(&wgpu::CommandEncoderDescriptor {
+        label: Some("ViewEffect Capture Texture Init"),
+    });
+    drop(encoder.begin_render_pass(&wgpu::RenderPassDescriptor {
+        label: Some("ViewEffect Capture Texture Init"),
+        color_attachments: &[Some(wgpu::RenderPassColorAttachment {
+            view: &view,
+            depth_slice: None,
+            resolve_target: None,
+            ops: wgpu::Operations {
+                load: wgpu::LoadOp::Clear(wgpu::Color::TRANSPARENT),
+                store: wgpu::StoreOp::Store,
+            },
+        })],
+        depth_stencil_attachment: None,
+        timestamp_writes: None,
+        occlusion_query_set: None,
+        multiview_mask: None,
+    }));
+    queue.submit([encoder.finish()]);
+    texture
+}

--- a/ffi/src/components/visual/gpu_surface.rs
+++ b/ffi/src/components/visual/gpu_surface.rs
@@ -224,6 +224,23 @@ pub struct WuiGpuCaptureFence {
     submission: wgpu::SubmissionIndex,
 }
 
+impl WuiGpuCaptureFence {
+    /// Wraps one queue submission as the token native waits on.
+    ///
+    /// Every external capture path ends here, whichever platform primitive it
+    /// started from, so `waterui_gpu_capture_fence_on_complete` is the one way a
+    /// backend learns that the GPU is finished with the memory it lent us.
+    pub(crate) const fn new(
+        completion_driver: GpuSubmissionCompletionDriver,
+        submission: wgpu::SubmissionIndex,
+    ) -> Self {
+        Self {
+            completion_driver,
+            submission,
+        }
+    }
+}
+
 /// Completion function invoked after an external GPU capture submission.
 pub type WuiGpuCaptureCompletionCallback = unsafe extern "C" fn(context: *mut c_void);
 
@@ -1016,10 +1033,10 @@ pub unsafe extern "C" fn waterui_gpu_surface_render_to_metal_texture(
         state.redraw_handle.request_redraw();
     }
     let submission = state.runtime.context().queue.submit([]);
-    Box::into_raw(Box::new(WuiGpuCaptureFence {
-        completion_driver: state.runtime.context().submission_completion_driver(),
+    Box::into_raw(Box::new(WuiGpuCaptureFence::new(
+        state.runtime.context().submission_completion_driver(),
         submission,
-    }))
+    )))
 }
 
 /// Schedules one external capture submission completion and consumes its fence.
@@ -1031,8 +1048,11 @@ pub unsafe extern "C" fn waterui_gpu_surface_render_to_metal_texture(
 ///
 /// # Safety
 ///
-/// `fence` must be a valid owning pointer returned by
-/// [`waterui_gpu_surface_render_to_metal_texture`] and must be consumed once.
+/// `fence` must be a valid owning pointer returned by an external capture entry
+/// point — `waterui_gpu_surface_render_to_metal_texture` on Apple,
+/// `waterui_applied_filter_set_capture_hardware_buffer` or
+/// `waterui_view_effect_set_input_hardware_buffer` on Android — and must be
+/// consumed once.
 /// `context`, `callback`, and `drop` must remain valid until completion; Rust
 /// consumes the context and releases it through `drop`.
 #[unsafe(no_mangle)]

--- a/ffi/src/components/visual/gpu_surface.rs
+++ b/ffi/src/components/visual/gpu_surface.rs
@@ -230,6 +230,15 @@ impl WuiGpuCaptureFence {
     /// Every external capture path ends here, whichever platform primitive it
     /// started from, so `waterui_gpu_capture_fence_on_complete` is the one way a
     /// backend learns that the GPU is finished with the memory it lent us.
+    // Only the platforms with an external capture path produce a fence: Metal
+    // on Apple, `AHardwareBuffer` on Android. Elsewhere the type is consumed by
+    // `waterui_gpu_capture_fence_on_complete` alone, so a constructor would be
+    // dead code.
+    #[cfg(any(
+        target_os = "macos",
+        target_os = "ios",
+        all(target_os = "android", feature = "gpu")
+    ))]
     pub(crate) const fn new(
         completion_driver: GpuSubmissionCompletionDriver,
         submission: wgpu::SubmissionIndex,

--- a/ffi/src/components/visual/gpu_surface.rs
+++ b/ffi/src/components/visual/gpu_surface.rs
@@ -99,6 +99,15 @@ pub struct WuiGpuSurfaceState {
     config: Option<wgpu::SurfaceConfiguration>,
     /// The format selected when asynchronous renderer setup starts.
     renderer_format: Cell<Option<wgpu::TextureFormat>>,
+    /// Where this surface's frame is drawn when an enclosing capture wants it.
+    ///
+    /// Android's HWUI records a `SurfaceView` as a cleared hole, so a surface
+    /// inside a filtered or effected subtree is missing from that subtree's
+    /// captured buffer and is drawn into it from here instead. Kept across
+    /// frames and reallocated only when the size or the renderer's format
+    /// changes.
+    #[cfg(target_os = "android")]
+    composite_texture: Option<wgpu::Texture>,
     /// Becomes true only after the local setup future has completed.
     setup_ready: Rc<Cell<bool>>,
     /// Maximum MSAA sample count requested by the public `GpuSurface` API.
@@ -577,6 +586,8 @@ pub unsafe extern "C" fn waterui_gpu_surface_create(
         runtime,
         wgpu_surface: None,
         renderer_format: Cell::new(None),
+        #[cfg(target_os = "android")]
+        composite_texture: None,
         setup_ready: Rc::new(Cell::new(false)),
         msaa_max_samples,
         config: None,
@@ -1017,14 +1028,54 @@ pub unsafe extern "C" fn waterui_gpu_surface_render_to_metal_texture(
         format: Some(target_format),
         ..Default::default()
     });
-    let (elapsed, delta) = advance_frame_timing(state);
-
-    let mut frame = GpuFrame::new(
-        &state.runtime.context().device,
-        &state.runtime.context().queue,
+    render_into_texture(
+        state,
         &wgpu_texture,
         view,
         target_format,
+        width,
+        height,
+        scale,
+    );
+    let submission = state.runtime.context().queue.submit([]);
+    Box::into_raw(Box::new(WuiGpuCaptureFence::new(
+        state.runtime.context().submission_completion_driver(),
+        submission,
+    )))
+}
+
+/// Renders one frame of the semantic GPU view into a texture it does not own.
+///
+/// Every path that captures a surface into foreign memory ends here: Apple's
+/// imported `MTLTexture` and Android's compositing of a surface nested inside a
+/// captured subtree both hand in a texture of the renderer's established format
+/// and take whatever the renderer draws into it. The redraw bookkeeping is a
+/// presented frame's, so a renderer that asks for another frame from inside its
+/// own draw is woken the same way whether it was presenting or being captured.
+///
+/// Nothing is submitted here: the renderer submits its own work, and the caller
+/// decides what the frame is ordered against.
+///
+/// # Panics
+///
+/// Panics if the renderer's asynchronous setup has not completed.
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
+pub(super) fn render_into_texture(
+    state: &mut WuiGpuSurfaceState,
+    texture: &wgpu::Texture,
+    view: wgpu::TextureView,
+    format: wgpu::TextureFormat,
+    width: u32,
+    height: u32,
+    scale: f64,
+) {
+    let (elapsed, delta) = advance_frame_timing(state);
+    let mut frame = GpuFrame::new(
+        &state.runtime.context().device,
+        &state.runtime.context().queue,
+        texture,
+        view,
+        format,
         width,
         height,
         scale,
@@ -1041,11 +1092,82 @@ pub unsafe extern "C" fn waterui_gpu_surface_render_to_metal_texture(
     if frame.was_redraw_requested() || state.redraw_handle.take_dirty() {
         state.redraw_handle.request_redraw();
     }
-    let submission = state.runtime.context().queue.submit([]);
-    Box::into_raw(Box::new(WuiGpuCaptureFence::new(
-        state.runtime.context().submission_completion_driver(),
-        submission,
-    )))
+}
+
+/// The GPU runtime this surface renders on, for a caller that needs its own
+/// handle on the device and queue while the surface state is borrowed.
+#[cfg(target_os = "android")]
+pub(super) fn composite_runtime(state: &WuiGpuSurfaceState) -> GpuRuntime {
+    state.runtime.clone()
+}
+
+/// Renders this surface's next frame into the texture a capture reads it from.
+///
+/// The returned texture holds one frame of the semantic GPU view at
+/// `width`x`height` in the renderer's established format, ready to be drawn
+/// into the enclosing capture's texture. It belongs to this state and is reused
+/// for every frame of the same size.
+///
+/// # Panics
+///
+/// Panics if the renderer has no established format yet — a surface that has
+/// never been attached has drawn nothing and cannot be composited — or if its
+/// asynchronous setup has not completed.
+#[cfg(target_os = "android")]
+pub(super) fn render_composite_source(
+    state: &mut WuiGpuSurfaceState,
+    width: u32,
+    height: u32,
+    scale: f64,
+) -> &wgpu::Texture {
+    assert!(
+        width > 0 && height > 0,
+        "GpuSurface composite source must be non-zero, got {width}x{height}"
+    );
+    let format = state
+        .renderer_format
+        .get()
+        .expect("GpuSurface cannot be composited into a capture before it has been attached once");
+    let matches_request = state.composite_texture.as_ref().is_some_and(|texture| {
+        texture.width() == width && texture.height() == height && texture.format() == format
+    });
+    if !matches_request {
+        state.composite_texture = Some(state.runtime.context().device.create_texture(
+            &wgpu::TextureDescriptor {
+                label: Some("GpuSurface Composite Source"),
+                size: wgpu::Extent3d {
+                    width,
+                    height,
+                    depth_or_array_layers: 1,
+                },
+                mip_level_count: 1,
+                sample_count: 1,
+                dimension: wgpu::TextureDimension::D2,
+                format,
+                usage: wgpu::TextureUsages::RENDER_ATTACHMENT
+                    | wgpu::TextureUsages::TEXTURE_BINDING,
+                view_formats: &[],
+            },
+        ));
+    }
+
+    // Lent out for the render so the renderer's own `&mut` borrow of the state
+    // and the texture do not overlap, then returned to its slot.
+    let texture = state
+        .composite_texture
+        .take()
+        .expect("GpuSurface composite source was just ensured");
+    let view = texture.create_view(&wgpu::TextureViewDescriptor {
+        label: Some("GpuSurface Composite Source View"),
+        format: Some(format),
+        ..Default::default()
+    });
+    render_into_texture(state, &texture, view, format, width, height, scale);
+    state.composite_texture = Some(texture);
+    state
+        .composite_texture
+        .as_ref()
+        .expect("GpuSurface composite source was just returned")
 }
 
 /// Schedules one external capture submission completion and consumes its fence.

--- a/ffi/src/components/visual/hardware_buffer.rs
+++ b/ffi/src/components/visual/hardware_buffer.rs
@@ -504,15 +504,17 @@ pub unsafe fn copy_hardware_buffer_into_texture(
         unsafe { guard.raw_handle() }
     };
 
-    let mut encoder = gpu
+    // wgpu refuses to mix its own commands with raw HAL recording in one encoder,
+    // so the frame is two: the first carries wgpu's barrier into `COPY_DST`, from
+    // whatever state it is tracking, and records that new state so the layout the
+    // raw commands leave the image in is the layout wgpu expects next time; the
+    // second is recorded through the HAL alone. One submit keeps them in order.
+    let mut transition = gpu
         .device
         .create_command_encoder(&wgpu::CommandEncoderDescriptor {
-            label: Some("WaterUI Android Capture Copy"),
+            label: Some("WaterUI Android Capture Transition"),
         });
-    // wgpu's own barrier into `COPY_DST`, from whatever state it is tracking. It
-    // records the new state too, so the layout the raw commands below leave the
-    // image in is the layout wgpu expects to find it in next time.
-    encoder.transition_resources(
+    transition.transition_resources(
         core::iter::empty(),
         core::iter::once(wgpu::TextureTransition {
             texture: destination,
@@ -520,6 +522,11 @@ pub unsafe fn copy_hardware_buffer_into_texture(
             state: wgpu::TextureUses::COPY_DST,
         }),
     );
+    let mut encoder = gpu
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("WaterUI Android Capture Copy"),
+        });
     // SAFETY: the callback only records into the encoder's active command buffer
     // and never ends it, which is `as_hal_mut`'s contract, and the wgpu encoder is
     // untouched for the duration of the callback.
@@ -542,7 +549,7 @@ pub unsafe fn copy_hardware_buffer_into_texture(
         });
     }
 
-    let submission = gpu.queue.submit([encoder.finish()]);
+    let submission = gpu.queue.submit([transition.finish(), encoder.finish()]);
     Box::into_raw(Box::new(WuiGpuCaptureFence::new(
         gpu.submission_completion_driver(),
         submission,

--- a/ffi/src/components/visual/hardware_buffer.rs
+++ b/ffi/src/components/visual/hardware_buffer.rs
@@ -1,0 +1,664 @@
+//! Android view capture: `AHardwareBuffer` to Vulkan external memory to wgpu.
+//!
+//! Android's answer to Apple's `CARenderer`-into-an-`MTLTexture` capture is
+//! `HardwareRenderer` drawing a `RenderNode` into an `ImageReader`, which hands
+//! back an `AHardwareBuffer`. This module is what turns that buffer into pixels
+//! the filter pipeline can sample, without ever taking them through the CPU.
+//!
+//! # Why the buffer is imported as a raw `VkImage` and copied
+//!
+//! The obvious shape — import the buffer as a `wgpu::Texture` through
+//! `Device::create_texture_from_hal` and sample it directly — is wrong, and
+//! quietly so. `wgpu-core` records every texture created that way with an
+//! initial tracked state of `TextureUses::UNINITIALIZED`, so the first barrier
+//! it emits for one is `VK_IMAGE_LAYOUT_UNDEFINED` to `SHADER_READ_ONLY_OPTIMAL`
+//! with no queue-family acquire — a transition Vulkan explicitly permits an
+//! implementation to satisfy by *discarding* the image's contents. On a tiler
+//! that is exactly what happens, and the filter samples an empty capture.
+//!
+//! So the imported buffer is never a wgpu texture. It is a raw `vk::Image` bound
+//! to imported memory, acquired from `VK_QUEUE_FAMILY_FOREIGN_EXT`, copied into
+//! the wgpu-owned capture texture with `vkCmdCopyImage`, and released back to the
+//! framework — one GPU-side copy of the subtree per captured frame, no readback.
+//!
+//! # How the copy stays truthful to wgpu's tracker
+//!
+//! The copy is recorded into a real `wgpu::CommandEncoder` through
+//! [`wgpu::CommandEncoder::as_hal_mut`], not into a private command pool
+//! submitted by hand. Two things fall out of that, both load-bearing:
+//!
+//! - The destination's layout is established by
+//!   [`wgpu::CommandEncoder::transition_resources`] — wgpu's documented
+//!   native-interoperability API — rather than assumed. wgpu emits the barrier
+//!   from whatever state it is actually tracking (`COLOR_TARGET` on the frame
+//!   after the texture was created, `RESOURCE` on every frame after the filter
+//!   sampled it) into `COPY_DST`, and records `COPY_DST` as the new truth. The
+//!   raw copy therefore finds the image in `TRANSFER_DST_OPTIMAL` and leaves it
+//!   there, matching what wgpu believes on every frame.
+//! - The submission is wgpu's own, so the [`WuiGpuCaptureFence`] handed back to
+//!   the backend carries a real `wgpu::SubmissionIndex` and the existing
+//!   completion machinery resolves it exactly. A separate `vkQueueSubmit` could
+//!   not: Vulkan gives no guarantee that a later submission's fence implies an
+//!   earlier one finished.
+
+use alloc::boxed::Box;
+use alloc::vec::Vec;
+use core::ffi::c_void;
+
+use ash::vk;
+use ndk_sys::AHardwareBuffer;
+use waterui_graphics::shared_context::{GpuRuntime, drain_device_before_teardown};
+use wgpu_hal::api::Vulkan;
+
+use super::capture_format::{WuiCaptureFormat, capture_buffer_format};
+use super::gpu_surface::WuiGpuCaptureFence;
+
+/// `AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM` as the plain `u32` a descriptor holds.
+const BUFFER_FORMAT_RGBA_8888: u32 =
+    ndk_sys::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM.0;
+/// `AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT`, likewise.
+const BUFFER_FORMAT_RGBA_FP16: u32 =
+    ndk_sys::AHardwareBuffer_Format::AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT.0;
+
+/// The size and layout of one `AHardwareBuffer`, as the framework describes it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct HardwareBufferDescription {
+    /// Buffer width in pixels.
+    pub width: u32,
+    /// Buffer height in pixels.
+    pub height: u32,
+    /// The buffer's pixel layout.
+    pub format: WuiCaptureFormat,
+}
+
+/// Reads back the size and layout of a hardware buffer.
+///
+/// # Safety
+///
+/// `buffer` must be a live `AHardwareBuffer` for the duration of this call.
+///
+/// # Panics
+///
+/// Panics when the buffer's layout is not one `WaterUI` captures into, which means
+/// the backend allocated its `ImageReader` with a format
+/// [`capture_buffer_format`] never asked for.
+#[must_use]
+pub unsafe fn describe_hardware_buffer(buffer: *mut AHardwareBuffer) -> HardwareBufferDescription {
+    assert!(
+        !buffer.is_null(),
+        "Android view capture was handed a null AHardwareBuffer"
+    );
+    let mut description = ndk_sys::AHardwareBuffer_Desc {
+        width: 0,
+        height: 0,
+        layers: 0,
+        format: 0,
+        usage: 0,
+        stride: 0,
+        rfu0: 0,
+        rfu1: 0,
+    };
+    // SAFETY: the caller contract keeps `buffer` alive for this call, and
+    // `description` is writable storage for exactly one descriptor.
+    unsafe { ndk_sys::AHardwareBuffer_describe(buffer, &raw mut description) };
+    let format = match description.format {
+        BUFFER_FORMAT_RGBA_8888 => WuiCaptureFormat::Rgba8Unorm,
+        BUFFER_FORMAT_RGBA_FP16 => WuiCaptureFormat::Rgba16Float,
+        other => panic!(
+            "Android view capture received an AHardwareBuffer in format {other}, which is neither \
+             RGBA_8888 nor RGBA_FP16"
+        ),
+    };
+    HardwareBufferDescription {
+        width: description.width,
+        height: description.height,
+        format,
+    }
+}
+
+/// Reads the `AHardwareBuffer` behind a Java `android.hardware.HardwareBuffer`.
+///
+/// The returned pointer is borrowed from the Java object and is only valid while
+/// that object is alive and open; an import takes its own reference before
+/// keeping it.
+///
+/// # Safety
+///
+/// `env` and `hardware_buffer` must be the raw environment and the local
+/// reference of the JNI call currently on this thread.
+///
+/// # Panics
+///
+/// Panics when the object is not a `HardwareBuffer`, or has been closed.
+#[must_use]
+pub unsafe fn hardware_buffer_from_java(
+    env: *mut c_void,
+    hardware_buffer: *mut c_void,
+) -> *mut AHardwareBuffer {
+    // SAFETY: the caller contract makes both arguments valid for this call, which
+    // is all `AHardwareBuffer_fromHardwareBuffer` reads.
+    let buffer =
+        unsafe { ndk_sys::AHardwareBuffer_fromHardwareBuffer(env.cast(), hardware_buffer.cast()) };
+    assert!(
+        !buffer.is_null(),
+        "Android view capture was handed a HardwareBuffer that is not backed by an AHardwareBuffer"
+    );
+    buffer
+}
+
+/// The whole of a 2D colour image, as every barrier here addresses it.
+const COLOR_SUBRESOURCE: vk::ImageSubresourceRange = vk::ImageSubresourceRange {
+    aspect_mask: vk::ImageAspectFlags::COLOR,
+    base_mip_level: 0,
+    level_count: 1,
+    base_array_layer: 0,
+    layer_count: 1,
+};
+
+/// The same subresource, spelled the way `vkCmdCopyImage` wants it.
+const COLOR_LAYERS: vk::ImageSubresourceLayers = vk::ImageSubresourceLayers {
+    aspect_mask: vk::ImageAspectFlags::COLOR,
+    mip_level: 0,
+    base_array_layer: 0,
+    layer_count: 1,
+};
+
+/// How many distinct buffers one capture target keeps imported at a time.
+///
+/// An `ImageReader` rotates a small fixed set of buffers, so the same handful of
+/// pointers come back frame after frame and importing each once is the whole of
+/// the caching story. This cap is well above any `maxImages` a capture would be
+/// configured with; reaching it means the backend is rotating more buffers than
+/// expected, and the least recently used import is evicted rather than letting
+/// the list grow without bound.
+const MAX_CACHED_IMPORTS: usize = 8;
+
+/// One `AHardwareBuffer` imported as a raw Vulkan image.
+///
+/// The import holds a reference on the buffer for as long as it lives, so the
+/// pointer it is keyed by stays valid and cannot be reused for a different
+/// allocation underneath the cache.
+struct ImportedHardwareBuffer {
+    /// The device the image and its memory belong to. `ash::Device` is a handle
+    /// plus a function table, so this clone costs nothing and lets [`Drop`]
+    /// destroy them without reaching back through wgpu.
+    device: ash::Device,
+    /// The acquired buffer, released when this import is dropped.
+    buffer: *mut AHardwareBuffer,
+    /// The image bound to the buffer's imported memory.
+    image: vk::Image,
+    /// The imported memory the image is bound to.
+    memory: vk::DeviceMemory,
+    /// What the buffer was when it was imported. A buffer whose description no
+    /// longer matches is a different capture and gets a fresh import.
+    description: HardwareBufferDescription,
+}
+
+impl Drop for ImportedHardwareBuffer {
+    fn drop(&mut self) {
+        // SAFETY: both handles were created by this device in `import`, are owned
+        // solely by this value, and every path that drops an import has drained
+        // the device first, so no submission still reads them. `Drop` runs once,
+        // so each is destroyed once.
+        unsafe {
+            self.device.destroy_image(self.image, None);
+            self.device.free_memory(self.memory, None);
+            ndk_sys::AHardwareBuffer_release(self.buffer);
+        }
+    }
+}
+
+impl ImportedHardwareBuffer {
+    /// Imports `buffer` as a `VkImage` bound to its memory.
+    ///
+    /// # Safety
+    ///
+    /// `buffer` must be a live `AHardwareBuffer` for the duration of this call.
+    ///
+    /// # Panics
+    ///
+    /// Panics when the device was opened without the import extension, when the
+    /// driver refuses the buffer, or when image creation, allocation or binding
+    /// fails.
+    unsafe fn import(
+        device: &wgpu_hal::vulkan::Device,
+        buffer: *mut AHardwareBuffer,
+        description: HardwareBufferDescription,
+        context: &'static str,
+    ) -> Self {
+        let raw_device = device.raw_device();
+        let instance = device.shared_instance().raw_instance();
+        let extension = ash::android::external_memory_android_hardware_buffer::NAME;
+        assert!(
+            device.enabled_device_extensions().contains(&extension),
+            "{context}: the GPU device was opened without {}, so a captured view subtree cannot \
+             be imported",
+            extension.to_string_lossy()
+        );
+        let external_memory = ash::android::external_memory_android_hardware_buffer::Device::new(
+            instance, raw_device,
+        );
+
+        let mut format_properties = vk::AndroidHardwareBufferFormatPropertiesANDROID::default();
+        let (memory_type_bits, allocation_size) = {
+            let mut properties = vk::AndroidHardwareBufferPropertiesANDROID::default()
+                .push_next(&mut format_properties);
+            // SAFETY: the caller contract keeps `buffer` alive, and `properties` is
+            // writable storage chained to `format_properties` for this call only.
+            unsafe {
+                external_memory.get_android_hardware_buffer_properties(
+                    buffer.cast::<c_void>().cast_const(),
+                    &mut properties,
+                )
+            }
+            .unwrap_or_else(|error| {
+                panic!("{context}: the driver rejected the captured AHardwareBuffer: {error}")
+            });
+            (properties.memory_type_bits, properties.allocation_size)
+        };
+        // Read once the chained query above has released its borrow: the driver
+        // names the format the image must be created with, and it is the only
+        // format the import is allowed to claim.
+        let vk_format = format_properties.format;
+
+        let mut external_info = vk::ExternalMemoryImageCreateInfo::default()
+            .handle_types(vk::ExternalMemoryHandleTypeFlags::ANDROID_HARDWARE_BUFFER_ANDROID);
+        let image_info = vk::ImageCreateInfo::default()
+            .image_type(vk::ImageType::TYPE_2D)
+            .format(vk_format)
+            .extent(vk::Extent3D {
+                width: description.width,
+                height: description.height,
+                depth: 1,
+            })
+            .mip_levels(1)
+            .array_layers(1)
+            .samples(vk::SampleCountFlags::TYPE_1)
+            .tiling(vk::ImageTiling::OPTIMAL)
+            .usage(vk::ImageUsageFlags::TRANSFER_SRC)
+            .sharing_mode(vk::SharingMode::EXCLUSIVE)
+            .initial_layout(vk::ImageLayout::UNDEFINED)
+            .push_next(&mut external_info);
+        // SAFETY: `image_info` and everything chained onto it live until this call
+        // returns, and the image it creates is owned by the value built below.
+        let image = unsafe { raw_device.create_image(&image_info, None) }.unwrap_or_else(|error| {
+            panic!("{context}: could not create the image for a captured AHardwareBuffer: {error}")
+        });
+
+        let memory_type_index = external_memory_type_index(
+            instance,
+            device.raw_physical_device(),
+            memory_type_bits,
+            context,
+        );
+        let mut dedicated = vk::MemoryDedicatedAllocateInfo::default().image(image);
+        let mut import_info =
+            vk::ImportAndroidHardwareBufferInfoANDROID::default().buffer(buffer.cast::<c_void>());
+        let allocate_info = vk::MemoryAllocateInfo::default()
+            .allocation_size(allocation_size)
+            .memory_type_index(memory_type_index)
+            .push_next(&mut dedicated)
+            .push_next(&mut import_info);
+        // SAFETY: `allocate_info` and its chain live until this call returns, and
+        // the buffer it imports stays alive because the caller holds it for this
+        // call and the acquire below takes a reference of our own.
+        let memory =
+            unsafe { raw_device.allocate_memory(&allocate_info, None) }.unwrap_or_else(|error| {
+                // SAFETY: `image` was created just above and nothing else owns it.
+                unsafe { raw_device.destroy_image(image, None) };
+                panic!(
+                    "{context}: could not import the memory of a captured AHardwareBuffer: {error}"
+                )
+            });
+        // SAFETY: the image was created for exactly this dedicated allocation, and
+        // neither has been bound before.
+        unsafe { raw_device.bind_image_memory(image, memory, 0) }.unwrap_or_else(|error| {
+            panic!("{context}: could not bind a captured AHardwareBuffer to its image: {error}")
+        });
+
+        // The import outlives the Java `HardwareBuffer` it came from, so it holds
+        // its own reference for as long as the image is bound to it.
+        // SAFETY: the caller contract keeps `buffer` alive for this call, which is
+        // when the reference is taken; `Drop` releases it once.
+        unsafe { ndk_sys::AHardwareBuffer_acquire(buffer) };
+
+        tracing::debug!(
+            context,
+            width = description.width,
+            height = description.height,
+            format = ?description.format,
+            "imported an Android capture buffer as a Vulkan image"
+        );
+
+        Self {
+            device: raw_device.clone(),
+            buffer,
+            image,
+            memory,
+            description,
+        }
+    }
+}
+
+/// The imports one capture target is holding.
+pub struct HardwareBufferImports {
+    /// The runtime whose device the imports belong to. Held so they can be
+    /// destroyed after the work that reads them, including from [`Drop`], where
+    /// there is no caller left to hand a device in.
+    runtime: GpuRuntime,
+    /// Most recently used last.
+    imports: Vec<ImportedHardwareBuffer>,
+}
+
+impl Drop for HardwareBufferImports {
+    fn drop(&mut self) {
+        self.clear();
+    }
+}
+
+impl core::fmt::Debug for HardwareBufferImports {
+    fn fmt(&self, formatter: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        formatter
+            .debug_struct("HardwareBufferImports")
+            .field("runtime", &self.runtime)
+            .field("imports", &self.imports.len())
+            .finish()
+    }
+}
+
+impl HardwareBufferImports {
+    /// An empty cache on `runtime`'s device, holding no buffer.
+    #[must_use]
+    pub const fn new(runtime: GpuRuntime) -> Self {
+        Self {
+            runtime,
+            imports: Vec::new(),
+        }
+    }
+
+    /// Releases every import, after waiting for the work that reads them.
+    ///
+    /// The imported images are raw Vulkan objects wgpu knows nothing about, so
+    /// nothing else defers their destruction until the GPU is done with them.
+    /// Called when a capture target detaches or is destroyed, which are the only
+    /// moments this costs a wait — and it costs nothing when nothing is cached.
+    pub fn clear(&mut self) {
+        if self.imports.is_empty() {
+            return;
+        }
+        drain_device_before_teardown(&self.runtime.context().device);
+        self.imports.clear();
+    }
+
+    /// The image for `buffer`, importing it the first time it is seen.
+    ///
+    /// # Safety
+    ///
+    /// `buffer` must be a live `AHardwareBuffer` for the duration of this call.
+    unsafe fn get_or_import(
+        &mut self,
+        device: &wgpu_hal::vulkan::Device,
+        buffer: *mut AHardwareBuffer,
+        description: HardwareBufferDescription,
+        context: &'static str,
+    ) -> vk::Image {
+        if let Some(index) = self.imports.iter().position(|import| {
+            core::ptr::eq(import.buffer, buffer) && import.description == description
+        }) {
+            let import = self.imports.remove(index);
+            let image = import.image;
+            self.imports.push(import);
+            return image;
+        }
+
+        // A buffer whose pointer is already cached but whose description changed
+        // is a different capture in the same slot, and its stale import — like any
+        // import evicted for the cap — may still be read by work in flight.
+        let stale = self
+            .imports
+            .iter()
+            .position(|import| core::ptr::eq(import.buffer, buffer));
+        let evicted = stale.or_else(|| (self.imports.len() >= MAX_CACHED_IMPORTS).then_some(0));
+        if let Some(index) = evicted {
+            drain_device_before_teardown(&self.runtime.context().device);
+            drop(self.imports.remove(index));
+        }
+
+        // SAFETY: forwarding the caller's contract that `buffer` is live; `import`
+        // acquires its own reference before returning.
+        let import =
+            unsafe { ImportedHardwareBuffer::import(device, buffer, description, context) };
+        let image = import.image;
+        self.imports.push(import);
+        image
+    }
+}
+
+/// Copies a captured hardware buffer into a wgpu texture on the GPU.
+///
+/// Returns the fence for the submission that performs the copy: the backend
+/// registers a completion on it with `waterui_gpu_capture_fence_on_complete` and
+/// closes the `Image` the buffer came from only once that fires, because until
+/// then the GPU is still reading it.
+///
+/// # Safety
+///
+/// `buffer` must be a live `AHardwareBuffer` for the duration of this call.
+///
+/// # Panics
+///
+/// Panics when the buffer's size or layout does not match `destination`, when the
+/// device is not the Vulkan backend, or when any Vulkan call in the import fails.
+pub unsafe fn copy_hardware_buffer_into_texture(
+    imports: &mut HardwareBufferImports,
+    buffer: *mut AHardwareBuffer,
+    destination: &wgpu::Texture,
+    context: &'static str,
+) -> *mut WuiGpuCaptureFence {
+    // SAFETY: forwarding the caller's own contract that `buffer` is live.
+    let description = unsafe { describe_hardware_buffer(buffer) };
+    assert_eq!(
+        (description.width, description.height),
+        (destination.width(), destination.height()),
+        "{context}: the captured buffer is {}x{} but the capture texture is {}x{}",
+        description.width,
+        description.height,
+        destination.width(),
+        destination.height()
+    );
+    assert_eq!(
+        description.format,
+        capture_buffer_format(destination.format()),
+        "{context}: the captured buffer's layout does not match the capture texture's format"
+    );
+
+    // Cloned rather than borrowed out of `imports`, which the import below takes
+    // exclusively; it is one `Arc` bump.
+    let runtime = imports.runtime.clone();
+    let gpu = runtime.context();
+    let (raw_device, family_index, source) = {
+        // SAFETY: the HAL device is only borrowed to read its raw handles and to
+        // create the import's own image and memory; it is never destroyed here.
+        let hal_device = unsafe { gpu.device.as_hal::<Vulkan>() }.unwrap_or_else(|| {
+            panic!("{context}: Android view capture requires the Vulkan backend")
+        });
+        // SAFETY: forwarding the caller's contract that `buffer` is live; the
+        // import acquires its own reference on it.
+        let source = unsafe { imports.get_or_import(&hal_device, buffer, description, context) };
+        (
+            hal_device.raw_device().clone(),
+            hal_device.queue_family_index(),
+            source,
+        )
+    };
+
+    // Scoped: the texture guard holds the device's snatchable read lock, and
+    // every wgpu call below wants it too.
+    let destination_image = {
+        // SAFETY: the destination is a texture of this device, so its HAL type is
+        // `Vulkan`; the guard only reads it.
+        let guard = unsafe { destination.as_hal::<Vulkan>() }
+            .unwrap_or_else(|| panic!("{context}: the capture texture is not a Vulkan texture"));
+        // SAFETY: the handle is only recorded into a command buffer below, never
+        // destroyed, and the texture that owns it outlives this call.
+        unsafe { guard.raw_handle() }
+    };
+
+    let mut encoder = gpu
+        .device
+        .create_command_encoder(&wgpu::CommandEncoderDescriptor {
+            label: Some("WaterUI Android Capture Copy"),
+        });
+    // wgpu's own barrier into `COPY_DST`, from whatever state it is tracking. It
+    // records the new state too, so the layout the raw commands below leave the
+    // image in is the layout wgpu expects to find it in next time.
+    encoder.transition_resources(
+        core::iter::empty(),
+        core::iter::once(wgpu::TextureTransition {
+            texture: destination,
+            selector: None,
+            state: wgpu::TextureUses::COPY_DST,
+        }),
+    );
+    // SAFETY: the callback only records into the encoder's active command buffer
+    // and never ends it, which is `as_hal_mut`'s contract, and the wgpu encoder is
+    // untouched for the duration of the callback.
+    unsafe {
+        encoder.as_hal_mut::<Vulkan, _, ()>(|hal_encoder| {
+            let hal_encoder = hal_encoder.unwrap_or_else(|| {
+                panic!("{context}: the command encoder is not a Vulkan encoder")
+            });
+            // SAFETY: the command buffer is the encoder's own, recorded into and
+            // never destroyed here.
+            let command_buffer = hal_encoder.raw_handle();
+            record_capture_copy(
+                &raw_device,
+                command_buffer,
+                family_index,
+                source,
+                destination_image,
+                description,
+            );
+        });
+    }
+
+    let submission = gpu.queue.submit([encoder.finish()]);
+    Box::into_raw(Box::new(WuiGpuCaptureFence::new(
+        gpu.submission_completion_driver(),
+        submission,
+    )))
+}
+
+/// Records the acquire, copy and release for one captured frame.
+///
+/// The image arrives owned by `VK_QUEUE_FAMILY_FOREIGN_EXT` — the Android
+/// framework rendered into it — and is handed straight back there afterwards so
+/// the next producer can take it. An `AHardwareBuffer`-backed image keeps its
+/// contents across an acquire out of `VK_IMAGE_LAYOUT_UNDEFINED`, which is what
+/// makes this the standard import pattern rather than a discard.
+fn record_capture_copy(
+    device: &ash::Device,
+    command_buffer: vk::CommandBuffer,
+    family_index: u32,
+    source: vk::Image,
+    destination: vk::Image,
+    description: HardwareBufferDescription,
+) {
+    let acquire = vk::ImageMemoryBarrier::default()
+        .src_access_mask(vk::AccessFlags::empty())
+        .dst_access_mask(vk::AccessFlags::TRANSFER_READ)
+        .old_layout(vk::ImageLayout::UNDEFINED)
+        .new_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .src_queue_family_index(vk::QUEUE_FAMILY_FOREIGN_EXT)
+        .dst_queue_family_index(family_index)
+        .image(source)
+        .subresource_range(COLOR_SUBRESOURCE);
+    // SAFETY: `command_buffer` is in the recording state — wgpu is mid-encode —
+    // and every handle named here belongs to `device`.
+    unsafe {
+        device.cmd_pipeline_barrier(
+            command_buffer,
+            vk::PipelineStageFlags::TOP_OF_PIPE,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::DependencyFlags::empty(),
+            &[],
+            &[],
+            &[acquire],
+        );
+    }
+
+    let region = vk::ImageCopy::default()
+        .src_subresource(COLOR_LAYERS)
+        .dst_subresource(COLOR_LAYERS)
+        .extent(vk::Extent3D {
+            width: description.width,
+            height: description.height,
+            depth: 1,
+        });
+    // SAFETY: both images are in the layouts named, the region covers an extent
+    // both cover, and their formats are size-compatible — they differ at most in
+    // sRGB encoding, which `vkCmdCopyImage` does not interpret.
+    unsafe {
+        device.cmd_copy_image(
+            command_buffer,
+            source,
+            vk::ImageLayout::TRANSFER_SRC_OPTIMAL,
+            destination,
+            vk::ImageLayout::TRANSFER_DST_OPTIMAL,
+            &[region],
+        );
+    }
+
+    // A release may not name `VK_IMAGE_LAYOUT_UNDEFINED`, so the image is handed
+    // back in `GENERAL`, which any consumer can acquire from.
+    let release = vk::ImageMemoryBarrier::default()
+        .src_access_mask(vk::AccessFlags::TRANSFER_READ)
+        .dst_access_mask(vk::AccessFlags::empty())
+        .old_layout(vk::ImageLayout::TRANSFER_SRC_OPTIMAL)
+        .new_layout(vk::ImageLayout::GENERAL)
+        .src_queue_family_index(family_index)
+        .dst_queue_family_index(vk::QUEUE_FAMILY_FOREIGN_EXT)
+        .image(source)
+        .subresource_range(COLOR_SUBRESOURCE);
+    // SAFETY: as for the acquire above.
+    unsafe {
+        device.cmd_pipeline_barrier(
+            command_buffer,
+            vk::PipelineStageFlags::TRANSFER,
+            vk::PipelineStageFlags::BOTTOM_OF_PIPE,
+            vk::DependencyFlags::empty(),
+            &[],
+            &[],
+            &[release],
+        );
+    }
+}
+
+/// A memory type that can back an imported hardware buffer.
+///
+/// The driver answers with a mask of every type the buffer may be imported into;
+/// any of them is valid, so the lowest is taken.
+///
+/// # Panics
+///
+/// Panics when the driver reports no usable memory type, which means the buffer
+/// cannot be imported on this device at all.
+fn external_memory_type_index(
+    instance: &ash::Instance,
+    physical_device: vk::PhysicalDevice,
+    memory_type_bits: u32,
+    context: &'static str,
+) -> u32 {
+    // SAFETY: `physical_device` belongs to `instance`, and the properties are
+    // returned by value.
+    let memory_properties =
+        unsafe { instance.get_physical_device_memory_properties(physical_device) };
+    (0..memory_properties.memory_type_count)
+        .find(|index| memory_type_bits & (1 << index) != 0)
+        .unwrap_or_else(|| {
+            panic!(
+                "{context}: the driver reports no memory type that can back a captured \
+                 AHardwareBuffer"
+            )
+        })
+}

--- a/ffi/src/components/visual/mod.rs
+++ b/ffi/src/components/visual/mod.rs
@@ -2,6 +2,8 @@
 // the JNI bindings, which are compiled with `android-jni` and without `c-api`.
 #[cfg(feature = "gpu")]
 pub mod applied_filter;
+#[cfg(all(target_os = "android", feature = "gpu"))]
+pub mod capture_composite;
 #[cfg(feature = "gpu")]
 pub mod capture_format;
 #[cfg(feature = "gpu")]

--- a/ffi/src/components/visual/mod.rs
+++ b/ffi/src/components/visual/mod.rs
@@ -1,13 +1,19 @@
-#[cfg(all(feature = "c-api", feature = "gpu"))]
+// Gated on `gpu` alone, like `gpu_surface`: Android drives both of these through
+// the JNI bindings, which are compiled with `android-jni` and without `c-api`.
+#[cfg(feature = "gpu")]
 pub mod applied_filter;
+#[cfg(feature = "gpu")]
+pub mod capture_format;
 #[cfg(feature = "gpu")]
 pub mod gpu_runtime;
 #[cfg(feature = "gpu")]
 pub mod gpu_surface;
 #[cfg(feature = "gpu")]
 pub mod gpu_surface_input;
+#[cfg(all(target_os = "android", feature = "gpu"))]
+pub mod hardware_buffer;
 pub mod picture;
-#[cfg(all(feature = "c-api", feature = "gpu"))]
+#[cfg(feature = "gpu")]
 pub mod view_effect;
 pub mod view_renderer;
 

--- a/ffi/src/components/visual/view_effect.rs
+++ b/ffi/src/components/visual/view_effect.rs
@@ -20,8 +20,8 @@ use std::sync::Arc;
 
 use alloc::boxed::Box;
 use alloc::vec;
-// Only the Apple Metal input-import path drives asynchronous effect setup.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+// Only the platform input-import paths drive asynchronous effect setup.
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
 use executor_core::spawn_local;
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
@@ -33,7 +33,7 @@ use {
 
 use waterui_graphics::RedrawHandle;
 use waterui_graphics::shared_context::{GpuRuntime, reclaim_device};
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
 use waterui_graphics::view_effect::ViewEffectContext;
 use waterui_graphics::view_effect::{
     OutputSize, ViewEffectErased, ViewEffectInput, ViewEffectOutput,
@@ -166,7 +166,7 @@ struct ViewEffectRendererWrapper {
 }
 
 // Generate waterui_view_effect_id() and waterui_force_as_view_effect()
-ffi_view!(ViewEffectErased, WuiViewEffect, view_effect, all(), any());
+ffi_view!(ViewEffectErased, WuiViewEffect, view_effect);
 
 /// Opaque state held by the native backend after initialization.
 pub struct WuiViewEffectState {
@@ -196,6 +196,9 @@ pub struct WuiViewEffectState {
     output_height: u32,
     /// Output size configuration
     output_size: OutputSize,
+    /// Vulkan imports of the Android capture buffers handed to this effect.
+    #[cfg(target_os = "android")]
+    hardware_buffer_imports: super::hardware_buffer::HardwareBufferImports,
 }
 
 impl core::fmt::Debug for WuiViewEffectState {
@@ -246,6 +249,9 @@ pub unsafe extern "C" fn waterui_view_effect_create(
     // SAFETY: the caller contract requires `env` to be a valid handle alive for this
     // call; it is only borrowed.
     let runtime = super::gpu_runtime::gpu_runtime(&unsafe { &*env }.0);
+    #[cfg(target_os = "android")]
+    let hardware_buffer_imports =
+        super::hardware_buffer::HardwareBufferImports::new(runtime.clone());
     let redraw_handle = effect_wrapper.erased.redraw_handle();
     Box::into_raw(Box::new(WuiViewEffectState {
         runtime,
@@ -262,6 +268,8 @@ pub unsafe extern "C" fn waterui_view_effect_create(
         output_width: 0,
         output_height: 0,
         output_size,
+        #[cfg(target_os = "android")]
+        hardware_buffer_imports,
     }))
 }
 
@@ -383,6 +391,11 @@ pub unsafe extern "C" fn waterui_view_effect_detach(state: *mut WuiViewEffectSta
         .output_surface
         .take()
         .expect("waterui_view_effect_detach: output surface is already detached");
+    // Before the input texture goes: the imported buffers are raw Vulkan objects
+    // wgpu does not defer the destruction of, so they are released here rather
+    // than left to outlive the target they were captured for.
+    #[cfg(target_os = "android")]
+    state.hardware_buffer_imports.clear();
     state.output_config = None;
     state.imported_texture = None;
     state.imported_format = None;
@@ -422,9 +435,10 @@ pub unsafe extern "C" fn waterui_view_effect_set_redraw_callback(
 
 /// Validates and applies new input dimensions, resizing owned textures.
 ///
-/// Only reachable from the Apple Metal input-import entry point; every other
-/// platform feeds `ViewEffect` through the Rust-side filter pipeline.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+/// Only reachable from the platform input-import entry points — the Apple Metal
+/// one and the Android hardware-buffer one; every other platform feeds
+/// `ViewEffect` through the Rust-side filter pipeline.
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
 fn ensure_dimensions(state: &mut WuiViewEffectState, width: u32, height: u32) {
     assert!(
         width > 0 && height > 0,
@@ -496,6 +510,98 @@ pub unsafe extern "C" fn waterui_view_effect_set_input_metal_texture(
         .imported_format
         .expect("ViewEffect Metal input import did not provide a texture format");
     start_view_effect_setup(state, input_format);
+}
+
+/// Copies a captured `AHardwareBuffer` into the effect's input (Android only).
+///
+/// The buffer is the one `HardwareRenderer` drew the effect's child subtree
+/// into. The effect keeps a wgpu texture of that buffer's size and layout —
+/// created once per size, and cleared so wgpu counts it as written — which the
+/// import is copied into on the GPU. The returned fence is what tells the
+/// backend the copy is finished, so it must be consumed by
+/// `waterui_gpu_capture_fence_on_complete` and the `Image` the buffer came from
+/// closed only from that completion.
+///
+/// # Safety
+///
+/// - `state` must be a valid pointer from `waterui_view_effect_create` with an
+///   attached target.
+/// - `buffer` must be a live `AHardwareBuffer` for the duration of this call.
+///
+/// # Panics
+///
+/// Panics if `state` is detached, or if the buffer's layout is one the effect
+/// pipeline cannot sample.
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_view_effect_set_input_hardware_buffer(
+    state: *mut WuiViewEffectState,
+    buffer: *mut c_void,
+) -> *mut super::gpu_surface::WuiGpuCaptureFence {
+    use super::capture_format::{create_effect_input_texture, effect_input_texture_format};
+    use super::hardware_buffer::{copy_hardware_buffer_into_texture, describe_hardware_buffer};
+
+    // SAFETY: the caller contract requires `state` to be a valid handle, alive and
+    // not otherwise borrowed for this call; the exclusive borrow ends here.
+    let state = unsafe { crate::borrow_ffi_mut(state) };
+    let buffer = buffer.cast();
+    // SAFETY: the caller contract makes `buffer` a live `AHardwareBuffer` for this
+    // call, which is all `describe_hardware_buffer` needs.
+    let description = unsafe { describe_hardware_buffer(buffer) };
+    ensure_dimensions(state, description.width, description.height);
+
+    let input_format = effect_input_texture_format(description.format);
+    assert_setup_input_format(state, input_format);
+    let input_texture = match state.imported_texture.take() {
+        Some(texture)
+            if texture.width() == description.width
+                && texture.height() == description.height
+                && texture.format() == input_format =>
+        {
+            texture
+        }
+        _ => create_effect_input_texture(
+            &state.runtime.context().device,
+            &state.runtime.context().queue,
+            input_format,
+            description.width,
+            description.height,
+        ),
+    };
+
+    // SAFETY: as above, `buffer` is live for this call, which is when the import
+    // takes its own reference on it.
+    let fence = unsafe {
+        copy_hardware_buffer_into_texture(
+            &mut state.hardware_buffer_imports,
+            buffer,
+            &input_texture,
+            "waterui_view_effect_set_input_hardware_buffer",
+        )
+    };
+    state.imported_texture = Some(input_texture);
+    state.imported_format = Some(input_format);
+    start_view_effect_setup(state, input_format);
+    fence
+}
+
+/// Copies a captured `AHardwareBuffer` into the effect's input (Android only).
+///
+/// # Safety
+///
+/// `state` must be a valid pointer from `waterui_view_effect_create` with an
+/// attached target, and `buffer` a live `AHardwareBuffer`.
+///
+/// # Panics
+///
+/// Always panics: `AHardwareBuffer` capture only exists on Android.
+#[cfg(not(target_os = "android"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_view_effect_set_input_hardware_buffer(
+    _state: *mut WuiViewEffectState,
+    _buffer: *mut c_void,
+) -> *mut super::gpu_surface::WuiGpuCaptureFence {
+    panic!("waterui_view_effect_set_input_hardware_buffer: only supported on Android");
 }
 
 /// Returns whether asynchronous effect setup has completed.
@@ -622,9 +728,10 @@ pub unsafe extern "C" fn waterui_view_effect_render(state: *mut WuiViewEffectSta
 
 /// Kicks off asynchronous effect setup for the given input format.
 ///
-/// Only reachable from the Apple Metal input-import entry point; every other
-/// platform feeds `ViewEffect` through the Rust-side filter pipeline.
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+/// Only reachable from the platform input-import entry points — the Apple Metal
+/// one and the Android hardware-buffer one; every other platform feeds
+/// `ViewEffect` through the Rust-side filter pipeline.
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "android"))]
 fn start_view_effect_setup(state: &WuiViewEffectState, input_format: wgpu::TextureFormat) {
     let output_format = state
         .output_config

--- a/ffi/src/components/visual/view_effect.rs
+++ b/ffi/src/components/visual/view_effect.rs
@@ -199,6 +199,9 @@ pub struct WuiViewEffectState {
     /// Vulkan imports of the Android capture buffers handed to this effect.
     #[cfg(target_os = "android")]
     hardware_buffer_imports: super::hardware_buffer::HardwareBufferImports,
+    /// Pipelines for drawing surfaces nested in the captured subtree back into it.
+    #[cfg(target_os = "android")]
+    capture_compositor: super::capture_composite::CaptureCompositor,
 }
 
 impl core::fmt::Debug for WuiViewEffectState {
@@ -270,6 +273,8 @@ pub unsafe extern "C" fn waterui_view_effect_create(
         output_size,
         #[cfg(target_os = "android")]
         hardware_buffer_imports,
+        #[cfg(target_os = "android")]
+        capture_compositor: super::capture_composite::CaptureCompositor::default(),
     }))
 }
 
@@ -602,6 +607,92 @@ pub unsafe extern "C" fn waterui_view_effect_set_input_hardware_buffer(
     _buffer: *mut c_void,
 ) -> *mut super::gpu_surface::WuiGpuCaptureFence {
     panic!("waterui_view_effect_set_input_hardware_buffer: only supported on Android");
+}
+
+/// Draws a `GpuSurface` nested in the captured subtree into the input (Android only).
+///
+/// HWUI records a `SurfaceView` as a cleared hole, so a GPU surface inside an
+/// effect's subtree is missing from the buffer the subtree was captured into.
+/// The backend calls this once per nested surface, between handing over the
+/// captured buffer and rendering the effect, with the rectangle the surface
+/// occupies inside the captured content in capture pixels. The surface renders
+/// one frame of its own and it is drawn into the effect's input at that
+/// rectangle.
+///
+/// Everything runs on one queue in call order, so the capture copy, the
+/// composites and the effect render need no fence between them.
+///
+/// # Safety
+///
+/// - `effect` must be a valid pointer from `waterui_view_effect_create` that has
+///   already been handed one captured buffer, so its input texture exists.
+/// - `surface` must be a valid pointer from `waterui_gpu_surface_create` that
+///   has been attached at least once, so it has an established renderer format.
+/// - Both must be used from the thread that created them.
+///
+/// # Panics
+///
+/// Panics if the effect has no input texture yet, if the surface has never been
+/// attached, or if the placement is empty.
+#[cfg(target_os = "android")]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_view_effect_composite_gpu_surface(
+    effect: *mut WuiViewEffectState,
+    surface: *mut super::gpu_surface::WuiGpuSurfaceState,
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+    scale: f64,
+) {
+    // SAFETY: the caller contract requires `effect` to be a valid handle, alive and
+    // not otherwise borrowed for this call; the exclusive borrow ends here.
+    let effect = unsafe { crate::borrow_ffi_mut(effect) };
+    // SAFETY: the caller contract requires `surface` to be a valid handle for a
+    // different state, alive and not otherwise borrowed for this call.
+    let surface = unsafe { crate::borrow_ffi_mut(surface) };
+    let input_texture = effect.imported_texture.take().expect(
+        "waterui_view_effect_composite_gpu_surface: no captured input has been handed over yet",
+    );
+    super::capture_composite::composite_gpu_surface(
+        &mut effect.capture_compositor,
+        surface,
+        &input_texture,
+        super::capture_composite::CompositePlacement {
+            x,
+            y,
+            width,
+            height,
+            scale,
+        },
+        "waterui_view_effect_composite_gpu_surface",
+    );
+    effect.imported_texture = Some(input_texture);
+}
+
+/// Draws a `GpuSurface` nested in the captured subtree into the input (Android only).
+///
+/// # Safety
+///
+/// `effect` and `surface` must be valid state pointers from their matching
+/// constructors.
+///
+/// # Panics
+///
+/// Always panics: nested-surface compositing only exists on Android, because
+/// only there does the capture arrive with the surface missing from it.
+#[cfg(not(target_os = "android"))]
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn waterui_view_effect_composite_gpu_surface(
+    _effect: *mut WuiViewEffectState,
+    _surface: *mut super::gpu_surface::WuiGpuSurfaceState,
+    _x: i32,
+    _y: i32,
+    _width: u32,
+    _height: u32,
+    _scale: f64,
+) {
+    panic!("waterui_view_effect_composite_gpu_surface: only supported on Android");
 }
 
 /// Returns whether asynchronous effect setup has completed.

--- a/ffi/src/jni/components.rs
+++ b/ffi/src/jni/components.rs
@@ -2360,3 +2360,664 @@ extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_gpuSurfaceDrop<'local
     }
     drop(wrapper);
 }
+
+// ============================================================================
+// AppliedFilter / ViewEffect (Android view capture)
+//
+// These mirror the `gpuSurface*` conventions exactly: the state handle crosses
+// as a `Long` wrapper this file owns, an attached `Surface` becomes an
+// `ANativeWindow` held alongside it, and the redraw callback is installed by
+// `*Create` so Kotlin only implements `requestNativeRedraw()` on the owner view.
+// ============================================================================
+
+/// The handle `appliedFilterCreate` returns, and every `appliedFilter*` takes.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+struct JniAppliedFilterState {
+    state: *mut crate::components::applied_filter::WuiAppliedFilterState,
+    window: Option<AndroidNativeWindow>,
+}
+
+/// The handle `viewEffectCreate` returns, and every `viewEffect*` takes.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+struct JniViewEffectState {
+    state: *mut crate::components::view_effect::WuiViewEffectState,
+    window: Option<AndroidNativeWindow>,
+}
+
+/// What an Android capture target's redraw callback wakes.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+struct AndroidCaptureRedrawTarget {
+    jvm: jni::JavaVM,
+    owner: Global<JObject<'static>>,
+}
+
+#[cfg(all(target_os = "android", feature = "gpu"))]
+unsafe extern "C" fn wake_android_capture(context: *mut c_void) {
+    // SAFETY: `context` is the target the matching `*Create` registered with this
+    // entry point, live until the paired drop entry point reclaims it.
+    let target = unsafe { &*context.cast::<AndroidCaptureRedrawTarget>() };
+    super::with_attached_env(&target.jvm, |env| {
+        env.call_method(
+            &target.owner,
+            jni_str!("requestNativeRedraw"),
+            jni_sig!("()V"),
+            &[],
+        )
+        .expect("capture redraw callback failed to call requestNativeRedraw");
+    })
+    .expect("capture redraw callback failed to attach to JVM");
+}
+
+#[cfg(all(target_os = "android", feature = "gpu"))]
+unsafe extern "C" fn drop_android_capture_redraw_target(context: *mut c_void) {
+    // SAFETY: `context` is the boxed target the matching `*Create` registered with
+    // this drop entry point, which the capture target invokes once.
+    unsafe {
+        drop(Box::from_raw(context.cast::<AndroidCaptureRedrawTarget>()));
+    }
+}
+
+/// Boxes the redraw target Kotlin's owner view is woken through.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+fn android_capture_redraw_context<'local>(
+    env: &Env<'local>,
+    owner: JObject<'local>,
+    function: &str,
+) -> *mut c_void {
+    let target = Box::new(AndroidCaptureRedrawTarget {
+        jvm: env
+            .get_java_vm()
+            .unwrap_or_else(|_| panic!("WatcherJni.{function} failed to access JavaVM")),
+        owner: env
+            .new_global_ref(owner)
+            .unwrap_or_else(|_| panic!("WatcherJni.{function} failed to retain owner view")),
+    });
+    Box::into_raw(target).cast::<c_void>()
+}
+
+/// `WatcherJni.appliedFilterCreate(owner, filterPtr, wuiEnvPtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterCreate<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    owner: JObject<'local>,
+    filter_ptr: jlong,
+    wui_env_ptr: jlong,
+) -> jlong {
+    super::with_env(&mut env, |env| {
+        let mut wui_filter = crate::components::applied_filter::WuiAppliedFilter {
+            content: core::ptr::null_mut(),
+            filter: filter_ptr as *mut c_void,
+        };
+        // SAFETY: `wui_filter` carries the semantic filter Kotlin took from the
+        // struct `forceAsMetadataAppliedFilter` handed it, and `wui_env_ptr` is the
+        // live app environment.
+        let state = unsafe {
+            crate::components::applied_filter::waterui_applied_filter_create(
+                &raw mut wui_filter,
+                wui_env_ptr as *const crate::WuiEnv,
+            )
+        };
+        let redraw_context = android_capture_redraw_context(env, owner, "appliedFilterCreate");
+        // SAFETY: `state` was just created above, and `redraw_context` is the
+        // payload the two entry points above expect, whose ownership moves to the
+        // filter.
+        unsafe {
+            crate::components::applied_filter::waterui_applied_filter_set_redraw_callback(
+                state,
+                redraw_context,
+                wake_android_capture,
+                drop_android_capture_redraw_target,
+            );
+        }
+        Box::into_raw(Box::new(JniAppliedFilterState {
+            state,
+            window: None,
+        })) as jlong
+    })
+}
+
+/// `WatcherJni.appliedFilterAttach(statePtr, surface, width, height, prefersHdr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterAttach<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    surface: JObject<'local>,
+    input_width: jint,
+    input_height: jint,
+    prefers_hdr: jboolean,
+) {
+    super::with_env(&mut env, |env| {
+        // SAFETY: Kotlin passes back the handle `appliedFilterCreate` returned, live
+        // until `appliedFilterDrop`; the Android view calls these entry points one at
+        // a time from its own thread, so this exclusive borrow is the only live one.
+        let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+        assert!(
+            wrapper.window.is_none(),
+            "WatcherJni.appliedFilterAttach called while a native surface is already attached"
+        );
+        let window = require_native_window(
+            // SAFETY: `env` is this JNI call's own environment and `surface` its local
+            // reference, both valid for the call.
+            unsafe { AndroidNativeWindow::from_surface(env.get_raw(), surface.as_raw()) },
+            "appliedFilterAttach",
+        );
+        // SAFETY: `wrapper.state` is the filter state created alongside it, and the
+        // `ANativeWindow` stays alive because `wrapper.window` takes it below, before
+        // any detach.
+        unsafe {
+            crate::components::applied_filter::waterui_applied_filter_attach(
+                wrapper.state,
+                window.as_void_ptr(),
+                input_width.cast_unsigned(),
+                input_height.cast_unsigned(),
+                prefers_hdr,
+            );
+        }
+        wrapper.window = Some(window);
+    });
+}
+
+/// `WatcherJni.appliedFilterDetach(statePtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterDetach<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) {
+    // SAFETY: as for every other `appliedFilter*` entry point, Kotlin passes back
+    // the live handle from `appliedFilterCreate`, one call at a time.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+    assert!(
+        wrapper.window.is_some(),
+        "WatcherJni.appliedFilterDetach called without an attached native surface"
+    );
+    // SAFETY: `wrapper.state` is the filter state created alongside it, still live.
+    unsafe {
+        crate::components::applied_filter::waterui_applied_filter_detach(wrapper.state);
+    }
+    drop(wrapper.window.take());
+}
+
+/// `WatcherJni.appliedFilterSetup(statePtr)`: starts asynchronous filter setup.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterSetup<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) {
+    // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+    // SAFETY: `wrapper.state` is the filter state created alongside it, still live.
+    unsafe {
+        crate::components::applied_filter::waterui_applied_filter_setup(wrapper.state);
+    }
+}
+
+/// `WatcherJni.appliedFilterIsReady(statePtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterIsReady<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) -> jboolean {
+    // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+    let wrapper = unsafe { &*(state_ptr as *const JniAppliedFilterState) };
+    // SAFETY: `wrapper.state` is the filter state created alongside it, still live.
+    unsafe { crate::components::applied_filter::waterui_applied_filter_is_ready(wrapper.state) }
+}
+
+/// `WatcherJni.appliedFilterResolveOutputSize(statePtr, inputWidth, inputHeight)`.
+///
+/// Returns `[width, height]` in pixels.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterResolveOutputSize<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    input_width: jint,
+    input_height: jint,
+) -> jintArray {
+    super::with_env(&mut env, |env| {
+        // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+        let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+        // SAFETY: `wrapper.state` is the filter state created alongside it, still live.
+        let size = unsafe {
+            crate::components::applied_filter::waterui_applied_filter_resolve_output_size(
+                wrapper.state,
+                input_width.cast_unsigned(),
+                input_height.cast_unsigned(),
+            )
+        };
+        let values: [jint; 2] = [
+            jint::try_from(size.width)
+                .expect("appliedFilterResolveOutputSize: width exceeds jint capacity"),
+            jint::try_from(size.height)
+                .expect("appliedFilterResolveOutputSize: height exceeds jint capacity"),
+        ];
+        let array = env
+            .new_int_array(values.len())
+            .expect("appliedFilterResolveOutputSize: failed to allocate the size array");
+        array
+            .set_region(env, 0, &values)
+            .expect("appliedFilterResolveOutputSize: failed to write the size array");
+        array.into_raw()
+    })
+}
+
+/// `WatcherJni.appliedFilterPrepareCapture(statePtr, width, height)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterPrepareCapture<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    width: jint,
+    height: jint,
+) {
+    // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+    // SAFETY: `wrapper.state` is the filter state created alongside it, still live.
+    unsafe {
+        crate::components::applied_filter::waterui_applied_filter_prepare_capture(
+            wrapper.state,
+            width.cast_unsigned(),
+            height.cast_unsigned(),
+        );
+    }
+}
+
+/// `WatcherJni.appliedFilterCaptureFormat(statePtr)`.
+///
+/// The `ImageReader` format this filter's capture buffers must be allocated
+/// with: `0` is `PixelFormat.RGBA_8888`, `1` is `PixelFormat.RGBA_FP16`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterCaptureFormat<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) -> jint {
+    // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+    let wrapper = unsafe { &*(state_ptr as *const JniAppliedFilterState) };
+    // SAFETY: `wrapper.state` is the filter state created alongside it, still live.
+    let format = unsafe {
+        crate::components::applied_filter::waterui_applied_filter_capture_format(wrapper.state)
+    };
+    format as jint
+}
+
+/// `WatcherJni.appliedFilterSetCaptureHardwareBuffer(statePtr, hardwareBuffer)`.
+///
+/// Returns the capture fence, to be consumed exactly once by
+/// `gpuCaptureFenceOnComplete`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterSetCaptureHardwareBuffer<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    hardware_buffer: JObject<'local>,
+) -> jlong {
+    super::with_env(&mut env, |env| {
+        // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+        let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+        // SAFETY: `env` is this JNI call's own environment and `hardware_buffer` its
+        // local reference, both valid for the call.
+        let buffer = unsafe {
+            crate::components::hardware_buffer::hardware_buffer_from_java(
+                env.get_raw().cast(),
+                hardware_buffer.as_raw().cast(),
+            )
+        };
+        // SAFETY: `wrapper.state` is the live filter state, and `buffer` is borrowed
+        // from the Java object, which the caller keeps open across this call.
+        let fence = unsafe {
+            crate::components::applied_filter::waterui_applied_filter_set_capture_hardware_buffer(
+                wrapper.state,
+                buffer.cast::<c_void>(),
+            )
+        };
+        fence as jlong
+    })
+}
+
+/// `WatcherJni.appliedFilterRender(statePtr, width, height)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterRender<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    width: jint,
+    height: jint,
+) -> jboolean {
+    // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+    // SAFETY: `wrapper.state` is the filter state created alongside it, still live.
+    unsafe {
+        crate::components::applied_filter::waterui_applied_filter_render(
+            wrapper.state,
+            width.cast_unsigned(),
+            height.cast_unsigned(),
+        )
+    }
+}
+
+/// `WatcherJni.appliedFilterDrop(statePtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterDrop<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) {
+    // SAFETY: Kotlin passes back the owning handle `appliedFilterCreate` returned,
+    // and the runtime drops each filter once.
+    let wrapper = unsafe { Box::from_raw(state_ptr as *mut JniAppliedFilterState) };
+    // SAFETY: `wrapper.state` is the filter state created alongside it, dropped here
+    // exactly once together with its wrapper.
+    unsafe {
+        crate::components::applied_filter::waterui_applied_filter_drop(wrapper.state);
+    }
+    drop(wrapper);
+}
+
+/// `WatcherJni.viewEffectCreate(owner, effectPtr, outputSizeKind, outputWidth,
+/// outputHeight, outputScale, wuiEnvPtr)`.
+///
+/// The four output-size arguments are the flattened `ViewEffectStruct` fields
+/// `forceAsViewEffect` handed Kotlin, passed straight back.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectCreate<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    owner: JObject<'local>,
+    effect_ptr: jlong,
+    output_size_kind: jint,
+    output_width: jint,
+    output_height: jint,
+    output_scale: jfloat,
+    wui_env_ptr: jlong,
+) -> jlong {
+    super::with_env(&mut env, |env| {
+        let mut wui_effect = crate::components::view_effect::WuiViewEffect {
+            content: core::ptr::null_mut(),
+            effect: effect_ptr as *mut c_void,
+            output_size: view_effect_output_size(
+                output_size_kind,
+                output_width,
+                output_height,
+                output_scale,
+            ),
+        };
+        // SAFETY: `wui_effect` carries the renderer Kotlin took from the struct
+        // `forceAsViewEffect` handed it, and `wui_env_ptr` is the live app
+        // environment.
+        let state = unsafe {
+            crate::components::view_effect::waterui_view_effect_create(
+                &raw mut wui_effect,
+                wui_env_ptr as *const crate::WuiEnv,
+            )
+        };
+        let redraw_context = android_capture_redraw_context(env, owner, "viewEffectCreate");
+        // SAFETY: `state` was just created above, and `redraw_context` is the payload
+        // the two entry points above expect, whose ownership moves to the effect.
+        unsafe {
+            crate::components::view_effect::waterui_view_effect_set_redraw_callback(
+                state,
+                redraw_context,
+                wake_android_capture,
+                drop_android_capture_redraw_target,
+            );
+        }
+        Box::into_raw(Box::new(JniViewEffectState {
+            state,
+            window: None,
+        })) as jlong
+    })
+}
+
+/// Rebuilds the output-size enum from the fields `ViewEffectStruct` flattened it into.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+fn view_effect_output_size(
+    kind: jint,
+    width: jint,
+    height: jint,
+    scale: jfloat,
+) -> crate::components::view_effect::WuiOutputSize {
+    use crate::components::view_effect::WuiOutputSize;
+    match kind {
+        0 => WuiOutputSize::MatchInput,
+        1 => WuiOutputSize::Fixed {
+            width: width.cast_unsigned(),
+            height: height.cast_unsigned(),
+        },
+        2 => WuiOutputSize::Scale { factor: scale },
+        other => panic!("WatcherJni.viewEffectCreate: unknown output size kind {other}"),
+    }
+}
+
+/// `WatcherJni.viewEffectAttach(statePtr, surface, width, height, prefersHdr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectAttach<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    surface: JObject<'local>,
+    input_width: jint,
+    input_height: jint,
+    prefers_hdr: jboolean,
+) {
+    super::with_env(&mut env, |env| {
+        // SAFETY: Kotlin passes back the handle `viewEffectCreate` returned, live
+        // until `viewEffectDrop`, one call at a time from the view's own thread.
+        let wrapper = unsafe { &mut *(state_ptr as *mut JniViewEffectState) };
+        assert!(
+            wrapper.window.is_none(),
+            "WatcherJni.viewEffectAttach called while a native surface is already attached"
+        );
+        let window = require_native_window(
+            // SAFETY: `env` is this JNI call's own environment and `surface` its local
+            // reference, both valid for the call.
+            unsafe { AndroidNativeWindow::from_surface(env.get_raw(), surface.as_raw()) },
+            "viewEffectAttach",
+        );
+        // SAFETY: `wrapper.state` is the effect state created alongside it, and the
+        // `ANativeWindow` stays alive because `wrapper.window` takes it below, before
+        // any detach.
+        unsafe {
+            crate::components::view_effect::waterui_view_effect_attach(
+                wrapper.state,
+                window.as_void_ptr(),
+                input_width.cast_unsigned(),
+                input_height.cast_unsigned(),
+                prefers_hdr,
+            );
+        }
+        wrapper.window = Some(window);
+    });
+}
+
+/// `WatcherJni.viewEffectDetach(statePtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectDetach<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) {
+    // SAFETY: Kotlin passes back the live handle from `viewEffectCreate`.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniViewEffectState) };
+    assert!(
+        wrapper.window.is_some(),
+        "WatcherJni.viewEffectDetach called without an attached native surface"
+    );
+    // SAFETY: `wrapper.state` is the effect state created alongside it, still live.
+    unsafe {
+        crate::components::view_effect::waterui_view_effect_detach(wrapper.state);
+    }
+    drop(wrapper.window.take());
+}
+
+/// `WatcherJni.viewEffectIsReady(statePtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectIsReady<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) -> jboolean {
+    // SAFETY: Kotlin passes back the live handle from `viewEffectCreate`.
+    let wrapper = unsafe { &*(state_ptr as *const JniViewEffectState) };
+    // SAFETY: `wrapper.state` is the effect state created alongside it, still live.
+    unsafe { crate::components::view_effect::waterui_view_effect_is_ready(wrapper.state) }
+}
+
+/// `WatcherJni.viewEffectSetInputHardwareBuffer(statePtr, hardwareBuffer)`.
+///
+/// Returns the capture fence, to be consumed exactly once by
+/// `gpuCaptureFenceOnComplete`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectSetInputHardwareBuffer<
+    'local,
+>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    hardware_buffer: JObject<'local>,
+) -> jlong {
+    super::with_env(&mut env, |env| {
+        // SAFETY: Kotlin passes back the live handle from `viewEffectCreate`.
+        let wrapper = unsafe { &mut *(state_ptr as *mut JniViewEffectState) };
+        // SAFETY: `env` is this JNI call's own environment and `hardware_buffer` its
+        // local reference, both valid for the call.
+        let buffer = unsafe {
+            crate::components::hardware_buffer::hardware_buffer_from_java(
+                env.get_raw().cast(),
+                hardware_buffer.as_raw().cast(),
+            )
+        };
+        // SAFETY: `wrapper.state` is the live effect state, and `buffer` is borrowed
+        // from the Java object, which the caller keeps open across this call.
+        let fence = unsafe {
+            crate::components::view_effect::waterui_view_effect_set_input_hardware_buffer(
+                wrapper.state,
+                buffer.cast::<c_void>(),
+            )
+        };
+        fence as jlong
+    })
+}
+
+/// `WatcherJni.viewEffectRender(statePtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectRender<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) -> jboolean {
+    // SAFETY: Kotlin passes back the live handle from `viewEffectCreate`.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniViewEffectState) };
+    // SAFETY: `wrapper.state` is the effect state created alongside it, still live.
+    unsafe { crate::components::view_effect::waterui_view_effect_render(wrapper.state) }
+}
+
+/// `WatcherJni.viewEffectDrop(statePtr)`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectDrop<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+) {
+    // SAFETY: Kotlin passes back the owning handle `viewEffectCreate` returned, and
+    // the runtime drops each effect once.
+    let wrapper = unsafe { Box::from_raw(state_ptr as *mut JniViewEffectState) };
+    // SAFETY: `wrapper.state` is the effect state created alongside it, dropped here
+    // exactly once together with its wrapper.
+    unsafe {
+        crate::components::view_effect::waterui_view_effect_drop(wrapper.state);
+    }
+    drop(wrapper);
+}
+
+/// The completion Kotlin registers on a capture fence.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+struct AndroidCaptureCompletion {
+    jvm: jni::JavaVM,
+    runnable: Global<JObject<'static>>,
+}
+
+#[cfg(all(target_os = "android", feature = "gpu"))]
+unsafe extern "C" fn run_android_capture_completion(context: *mut c_void) {
+    // SAFETY: `context` is the completion `gpuCaptureFenceOnComplete` registered,
+    // live until the paired drop entry point reclaims it.
+    let completion = unsafe { &*context.cast::<AndroidCaptureCompletion>() };
+    super::with_attached_env(&completion.jvm, |env| {
+        env.call_method(&completion.runnable, jni_str!("run"), jni_sig!("()V"), &[])
+            .expect("capture completion failed to call Runnable.run");
+    })
+    .expect("capture completion failed to attach to JVM");
+}
+
+#[cfg(all(target_os = "android", feature = "gpu"))]
+unsafe extern "C" fn drop_android_capture_completion(context: *mut c_void) {
+    // SAFETY: `context` is the boxed completion registered with this drop entry
+    // point, which the completion driver invokes once.
+    unsafe {
+        drop(Box::from_raw(context.cast::<AndroidCaptureCompletion>()));
+    }
+}
+
+/// `WatcherJni.gpuCaptureFenceOnComplete(fencePtr, completion)`.
+///
+/// Consumes the fence and runs `completion` on `WaterUI`'s GPU completion thread —
+/// never on the main thread — once the capture copy has finished on the GPU.
+/// That is when the `Image` the buffer came from may be closed.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_gpuCaptureFenceOnComplete<'local>(
+    mut env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    fence_ptr: jlong,
+    completion: JObject<'local>,
+) {
+    super::with_env(&mut env, |env| {
+        let completion = Box::new(AndroidCaptureCompletion {
+            jvm: env
+                .get_java_vm()
+                .expect("WatcherJni.gpuCaptureFenceOnComplete failed to access JavaVM"),
+            runnable: env
+                .new_global_ref(completion)
+                .expect("WatcherJni.gpuCaptureFenceOnComplete failed to retain the completion"),
+        });
+        let context = Box::into_raw(completion).cast::<c_void>();
+        // SAFETY: Kotlin passes back the owning fence one of the capture entry
+        // points returned, consumed exactly once here, and `context` is the payload
+        // the two entry points above expect, whose ownership moves to the driver.
+        unsafe {
+            crate::components::gpu_surface::waterui_gpu_capture_fence_on_complete(
+                fence_ptr as *mut crate::components::gpu_surface::WuiGpuCaptureFence,
+                context,
+                run_android_capture_completion,
+                drop_android_capture_completion,
+            );
+        }
+    });
+}

--- a/ffi/src/jni/components.rs
+++ b/ffi/src/jni/components.rs
@@ -2693,6 +2693,46 @@ extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterSetCaptu
     })
 }
 
+/// `WatcherJni.appliedFilterCompositeGpuSurface(statePtr, surfaceStatePtr, x, y, width, height, scale)`.
+///
+/// Draws one `GpuSurface` nested in the captured subtree into the capture, at
+/// the rectangle it occupies inside the captured content in pixels. Called
+/// between `appliedFilterSetCaptureHardwareBuffer` and `appliedFilterRender`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterCompositeGpuSurface<
+    'local,
+>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    surface_state_ptr: jlong,
+    x: jint,
+    y: jint,
+    width: jint,
+    height: jint,
+    scale: jfloat,
+) {
+    // SAFETY: Kotlin passes back the live handle from `appliedFilterCreate`.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniAppliedFilterState) };
+    // SAFETY: Kotlin passes back the live handle from `gpuSurfaceCreate` for a
+    // surface inside this filter's own subtree, so the two states are distinct.
+    let surface = unsafe { &mut *(surface_state_ptr as *mut JniGpuSurfaceState) };
+    // SAFETY: both states were created on this thread and are only borrowed for
+    // the call, and the placement is the surface's rectangle in capture pixels.
+    unsafe {
+        crate::components::applied_filter::waterui_applied_filter_composite_gpu_surface(
+            wrapper.state,
+            surface.state,
+            x,
+            y,
+            width.cast_unsigned(),
+            height.cast_unsigned(),
+            f64::from(scale),
+        );
+    }
+}
+
 /// `WatcherJni.appliedFilterRender(statePtr, width, height)`.
 #[cfg(all(target_os = "android", feature = "gpu"))]
 #[unsafe(no_mangle)]
@@ -2922,6 +2962,44 @@ extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectSetInputHar
         };
         fence as jlong
     })
+}
+
+/// `WatcherJni.viewEffectCompositeGpuSurface(statePtr, surfaceStatePtr, x, y, width, height, scale)`.
+///
+/// Draws one `GpuSurface` nested in the captured subtree into the effect's
+/// input, at the rectangle it occupies inside the captured content in pixels.
+/// Called between `viewEffectSetInputHardwareBuffer` and `viewEffectRender`.
+#[cfg(all(target_os = "android", feature = "gpu"))]
+#[unsafe(no_mangle)]
+extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectCompositeGpuSurface<'local>(
+    _env: EnvUnowned<'local>,
+    _class: JClass<'local>,
+    state_ptr: jlong,
+    surface_state_ptr: jlong,
+    x: jint,
+    y: jint,
+    width: jint,
+    height: jint,
+    scale: jfloat,
+) {
+    // SAFETY: Kotlin passes back the live handle from `viewEffectCreate`.
+    let wrapper = unsafe { &mut *(state_ptr as *mut JniViewEffectState) };
+    // SAFETY: Kotlin passes back the live handle from `gpuSurfaceCreate` for a
+    // surface inside this effect's own subtree, so the two states are distinct.
+    let surface = unsafe { &mut *(surface_state_ptr as *mut JniGpuSurfaceState) };
+    // SAFETY: both states were created on this thread and are only borrowed for
+    // the call, and the placement is the surface's rectangle in capture pixels.
+    unsafe {
+        crate::components::view_effect::waterui_view_effect_composite_gpu_surface(
+            wrapper.state,
+            surface.state,
+            x,
+            y,
+            width.cast_unsigned(),
+            height.cast_unsigned(),
+            f64::from(scale),
+        );
+    }
 }
 
 /// `WatcherJni.viewEffectRender(statePtr)`.

--- a/ffi/src/jni/convert.rs
+++ b/ffi/src/jni/convert.rs
@@ -1903,3 +1903,63 @@ impl ToJavaStruct for crate::WuiMenuItem {
         .expect("Failed to create MenuItemStruct")
     }
 }
+
+/// `AppliedFilterStruct(contentPtr: Long, filterPtr: Long)`
+///
+/// `filterPtr` is the semantic filter, consumed once by
+/// `WatcherJni.appliedFilterCreate`.
+#[cfg(feature = "gpu")]
+impl ToJavaStruct for crate::components::applied_filter::WuiAppliedFilter {
+    fn to_java_struct<'local>(self, env: &mut JNIEnv<'local>) -> JObject<'local> {
+        let class = env
+            .find_class(jni_str!("dev/waterui/android/runtime/AppliedFilterStruct"))
+            .expect("AppliedFilterStruct class not found");
+        env.new_object(
+            &class,
+            jni_sig!("(JJ)V"),
+            &[
+                JValue::Long(self.content as jlong),
+                JValue::Long(self.filter as jlong),
+            ],
+        )
+        .expect("Failed to create AppliedFilterStruct")
+    }
+}
+
+/// `ViewEffectStruct(contentPtr: Long, effectPtr: Long, outputSizeKind: Int,
+/// outputWidth: Int, outputHeight: Int, outputScale: Float)`
+///
+/// The output size is a Rust enum with per-variant payloads, so it crosses
+/// flattened: `outputSizeKind` selects which of the remaining fields carry
+/// meaning — 0 matches the input and reads none of them, 1 is a fixed size and
+/// reads width and height, 2 is a scale factor and reads `outputScale`. Kotlin
+/// hands all four straight back to `WatcherJni.viewEffectCreate`.
+#[cfg(feature = "gpu")]
+impl ToJavaStruct for crate::components::view_effect::WuiViewEffect {
+    fn to_java_struct<'local>(self, env: &mut JNIEnv<'local>) -> JObject<'local> {
+        use crate::components::view_effect::WuiOutputSize;
+        let (kind, width, height, scale) = match self.output_size {
+            WuiOutputSize::MatchInput => (0, 0, 0, 1.0),
+            WuiOutputSize::Fixed { width, height } => {
+                (1, width.cast_signed(), height.cast_signed(), 1.0)
+            }
+            WuiOutputSize::Scale { factor } => (2, 0, 0, factor),
+        };
+        let class = env
+            .find_class(jni_str!("dev/waterui/android/runtime/ViewEffectStruct"))
+            .expect("ViewEffectStruct class not found");
+        env.new_object(
+            &class,
+            jni_sig!("(JJIIIF)V"),
+            &[
+                JValue::Long(self.content as jlong),
+                JValue::Long(self.effect as jlong),
+                JValue::Int(kind),
+                JValue::Int(width),
+                JValue::Int(height),
+                JValue::Float(scale),
+            ],
+        )
+        .expect("Failed to create ViewEffectStruct")
+    }
+}

--- a/ffi/src/jni/ffi_bridge.rs
+++ b/ffi/src/jni/ffi_bridge.rs
@@ -154,25 +154,6 @@ extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_spacerId<'local>(
 }
 
 #[unsafe(no_mangle)]
-extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_appliedFilterId<'local>(
-    mut env: EnvUnowned<'local>,
-    _class: JClass<'local>,
-) -> jobject {
-    let type_id = WuiTypeId::of::<waterui_core::Metadata<waterui_graphics::AppliedFilter>>();
-    super::with_env(&mut env, |env| type_id_to_java(env, type_id).into_raw())
-}
-
-#[unsafe(no_mangle)]
-extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_viewEffectId<'local>(
-    mut env: EnvUnowned<'local>,
-    _class: JClass<'local>,
-) -> jobject {
-    let type_id =
-        WuiTypeId::of::<waterui_core::Native<waterui_graphics::view_effect::ViewEffectErased>>();
-    super::with_env(&mut env, |env| type_id_to_java(env, type_id).into_raw())
-}
-
-#[unsafe(no_mangle)]
 extern "system" fn Java_dev_waterui_android_ffi_WatcherJni_webViewId<'local>(
     mut env: EnvUnowned<'local>,
     _class: JClass<'local>,

--- a/ffi/waterui.h
+++ b/ffi/waterui.h
@@ -11030,6 +11030,27 @@ struct WuiGpuCaptureFence *waterui_applied_filter_set_capture_hardware_buffer(st
                                                                               void *_buffer);
 
 /**
+ * Draws a `GpuSurface` nested in the captured subtree into the capture (Android only).
+ *
+ * # Safety
+ *
+ * `filter` and `surface` must be valid state pointers from their matching
+ * constructors.
+ *
+ * # Panics
+ *
+ * Always panics: nested-surface compositing only exists on Android, because
+ * only there does the capture arrive with the surface missing from it.
+ */
+void waterui_applied_filter_composite_gpu_surface(struct WuiAppliedFilterState *_filter,
+                                                  struct WuiGpuSurfaceState *_surface,
+                                                  int32_t _x,
+                                                  int32_t _y,
+                                                  uint32_t _width,
+                                                  uint32_t _height,
+                                                  double _scale);
+
+/**
  * Get a pointer to the Metal texture backing the capture texture (Apple only).
  *
  * This exposes the underlying `MTLTexture` so native code can render directly
@@ -11640,6 +11661,27 @@ void waterui_view_effect_set_input_metal_texture(struct WuiViewEffectState *stat
  */
 struct WuiGpuCaptureFence *waterui_view_effect_set_input_hardware_buffer(struct WuiViewEffectState *_state,
                                                                          void *_buffer);
+
+/**
+ * Draws a `GpuSurface` nested in the captured subtree into the input (Android only).
+ *
+ * # Safety
+ *
+ * `effect` and `surface` must be valid state pointers from their matching
+ * constructors.
+ *
+ * # Panics
+ *
+ * Always panics: nested-surface compositing only exists on Android, because
+ * only there does the capture arrive with the surface missing from it.
+ */
+void waterui_view_effect_composite_gpu_surface(struct WuiViewEffectState *_effect,
+                                               struct WuiGpuSurfaceState *_surface,
+                                               int32_t _x,
+                                               int32_t _y,
+                                               uint32_t _width,
+                                               uint32_t _height,
+                                               double _scale);
 
 /**
  * Returns whether asynchronous effect setup has completed.

--- a/ffi/waterui.h
+++ b/ffi/waterui.h
@@ -1202,6 +1202,37 @@ typedef enum WuiWebViewEventType {
 } WuiWebViewEventType;
 
 /**
+ * The pixel layout an Android capture buffer must be allocated with.
+ *
+ * The backend allocates its `ImageReader` from this after attaching, so the
+ * buffer it hands back is copy-compatible with the capture texture the filter
+ * samples. The discriminants are the values the JNI binding returns as an
+ * `Int`, and are part of the Kotlin contract.
+ */
+enum WuiCaptureFormat
+#if __STDC_VERSION__ >= 202311L
+  : uint32_t
+#endif // __STDC_VERSION__ >= 202311L
+ {
+  /**
+   * Four 8-bit unsigned channels: `AHARDWAREBUFFER_FORMAT_R8G8B8A8_UNORM`,
+   * which is `android.graphics.PixelFormat.RGBA_8888`.
+   */
+  WuiCaptureFormat_Rgba8Unorm = 0,
+  /**
+   * Four 16-bit half-float channels:
+   * `AHARDWAREBUFFER_FORMAT_R16G16B16A16_FLOAT`, which is
+   * `android.graphics.PixelFormat.RGBA_FP16`.
+   */
+  WuiCaptureFormat_Rgba16Float = 1,
+};
+#if __STDC_VERSION__ >= 202311L
+typedef enum WuiCaptureFormat WuiCaptureFormat;
+#else
+typedef uint32_t WuiCaptureFormat;
+#endif // __STDC_VERSION__ >= 202311L
+
+/**
  * Which event a [`WuiSurfaceInputEvent`] carries.
  *
  * The tag decides which of the struct's payload fields are read; the rest are
@@ -10970,6 +11001,35 @@ void waterui_applied_filter_prepare_capture(struct WuiAppliedFilterState *state,
                                             uint32_t height);
 
 /**
+ * The pixel layout this filter's capture buffers must be allocated with (Android only).
+ *
+ * # Safety
+ *
+ * `state` must be a valid pointer from `waterui_applied_filter_create` with an
+ * attached target.
+ *
+ * # Panics
+ *
+ * Always panics: `AHardwareBuffer` capture only exists on Android.
+ */
+WuiCaptureFormat waterui_applied_filter_capture_format(const struct WuiAppliedFilterState *_state);
+
+/**
+ * Copies a captured `AHardwareBuffer` into the capture texture (Android only).
+ *
+ * # Safety
+ *
+ * `state` must be a valid pointer from `waterui_applied_filter_create` with an
+ * attached target, and `buffer` a live `AHardwareBuffer`.
+ *
+ * # Panics
+ *
+ * Always panics: `AHardwareBuffer` capture only exists on Android.
+ */
+struct WuiGpuCaptureFence *waterui_applied_filter_set_capture_hardware_buffer(struct WuiAppliedFilterState *_state,
+                                                                              void *_buffer);
+
+/**
  * Get a pointer to the Metal texture backing the capture texture (Apple only).
  *
  * This exposes the underlying `MTLTexture` so native code can render directly
@@ -11273,8 +11333,11 @@ struct WuiGpuCaptureFence *waterui_gpu_surface_render_to_metal_texture(struct Wu
  *
  * # Safety
  *
- * `fence` must be a valid owning pointer returned by
- * [`waterui_gpu_surface_render_to_metal_texture`] and must be consumed once.
+ * `fence` must be a valid owning pointer returned by an external capture entry
+ * point — `waterui_gpu_surface_render_to_metal_texture` on Apple,
+ * `waterui_applied_filter_set_capture_hardware_buffer` or
+ * `waterui_view_effect_set_input_hardware_buffer` on Android — and must be
+ * consumed once.
  * `context`, `callback`, and `drop` must remain valid until completion; Rust
  * consumes the context and releases it through `drop`.
  */
@@ -11562,6 +11625,21 @@ void waterui_view_effect_set_input_metal_texture(struct WuiViewEffectState *stat
                                                  void *texture,
                                                  uint32_t width,
                                                  uint32_t height);
+
+/**
+ * Copies a captured `AHardwareBuffer` into the effect's input (Android only).
+ *
+ * # Safety
+ *
+ * `state` must be a valid pointer from `waterui_view_effect_create` with an
+ * attached target, and `buffer` a live `AHardwareBuffer`.
+ *
+ * # Panics
+ *
+ * Always panics: `AHardwareBuffer` capture only exists on Android.
+ */
+struct WuiGpuCaptureFence *waterui_view_effect_set_input_hardware_buffer(struct WuiViewEffectState *_state,
+                                                                         void *_buffer);
 
 /**
  * Returns whether asynchronous effect setup has completed.


### PR DESCRIPTION
The Rust half of Android view capture: `AppliedFilter` and `ViewEffect` can now
take their input from an `AHardwareBuffer` on the GPU, with no CPU readback. The
Kotlin half — the `FrameLayout` host, `HardwareRenderer`/`RenderNode` capture and
the `ImageReader` — is a separate pull request in `water-rs/android-backend`
against the JNI surface this adds.

## What is here

**Device creation.** `waterui-graphics` opens the Android device through the HAL
adapter (`open_android_device` in `gpu/shared_context.rs`), because
`Adapter::request_device` enables only the extensions wgpu itself wants and has no
descriptor field for asking for more. `open_with_callback` adds
`VK_ANDROID_external_memory_android_hardware_buffer` and
`VK_EXT_queue_family_foreign`, and `create_device_from_hal` adopts the result, so
the device is an ordinary `wgpu::Device` for everything else. Both extensions are
mandatory on any Android device reporting Vulkan 1.1, so an adapter without either
is a hard error naming it — there is no fallback path.

**Import and copy** (`ffi/src/components/visual/hardware_buffer.rs`). The buffer is
described, imported as a `vk::Image` bound to imported memory, acquired from
`VK_QUEUE_FAMILY_FOREIGN_EXT`, copied into the wgpu capture texture, and released
back to the framework. Imports are cached by buffer pointer, so an `ImageReader`
rotating a small `maxImages` pays one import each and nothing per frame.

**Entry points.** `waterui_applied_filter_capture_format`,
`waterui_applied_filter_set_capture_hardware_buffer` and
`waterui_view_effect_set_input_hardware_buffer`, each with the non-Android
panicking twin the Metal getters already have, so the C header is the same on
every platform. `ViewEffect` keeps a wgpu input texture of the buffer's size and
layout, created once per size and cleared like the `AppliedFilter` capture
texture. `ffi/waterui.h` is regenerated (never hand-edited).

**JNI.** The whole `appliedFilter*` and `viewEffect*` families plus
`gpuCaptureFenceOnComplete`, following the `gpuSurface*` conventions exactly:
state handles as `Long`, `Surface` to `ANativeWindow`, and the redraw callback
installed by `*Create` rather than a separate call. Two `ToJavaStruct` impls give
Kotlin the force-cast results.

## The decision worth reviewing: raw image + copy, not an imported wgpu texture

Importing the buffer as a `wgpu::Texture` through `create_texture_from_hal` and
sampling it directly would be simpler and is wrong. `wgpu-core` records every
texture created that way as `TextureUses::UNINITIALIZED`, so the first barrier it
emits is `VK_IMAGE_LAYOUT_UNDEFINED` to `SHADER_READ_ONLY_OPTIMAL` with no
foreign-family acquire — a transition Vulkan explicitly permits an implementation
to satisfy by *discarding* the image's contents, which on a tiler is what happens.
The filter would then sample an empty capture. See #522.

So the imported buffer is never a wgpu texture, and its pixels reach wgpu only
through `vkCmdCopyImage`. The copy is recorded into a real `wgpu::CommandEncoder`
via `as_hal_mut` rather than a private command pool, which buys two things:

- **wgpu's tracker stays truthful without guessing.**
  `CommandEncoder::transition_resources` — wgpu's documented native-interoperability
  API — emits the barrier into `COPY_DST` from whatever state wgpu is actually
  tracking (`COLOR_TARGET` on the frame after the texture is created, `RESOURCE` on
  every frame after the filter sampled it) and records the new state, so the raw
  copy finds the image in `TRANSFER_DST_OPTIMAL` and leaves it exactly where wgpu
  expects to find it next frame. Restoring a fixed layout after the copy would have
  been true only on the first frame.
- **The fence is exact.** The submission is wgpu's own, so the returned
  `WuiGpuCaptureFence` carries a real `SubmissionIndex` and the existing
  `waterui_gpu_capture_fence_on_complete` machinery resolves it unchanged. A
  separate `vkQueueSubmit` could not have used it: Vulkan gives no guarantee that a
  later submission's fence implies an earlier one finished.

## Pre-existing defect fixed on the way

`applied_filter` and `view_effect` were gated on `all(feature = "c-api", feature =
"gpu")`, so neither module existed in an Android (`android-jni`) build — and the
JNI halves their `ffi_metadata!` / `ffi_view!` invocations declare could never
compile. Both are now gated on `gpu` alone, matching `gpu_surface`, with their JNI
force-casts enabled (they were `any()`, meaning never).

## Checks

Green: `cargo check`/`clippy --all-targets -D warnings`/`nextest` for
`waterui-graphics` and `waterui-ffi` on the host, and CI's exact Android FFI
invocation (`cargo clippy -p waterui-ffi --no-default-features --features
std,android-jni,gpu --target aarch64-linux-android --all-targets -- -D warnings`)
against NDK r29.

Known red: **FFI Header**. `generate_header` propagates `waterui.h` into
`backends/apple` and `backends/android`, and the job checks all three copies. The
design for this work assigns the submodule copies to the backend pull requests, so
this branch carries only `ffi/waterui.h` and leaves the pins alone. The job goes
green once the backend pull requests land and the pins are bumped.

## Nested GPU surfaces

HWUI records a `SurfaceView` as a cleared hole, so a `GpuSurface` inside a filtered
subtree never reached the captured buffer, and its own layer went on presenting
beside the filtered output — positioned by the capture's private `HardwareRenderer`,
which reports render-node positions in the captured buffer's coordinates rather than
the window's. On the `image` example the photo was missing from the blur and its
layer floated over the title, at exactly its x offset inside the capture.

`waterui_applied_filter_composite_gpu_surface` and its `view_effect` twin answer
both. The backend walks the captured content on every frame, between handing over
the hardware buffer and rendering the filter, and hands each nested surface's
rectangle in. The surface renders one frame into a texture of its own — the Metal
capture path's inner render, factored out as `render_into_texture` and shared, so
the frame is the same one Apple captures — and that texture is drawn into the
capture texture (or the effect's input texture) by a pipeline cached per target
format. The destination rectangle travels in a uniform rather than a viewport,
because WebGPU requires a viewport to be contained in its attachment while a surface
inside a scrolled container legitimately hangs over the edge of the capture; the
rasterizer clips it instead, which is also why the origin is signed. Everything is
submitted on the one queue in call order, so the buffer copy, the composites and the
filter render need no fence between them.

On the Kotlin side the suppression is the view's own visibility. Hiding the layer
with a `SurfaceControl` transaction does not hold — `SurfaceView` shows it again from
every position update HWUI reports for its render node, and the capture draws that
node every frame — while `INVISIBLE` is the one value `SurfaceView` derives layer
existence, position and visibility from. The view stays measured and laid out, so
the rectangle stays right, and losing the swapchain costs nothing because rendering
for a capture needs the renderer's established format and finished setup, not a
surface. A suppressed surface's redraw callback is forwarded to the hosts that took
it over, since it no longer drives a frame loop of its own.

Verified on a Pixel 9 Pro with `examples/image`: no panic, no wgpu validation error,
the filtered photo renders in its slot with nothing floating, it tracks its slot
across a scroll, and a second filter host created at runtime by the Custom URL
Loader renders sharp at blur 0 beside the blurred one.

Advances #504

