### PR TITLE
feat(text): define the default type scale once

### DIFF
--- a/backends/dew/src/text.rs
+++ b/backends/dew/src/text.rs
@@ -739,15 +739,7 @@ mod tests {
     fn test_environment() -> Environment {
         let mut env = Environment::new();
         Theme::new()
-            .fonts(
-                FontSettings::new()
-                    .body(ResolvedFont::new(16.0, FontWeight::Normal))
-                    .title(ResolvedFont::new(24.0, FontWeight::Normal))
-                    .headline(ResolvedFont::new(22.0, FontWeight::Normal))
-                    .subheadline(ResolvedFont::new(20.0, FontWeight::Normal))
-                    .caption(ResolvedFont::new(12.0, FontWeight::Normal))
-                    .footnote(ResolvedFont::new(11.0, FontWeight::Normal)),
-            )
+            .fonts(FontSettings::default_scale())
             .install(&mut env);
         env
     }
@@ -765,7 +757,8 @@ mod tests {
     }
 
     /// `.title()` / `.sub_headline()` spans must shape at their preset font
-    /// sizes, visibly distinct from body text.
+    /// styles, visibly distinct from body text: under the default scale title
+    /// differs in size, subheadline in weight.
     #[test]
     fn styled_spans_produce_distinct_font_sizes() {
         let env = test_environment();
@@ -776,10 +769,21 @@ mod tests {
         styled.push(" body", Style::new());
 
         let layout = state.build_styled_layout(&styled, &env, None, theme::FOREGROUND);
-        let sizes = run_font_sizes(&layout);
+        let mut runs = Vec::new();
+        for line in layout.lines() {
+            for item in line.items() {
+                if let parley::PositionedLayoutItem::GlyphRun(glyph_run) = item {
+                    let run = glyph_run.run();
+                    runs.push((run.font_size(), run.font_attrs().weight.value()));
+                }
+            }
+        }
         assert!(
-            sizes.contains(&24.0) && sizes.contains(&20.0) && sizes.contains(&16.0),
-            "expected title (24), subheadline (20), and body (16) runs, got {sizes:?}"
+            runs.contains(&(22.0, 400.0))
+                && runs.contains(&(16.0, 500.0))
+                && runs.contains(&(16.0, 400.0)),
+            "expected title (22/normal), subheadline (16/medium), and body \
+             (16/normal) runs, got {runs:?}"
         );
 
         let (_, title_height) = state.measure_styled(&StyledStr::plain("Heading"), &env, None);

--- a/backends/dew/src/theme.rs
+++ b/backends/dew/src/theme.rs
@@ -12,7 +12,7 @@ use waterui_graphics::color::{
     MutedForegroundColor, ResolvedColor, Srgb, SurfaceColor, SurfaceVariantColor,
 };
 use waterui_text::font::{
-    Body, Caption, Font, FontWeight, Footnote, Headline, ResolvedFont, Subheadline, Title,
+    Body, Caption, Font, FontSlot, Footnote, Headline, ResolvedFont, Subheadline, Title,
 };
 use waterui_text::styled::StyledStr;
 
@@ -46,26 +46,8 @@ pub const TRACK: Color = Color::from_rgb8(229, 229, 234);
 /// Movable control knobs: toggle and slider thumbs.
 pub const THUMB: Color = Color::WHITE;
 
-/// Body text: the size and weight `text("…")` shapes at.
-pub const BODY_FONT: ResolvedFont = ResolvedFont::new(16.0, FontWeight::Normal);
-
-/// Screen and section titles.
-pub const TITLE_FONT: ResolvedFont = ResolvedFont::new(22.0, FontWeight::Normal);
-
-/// The most prominent line on a screen.
-pub const HEADLINE_FONT: ResolvedFont = ResolvedFont::new(24.0, FontWeight::Normal);
-
-/// Body-sized text carrying a heading's emphasis.
-pub const SUBHEADLINE_FONT: ResolvedFont = ResolvedFont::new(16.0, FontWeight::Medium);
-
-/// Secondary annotations beside content.
-pub const CAPTION_FONT: ResolvedFont = ResolvedFont::new(12.0, FontWeight::Normal);
-
-/// The smallest supporting text.
-pub const FOOTNOTE_FONT: ResolvedFont = ResolvedFont::new(11.0, FontWeight::Medium);
-
-/// Installs dew's built-in type scale for every font slot the application's
-/// theme left unset.
+/// Installs the framework's default type scale for every font slot the
+/// application's theme left unset.
 ///
 /// Font slots are the one part of the palette dew cannot resolve at draw time:
 /// a colour an application never chose falls back to this module's constants
@@ -79,23 +61,23 @@ pub const FOOTNOTE_FONT: ResolvedFont = ResolvedFont::new(11.0, FontWeight::Medi
 ///
 /// [`DewRenderer::render_tree`]: crate::DewRenderer::render_tree
 ///
-/// The scale matches the one every other `WaterUI` backend defaults to, so the
-/// same view has the same proportions on a panel and on a desktop window. No
-/// family is named: firmware shapes with the faces its board bundles, and a
-/// desktop simulator with the system collection.
+/// The scale is the shared [`FontSlot::DEFAULT`] values every `WaterUI`
+/// backend installs, so the same view has the same proportions on a panel and
+/// on a desktop window. No family is named: firmware shapes with the faces
+/// its board bundles, and a desktop simulator with the system collection.
 pub fn install_default_fonts(env: &mut Environment) {
-    install_default::<Body>(env, BODY_FONT);
-    install_default::<Title>(env, TITLE_FONT);
-    install_default::<Headline>(env, HEADLINE_FONT);
-    install_default::<Subheadline>(env, SUBHEADLINE_FONT);
-    install_default::<Caption>(env, CAPTION_FONT);
-    install_default::<Footnote>(env, FOOTNOTE_FONT);
+    install_default::<Body>(env);
+    install_default::<Title>(env);
+    install_default::<Headline>(env);
+    install_default::<Subheadline>(env);
+    install_default::<Caption>(env);
+    install_default::<Footnote>(env);
 }
 
-fn install_default<T: 'static>(env: &mut Environment, font: ResolvedFont) {
+fn install_default<T: FontSlot + 'static>(env: &mut Environment) {
     if env.query::<T, Computed<ResolvedFont>>().is_none() {
         env.insert(Store::<T, Computed<ResolvedFont>>::new(Computed::constant(
-            font,
+            T::DEFAULT,
         )));
     }
 }

--- a/backends/dew/tests/form_render.rs
+++ b/backends/dew/tests/form_render.rs
@@ -124,24 +124,24 @@ fn form_scene_contains_expected_widget_commands() {
         .filter(|placed| {
             matches!(
                 placed.command(),
-                DrawCommand::GlyphRun { font_size, .. } if (font_size - 24.0).abs() < f32::EPSILON
+                DrawCommand::GlyphRun { font_size, .. } if (font_size - 22.0).abs() < f32::EPSILON
             )
         })
         .count();
-    assert!(title_runs >= 1, "the .title() text must shape at 24px");
+    assert!(title_runs >= 1, "the .title() text must shape at 22px");
 
     let subheadline_runs = commands
         .iter()
         .filter(|placed| {
             matches!(
                 placed.command(),
-                DrawCommand::GlyphRun { font_size, .. } if (font_size - 20.0).abs() < f32::EPSILON
+                DrawCommand::GlyphRun { font_size, .. } if (font_size - 16.0).abs() < f32::EPSILON
             )
         })
         .count();
     assert!(
         subheadline_runs >= 2,
-        "both .sub_headline() sections must shape at 20px"
+        "both .sub_headline() sections must shape at 16px"
     );
 
     let accent_fills = commands

--- a/backends/dew/tests/navigation_render.rs
+++ b/backends/dew/tests/navigation_render.rs
@@ -405,7 +405,7 @@ fn a_bar_places_every_part_it_declares() {
         .commands()
         .iter()
         .find(|placed| {
-            matches!(placed.command(), DrawCommand::GlyphRun { font_size, .. } if exact_f32(*font_size, 24.0))
+            matches!(placed.command(), DrawCommand::GlyphRun { font_size, .. } if exact_f32(*font_size, 22.0))
         })
         .unwrap_or_else(|| panic!("the large title uses the configured title font: {title_sizes:?}"));
     assert_eq!(top_bar.intersect(title.bounds()), title.bounds());

--- a/backends/dew/tests/support/mod.rs
+++ b/backends/dew/tests/support/mod.rs
@@ -6,7 +6,6 @@ use waterui_backend_core::frame_signals::FrameSignals;
 use waterui_backend_core::time::Instant;
 use waterui_core::Environment;
 use waterui_dew::{DewRenderer, DisplayList, DrawCommand, FontSources, PlacedCommand};
-use waterui_text::font::{FontWeight, ResolvedFont};
 
 use std::path::PathBuf;
 
@@ -19,15 +18,7 @@ pub fn test_environment() -> Environment {
 
     let mut environment = Environment::new();
     Theme::new()
-        .fonts(
-            FontSettings::new()
-                .body(ResolvedFont::new(16.0, FontWeight::Normal))
-                .title(ResolvedFont::new(24.0, FontWeight::Normal))
-                .headline(ResolvedFont::new(22.0, FontWeight::Normal))
-                .subheadline(ResolvedFont::new(20.0, FontWeight::Normal))
-                .caption(ResolvedFont::new(12.0, FontWeight::Normal))
-                .footnote(ResolvedFont::new(11.0, FontWeight::Normal)),
-        )
+        .fonts(FontSettings::default_scale())
         .install(&mut environment);
     environment
 }

--- a/backends/hydrolysis/src/testing.rs
+++ b/backends/hydrolysis/src/testing.rs
@@ -3,7 +3,6 @@
 use waterui::{
     Environment, Plugin,
     color::{ResolvedColor, Srgb},
-    text::font::{FontWeight, ResolvedFont},
     theme::{ColorScheme, ColorSettings, FontSettings, Theme},
 };
 use waterui_core::{AnyView, Native};
@@ -51,14 +50,6 @@ pub fn install_theme(env: &mut Environment) {
                 .selection_container(color(0x25_63_EB))
                 .selection_foreground(color(0xFF_FF_FF)),
         )
-        .fonts(
-            FontSettings::new()
-                .body(ResolvedFont::new(16.0, FontWeight::Normal))
-                .title(ResolvedFont::new(22.0, FontWeight::Normal))
-                .headline(ResolvedFont::new(24.0, FontWeight::Normal))
-                .subheadline(ResolvedFont::new(16.0, FontWeight::Medium))
-                .caption(ResolvedFont::new(12.0, FontWeight::Normal))
-                .footnote(ResolvedFont::new(11.0, FontWeight::Medium)),
-        )
+        .fonts(FontSettings::default_scale())
         .install(env);
 }

--- a/components/foundation/text/src/font.rs
+++ b/components/foundation/text/src/font.rs
@@ -215,11 +215,30 @@ impl Font {
     }
 }
 
+/// A semantic font slot in the theme's type scale.
+///
+/// Implemented by each font slot type (`Body`, `Title`, `Headline`,
+/// `Subheadline`, `Caption`, `Footnote`). The slot's [`FontSlot::DEFAULT`]
+/// constants are the framework-wide default type scale every backend installs
+/// when the application theme leaves the slot unset.
+pub trait FontSlot {
+    /// The default font for this slot.
+    ///
+    /// Together these constants form the framework-wide default type scale
+    /// every backend installs when the application theme leaves the slot
+    /// unset.
+    const DEFAULT: ResolvedFont;
+}
+
 macro_rules! impl_font {
-    ($name:ident, $doc:expr) => {
+    ($name:ident, $doc:expr, $size:expr, $weight:expr) => {
         #[doc = $doc]
         #[derive(Debug, Clone, Copy)]
         pub struct $name;
+
+        impl FontSlot for $name {
+            const DEFAULT: ResolvedFont = ResolvedFont::new($size, $weight);
+        }
 
         impl Resolvable for $name {
             type Resolved = ResolvedFont;
@@ -242,9 +261,14 @@ macro_rules! impl_font {
         impl_constant!($name);
     };
 }
-impl_font!(Body, "Body font style.");
-impl_font!(Title, "Title font style.");
-impl_font!(Headline, "Headline font style.");
-impl_font!(Subheadline, "Subheadline font style.");
-impl_font!(Caption, "Caption font style.");
-impl_font!(Footnote, "Footnote font style.");
+impl_font!(Body, "Body font style.", 16.0, FontWeight::Normal);
+impl_font!(Title, "Title font style.", 22.0, FontWeight::Normal);
+impl_font!(Headline, "Headline font style.", 24.0, FontWeight::Normal);
+impl_font!(
+    Subheadline,
+    "Subheadline font style.",
+    16.0,
+    FontWeight::Medium
+);
+impl_font!(Caption, "Caption font style.", 12.0, FontWeight::Normal);
+impl_font!(Footnote, "Footnote font style.", 11.0, FontWeight::Medium);

--- a/src/theme/mod.rs
+++ b/src/theme/mod.rs
@@ -106,7 +106,7 @@ use waterui_core::{Environment, env::Store, plugin::Plugin};
 
 use crate::{
     color::ResolvedColor,
-    text::font::{Body, Caption, Footnote, Headline, ResolvedFont, Subheadline, Title},
+    text::font::{Body, Caption, FontSlot, Footnote, Headline, ResolvedFont, Subheadline, Title},
 };
 
 // ============================================================================
@@ -347,6 +347,23 @@ impl FontSettings {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Creates the full default type scale, with every slot set to its
+    /// [`FontSlot::DEFAULT`].
+    ///
+    /// This is the scale every backend installs when the application theme
+    /// leaves a font slot unset; use [`FontSettings::new`] to start from an
+    /// empty override set instead.
+    #[must_use]
+    pub fn default_scale() -> Self {
+        Self::new()
+            .body(<Body as FontSlot>::DEFAULT)
+            .title(<Title as FontSlot>::DEFAULT)
+            .headline(<Headline as FontSlot>::DEFAULT)
+            .subheadline(<Subheadline as FontSlot>::DEFAULT)
+            .caption(<Caption as FontSlot>::DEFAULT)
+            .footnote(<Footnote as FontSlot>::DEFAULT)
     }
 
     /// Sets the body font.


### PR DESCRIPTION
Fixes #383

The default type scale was written out as six `ResolvedFont` values in four places, and the two dew test copies had already drifted from the scale the backends ship (title 24 instead of 22, headline 22 instead of 24, subheadline 20/Normal instead of 16/Medium, footnote Normal instead of Medium).

- `waterui_text::font::FontSlot` gives every slot type its default as an associated constant (`Body::DEFAULT` …), filled in by the `impl_font!` macro.
- `FontSettings::default_scale()` builds the full scale from those constants.
- Dew's `install_default_fonts`, hydrolysis' test theme, dew's test support and the dew text unit test read the shared scale; the drifted assertions in `form_render`, `navigation_render` and the styled-span test now check the real values.

Foundation crate change approved on #383.