### PR TITLE
fix(release): drop the waterui-image override from release-plz.toml

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -66,10 +66,6 @@ name = "waterui-icon"
 git_tag_name = "icon-v{{ version }}"
 
 [[package]]
-name = "waterui-image"
-git_tag_name = "image-v{{ version }}"
-
-[[package]]
 name = "waterui-video"
 git_tag_name = "video-v{{ version }}"
 


### PR DESCRIPTION
Fixes #529

The release run after #500 aborted both jobs on `overrides are not present in the workspace: waterui-image`. The crate is a registry dependency now; the stale `[[package]]` entry is the only one not backed by a workspace member.