### PR TITLE
ci(ffi): build the header generator outside the framework graph and cache its expansion

### DIFF
--- a/.github/actions/ffi-header/action.yml
+++ b/.github/actions/ffi-header/action.yml
@@ -1,0 +1,61 @@
+name: ffi-header
+description: >-
+  Regenerates `ffi/waterui.h` with cbindgen and checks the three committed
+  copies against it. Both callers — the pull-request gate and the dev-push
+  cache warmer — go through here so they share one toolchain pin and one cache
+  key; only the warmer passes `save: 'true'`.
+
+inputs:
+  save:
+    description: >-
+      Whether this run writes the cache it restores. `'true'` on pushes to
+      `dev`, so pull requests read a warm cache without ever competing to
+      write it.
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    # The one place the header toolchain is named. cbindgen expands the
+    # macro-generated exports through `cargo rustc -- -Zunpretty=expanded`, so
+    # this is the only nightly in the repository — and it is a fixed date
+    # rather than the channel, because rust-cache keys on the rustc version and
+    # a moving `nightly` invalidates the cache below every single day.
+    - uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: nightly-2026-09-09
+    # The expansion is a check-profile build of the `waterui-ffi` graph, whose
+    # rmeta artifacts are a fraction of the 0.8 GB dev-profile tarball this job
+    # used to measure. It gets its own key because it is the only nightly
+    # consumer in the repository: sharing the stable jobs' `cargo-home` key
+    # restored nothing, since the rustc version is part of what rust-cache
+    # hashes.
+    - uses: Swatinem/rust-cache@v2
+      with:
+        shared-key: ffi-header-${{ runner.os }}
+        cache-targets: true
+        save-if: ${{ inputs.save }}
+        cache-on-failure: true
+    # `+nightly-2026-09-09` is named rather than inherited: `rust-toolchain.toml`
+    # pins the repository to stable and overrides what the action above sets, so
+    # an ambient `cargo run` here would generate the header with the wrong
+    # channel and cbindgen would lose the macro expansion.
+    - name: Regenerate the header
+      shell: bash
+      run: cargo +nightly-2026-09-09 run --manifest-path ffi/generator/Cargo.toml
+    - name: Verify the committed header matches
+      shell: bash
+      run: |
+        set -euo pipefail
+        status=0
+        check() {
+          if ! git -C "$1" diff --exit-code -- "$2"; then
+            echo "::error file=$2::$2 is stale; on macOS run 'cargo +nightly run --manifest-path ffi/generator/Cargo.toml' and commit the result"
+            status=1
+          fi
+        }
+        check . ffi/waterui.h
+        check backends/apple Sources/CWaterUI/include/waterui.h
+        check backends/android runtime/src/main/cpp/waterui.h
+        exit "$status"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -188,40 +188,19 @@ jobs:
       - uses: actions/checkout@v4
         with:
           submodules: recursive
-      # The only job that needs nightly: cbindgen expands the FFI macros through
-      # `cargo rustc -- -Zunpretty=expanded`, and the exported functions are
-      # macro-generated, so the expansion cannot be skipped.
-      - uses: dtolnay/rust-toolchain@nightly
-      # Dependency caches only: the full target tarball measured 0.8GB and, in
-      # a quota squeezed by the two Test tarballs, was evicted before every
-      # single restore — this job has never once hit it. Storing just the
-      # dependency caches keeps the quota pressure off the caches that do hit.
-      - uses: Swatinem/rust-cache@v2
+      # The toolchain pin, the cache and the verification all live in the
+      # action, which `ffi-header-cache.yml` runs on pushes to `dev` with
+      # `save: 'true'`. That warmer is the only writer; this job reads.
+      #
+      # The cache hits here where the old one never did: the generator is its
+      # own crate whose build costs cbindgen alone, the one framework compile
+      # left is cbindgen's check-profile expansion — rmeta, a fraction of the
+      # 0.8 GB dev-profile tarball this job measured when it last tried a target
+      # cache — and the nightly it runs on is a fixed date instead of a channel
+      # that moved out from under the key every day.
+      - uses: ./.github/actions/ffi-header
         with:
