### PR TITLE
Release: dev → main (release-plz config fix)

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -66,10 +66,6 @@ name = "waterui-icon"
 git_tag_name = "icon-v{{ version }}"
 
 [[package]]
-name = "waterui-image"
-git_tag_name = "image-v{{ version }}"
-
-[[package]]
 name = "waterui-video"
 git_tag_name = "video-v{{ version }}"
 


### PR DESCRIPTION
Carries dev's tree onto main after #500. The only change since main is #530 (drop the stale `waterui-image` override from `release-plz.toml`, #529), which made both release jobs abort before publishing. Merging re-runs `release.yml` on main.