-          shared-key: cargo-home-${{ runner.os }}
-          cache-targets: false
-          save-if: false
-          cache-on-failure: true
-      # `+nightly` is named rather than inherited: `rust-toolchain.toml` pins the
-      # repository to stable and overrides what the action above sets, so an
-      # ambient `cargo run` here would generate the header with the wrong
-      # channel and cbindgen would lose the macro expansion.
-      - name: Regenerate the header
-        run: cargo +nightly run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
-      - name: Verify the committed header matches
-        run: |
-          set -euo pipefail
-          status=0
-          check() {
-            if ! git -C "$1" diff --exit-code -- "$2"; then
-              echo "::error file=$2::$2 is stale; on macOS run 'cargo +nightly run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml' and commit the result"
-              status=1
-            fi
-          }
-          check . ffi/waterui.h
-          check backends/apple Sources/CWaterUI/include/waterui.h
-          check backends/android runtime/src/main/cpp/waterui.h
-          exit "$status"
+          save: 'false'
 
   android-ffi:
     name: Android FFI

--- a/.github/workflows/ffi-header-cache.yml
+++ b/.github/workflows/ffi-header-cache.yml
@@ -1,0 +1,45 @@
+name: FFI Header Cache
+
+# The only writer of the `ffi-header-<os>` cache. The pull-request gate in
+# `ci.yml` restores it read-only, so a PR never pays for the expansion it did
+# not change and never competes to save it. Running the full check here as well
+# means `dev` is also told immediately when a merge left the header stale.
+on:
+  push:
+    branches: [dev]
+    paths:
+      - ffi/**
+      - backends/apple
+      - backends/android
+      - Cargo.lock
+      - '**/Cargo.toml'
+      - .github/actions/ffi-header/**
+      - .github/workflows/ffi-header-cache.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ffi-header-cache-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+
+jobs:
+  warm:
+    name: FFI Header Cache
+    # The header is platform-dependent: the Apple exports (Metal, CEF) only
+    # appear when cbindgen expands on an Apple target, so the cache has to be
+    # warmed on the same host that generates it.
+    runs-on: macos-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ./.github/actions/ffi-header
+        with:
+          save: 'true'

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -263,8 +263,9 @@ cargo test --doc --workspace
 # Also run it locally after touching components/platform/webview/src/js/
 bun test components/platform/webview/tests/js/
 
-# Generate FFI C header (after modifying ffi/ APIs), never write C header by hand
-cargo +nightly run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
+# Generate FFI C header (after modifying ffi/ APIs), never write C header by hand.
+# The generator is its own crate so building it costs cbindgen, not the framework.
+cargo +nightly run --manifest-path ffi/generator/Cargo.toml
 
 # Build Apple backend
 cd backends/apple && swift build

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12837,7 +12837,6 @@ dependencies = [
  "ash",
  "async-channel",
  "base64 0.22.1",
- "cbindgen",
  "cookie",
  "executor-core",
  "jiff",
@@ -12879,6 +12878,13 @@ dependencies = [
  "waterui-webview",
  "wgpu",
  "wgpu-hal",
+]
+
+[[package]]
+name = "waterui-ffi-generator"
+version = "0.1.0"
+dependencies = [
+ "cbindgen",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "src",
     "testing",
     "ffi",
+    "ffi/generator",
     "macros",
     "cli",
     "examples/*",

--- a/ffi/Cargo.toml
+++ b/ffi/Cargo.toml
@@ -28,7 +28,6 @@ native-executor.workspace = true
 waterui-layout.workspace = true
 nami.workspace = true
 executor-core.workspace = true
-cbindgen = { version = "0.29.4", optional = true }
 # JNI crate - optional, enabled by android-jni feature for Android builds
 jni = { version = "0.22.4", optional = true }
 waterui-graphics = { workspace = true, features = ["cpu-scene"] }
@@ -79,11 +78,6 @@ wgpu-hal = { workspace = true, features = ["metal"], optional = true }
 waterkit-audio = { workspace = true, default-features = false, features = ["apple-artwork"] }
 
 
-[[bin]]
-name = "generate_header"
-path = "generate_header.rs"
-required-features = ["cbindgen"]
-
 [lints]
 workspace = true
 
@@ -117,13 +111,11 @@ android-jni = ["dep:jni", "std"]
 # tile, styling, and image-decoding stack, which no app that never shows a map
 # should pay for. Apple bridges MapKit instead and only needs the marshalling.
 map = ["dep:waterui-map"]
-# The checked-in `waterui.h` is a superset of every optional surface, so header
-# generation turns them all on. Native backends compile the matching component
-# only when the app enabled that feature.
-cbindgen = ["dep:cbindgen", "header"]
-# Every optional C surface the checked-in `waterui.h` must declare. Header
-# generation and the header's macro expansion both read this one list, so a new
-# optional surface is added in exactly one place.
+# Every optional C surface the checked-in `waterui.h` must declare. That header
+# is a superset of every optional surface, so the generator in `ffi/generator`
+# expands this crate with exactly this feature on; native backends compile the
+# matching component only when the app enabled that feature. A new optional
+# surface is added in exactly one place.
 header = ["cef-header", "map"]
 cef-runtime = [
     "gpu",

--- a/ffi/README.md
+++ b/ffi/README.md
@@ -317,7 +317,7 @@ into_ffi! {
 ffi_view!(RatingConfig, WuiRating, rating);
 
 // 3. Regenerate waterui.h
-// cargo run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
+// cargo +nightly run --manifest-path ffi/generator/Cargo.toml
 
 // 4. Implement in Swift (backends/apple/Sources/WaterUI/Views/Rating.swift)
 // if viewId == waterui_rating_id() {
@@ -353,10 +353,13 @@ let text = waterui_text(computed)
 
 ## C Header Generation
 
-The crate includes a `generate_header` binary that uses `cbindgen` to produce `waterui.h`:
+The sibling `waterui-ffi-generator` crate (`ffi/generator`) provides the `generate_header`
+binary, which uses `cbindgen` to produce `waterui.h`. It lives outside this crate so that
+building it costs cbindgen alone instead of the whole framework graph, and it needs nightly
+because cbindgen expands the macro-generated exports through `-Zunpretty=expanded`:
 
 ```bash
-cargo run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
+cargo +nightly run --manifest-path ffi/generator/Cargo.toml
 ```
 
 This generates the C header and automatically copies it to:
@@ -408,7 +411,8 @@ WaterUI distinguishes between two kinds of views:
 ## Features
 
 - **`std`** (default) - Enable standard library support
-- **`cbindgen`** - Required for the `generate_header` binary
+- **`header`** - Every optional C surface the checked-in `waterui.h` declares; what
+  `waterui-ffi-generator` expands this crate with
 
 ## API Overview
 
@@ -472,7 +476,7 @@ When adding a new view type to WaterUI:
 
 1. Define the Rust view struct in the appropriate component crate
 2. Add FFI bindings in `ffi/src/components/<module>.rs`
-3. Regenerate the C header: `cargo run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml`
+3. Regenerate the C header: `cargo +nightly run --manifest-path ffi/generator/Cargo.toml`
 4. Implement the native renderer in Swift (`backends/apple`) and Kotlin (`backends/android`)
 5. Update tests to verify FFI contract
 

--- a/ffi/generator/Cargo.toml
+++ b/ffi/generator/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "waterui-ffi-generator"
+version = "0.1.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+description = "Generates the checked-in `waterui.h` C header from the `waterui-ffi` crate"
+publish = false
+
+# Deliberately not a `[[bin]]` of `waterui-ffi`: building a bin inside that
+# crate compiles the whole framework dependency graph in the dev profile before
+# cbindgen has done anything, and cbindgen then checks the same graph again for
+# its `-Zunpretty=expanded` expansion. Out here the generator's own build costs
+# cbindgen alone, leaving exactly one compile of the framework — the expansion.
+[[bin]]
+name = "generate_header"
+path = "generate_header.rs"
+
+[dependencies]
+cbindgen = "0.29.4"
+
+[lints]
+workspace = true

--- a/ffi/generator/generate_header.rs
+++ b/ffi/generator/generate_header.rs
@@ -1,6 +1,14 @@
 //! Regenerates `ffi/waterui.h` from the `waterui-ffi` crate via cbindgen and
 //! propagates the header to the native backend submodules.
-use std::{env, fs, path::PathBuf};
+//!
+//! The generator lives in its own crate so that building it does not build the
+//! framework: its only dependency is cbindgen, and the single compile of the
+//! `waterui-ffi` graph left is the check-profile expansion cbindgen drives
+//! itself. Both the cbindgen configuration and the feature list stay where they
+//! were — `ffi/cbindgen.toml` and the `header` feature of `ffi/Cargo.toml` —
+//! and are read from the sibling crate directory.
+
+use std::{env, fs, path::Path, path::PathBuf};
 
 use cbindgen::{Builder, Config};
 
@@ -12,7 +20,7 @@ fn main() {
     // expansion produces nothing cacheable; every real build keeps its wrapper.
     // SAFETY: called at the start of `main`, before any other thread exists.
     unsafe { env::set_var("RUSTC_WRAPPER", "") };
-    let crate_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let crate_dir = ffi_crate_dir();
     let mut config =
         Config::from_file(crate_dir.join("cbindgen.toml")).expect("failed to load cbindgen.toml");
     config
@@ -34,10 +42,21 @@ fn main() {
     propagate_to_backends(&header_path);
 }
 
-fn propagate_to_backends(header_path: &std::path::Path) {
+/// Directory of the `waterui-ffi` crate this generator binds, which is the
+/// parent of this crate's own directory.
+fn ffi_crate_dir() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("failed to determine the FFI crate directory from the generator manifest path")
+        .to_path_buf()
+}
+
+/// Copies the freshly generated header over the native backends' checked-in
+/// copies, which CI compares against this one.
+fn propagate_to_backends(header_path: &Path) {
     let workspace_root = header_path
         .parent()
-        .and_then(|p| p.parent())
+        .and_then(Path::parent)
         .expect("failed to determine workspace root from FFI header path");
 
     let destinations = [

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -12,7 +12,7 @@
 # the channel explicitly, and an explicit `+toolchain` always wins over this
 # file:
 #
-#     cargo +nightly run --bin generate_header --features cbindgen --manifest-path ffi/Cargo.toml
+#     cargo +nightly run --manifest-path ffi/generator/Cargo.toml
 [toolchain]
 channel = "stable"
 components = ["clippy", "rustfmt"]


### PR DESCRIPTION
The `FFI Header` job took 24 minutes on every pull request touching `ffi/**` or a backend submodule (run 34437721362, job 102746205213), the longest gating job a backend PR waited on — #523 and #525 each waited ~40 minutes on it, against 6 for the Android FFI clippy beside it.

| phase | before |
|---|---|
| building the generator (`cargo +nightly run --bin generate_header --features cbindgen`) | 12m46s |
| running it (cbindgen's `cargo rustc --lib --profile=check -- -Zunpretty=expanded`) | 11m37s |

Both halves compiled the whole framework cold, and nothing was ever reused: `generate_header` was a `[[bin]]` inside `waterui-ffi`, so building it built the entire graph in the dev profile only for cbindgen to check the same graph again under the check profile; and the job's cache key never matched, because it restored the stable jobs' `cargo-home` cache while running on the `nightly` channel, which moves daily.

### Three parts

1. **`waterui-ffi-generator` (`ffi/generator`)** owns the generator, with cbindgen as its only dependency. `waterui-ffi` loses the bin, the optional `cbindgen` dependency and the `cbindgen` feature; the `header` feature that one aggregated stays exactly where it was, and the generator still reads `ffi/cbindgen.toml` and expands with `header`. Building it costs cbindgen alone — **16 seconds locally** against the 12m46s above — leaving one compile of the framework, the expansion. The regenerated header is byte-identical to the committed one, so the submodule copies are untouched.
2. **`.github/actions/ffi-header`** holds the toolchain pin, the cache and the header verification, so both callers share one of each. The nightly is a fixed date (`nightly-2026-09-09`) rather than the channel, which is what makes the key stable day to day, and the cache is this job's own `ffi-header-<os>` key over check-profile artifacts — rmeta, a fraction of the 0.8 GB dev-profile tarball the job measured when it last tried a target cache.
3. **`ffi-header-cache.yml`** runs that action on pushes to `dev` that touch the FFI, a submodule, the lockfile or a manifest, and is the only writer of the cache. The gate in `ci.yml` reads it, so a pull request never pays for an expansion it did not change and never competes to save one.

The documented command becomes `cargo +nightly run --manifest-path ffi/generator/Cargo.toml`; `ffi/README.md`, `rust-toolchain.toml` and the stale-header error message are updated, and `AGENTS.md` needs the same one-line change.

Note on reading the numbers here: this PR's own run still generates the header against an empty `ffi-header-<os>` cache — it is the merge to `dev` that warms it, so the second FFI-touching PR is the one that shows the time.

Fixes #526