### PR TITLE
build(deps): consume the extracted crates from crates.io at their foundation-0.4 releases

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.21.3",
+ "darling 0.23.0",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2456,7 +2456,6 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
- "strsim",
  "syn 2.0.119",
 ]
 
@@ -12206,41 +12205,6 @@ dependencies = [
  "smallvec",
  "smol",
  "swift-bridge",
- "symphonia-codec-aac",
- "symphonia-core 0.6.1",
- "tempfile",
- "thiserror 2.0.20",
- "timestretch",
- "tracing",
- "url",
- "wasm-bindgen",
- "waterkit-build 0.1.1",
- "web-sys",
- "windows 0.62.2",
- "zbus",
- "zenwave 0.5.0",
-]
-
-[[package]]
-name = "waterkit-audio"
-version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
-dependencies = [
- "async-channel",
- "cpal 0.18.2",
- "futures",
- "jni 0.22.4",
- "js-sys",
- "lofty",
- "mpris-server",
- "ndk",
- "ndk-context",
- "ndk-sys",
- "num-traits",
- "rodio",
- "smallvec",
- "smol",
- "swift-bridge",
  "symphonia-adapter-fdk-aac",
  "symphonia-codec-aac",
  "symphonia-core 0.6.1",
@@ -12250,27 +12214,16 @@ dependencies = [
  "tracing",
  "url",
  "wasm-bindgen",
- "waterkit-build 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-build",
  "web-sys",
  "windows 0.62.2",
  "zbus",
- "zenwave 0.6.1",
+ "zenwave 0.5.0",
 ]
 
 [[package]]
 name = "waterkit-build"
 version = "0.1.1"
-dependencies = [
- "jni 0.22.4",
- "ndk-context",
- "swift-bridge-build",
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "waterkit-build"
-version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
 dependencies = [
  "jni 0.22.4",
  "ndk-context",
@@ -12292,7 +12245,7 @@ dependencies = [
  "objc",
  "swift-bridge",
  "thiserror 2.0.20",
- "waterkit-build 0.1.1",
+ "waterkit-build",
  "waterkit-core",
  "wgpu",
 ]
@@ -12325,7 +12278,7 @@ dependencies = [
  "thiserror 2.0.20",
  "tracing",
  "wasm-bindgen-futures",
- "waterkit-build 0.1.1",
+ "waterkit-build",
  "web-sys",
 ]
 
@@ -12356,44 +12309,8 @@ dependencies = [
  "swift-bridge",
  "thiserror 2.0.20",
  "tracing",
- "waterkit-build 0.1.1",
- "waterkit-video-core 0.1.1",
- "wgpu",
- "wgpu-hal",
- "windows 0.62.2",
- "yuv",
-]
-
-[[package]]
-name = "waterkit-codec"
-version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
-dependencies = [
- "avif-parse",
- "cros-codecs",
- "half",
- "image",
- "jni 0.22.4",
- "libc",
- "moxcms",
- "ndk",
- "ndk-sys",
- "objc2 0.6.4",
- "objc2-core-foundation",
- "objc2-core-media",
- "objc2-core-video",
- "objc2-foundation 0.3.2",
- "objc2-io-surface",
- "objc2-metal 0.3.2",
- "objc2-video-toolbox",
- "rav1d",
- "rav1e",
- "shaderloom",
- "swift-bridge",
- "thiserror 2.0.20",
- "tracing",
- "waterkit-build 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
- "waterkit-video-core 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-build",
+ "waterkit-video-core",
  "wgpu",
  "wgpu-hal",
  "windows 0.62.2",
@@ -12422,8 +12339,8 @@ dependencies = [
  "roxmltree 0.21.1",
  "swift-bridge",
  "thiserror 2.0.20",
- "waterkit-build 0.1.1",
- "waterkit-fs 0.1.1",
+ "waterkit-build",
+ "waterkit-fs",
 ]
 
 [[package]]
@@ -12439,25 +12356,7 @@ dependencies = [
  "swift-bridge",
  "thiserror 2.0.20",
  "tracing",
- "waterkit-build 0.1.1",
- "windows 0.62.2",
-]
-
-[[package]]
-name = "waterkit-fs"
-version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
-dependencies = [
- "async-fs",
- "dirs 6.0.0",
- "indexed_db_futures",
- "jni 0.22.4",
- "serde",
- "serde_json",
- "swift-bridge",
- "thiserror 2.0.20",
- "tracing",
- "waterkit-build 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-build",
  "windows 0.62.2",
 ]
 
@@ -12470,7 +12369,7 @@ dependencies = [
  "ndk-context",
  "swift-bridge",
  "thiserror 2.0.20",
- "waterkit-build 0.1.1",
+ "waterkit-build",
  "waterkit-core",
  "windows 0.62.2",
  "zbus",
@@ -12489,7 +12388,7 @@ dependencies = [
  "swift-bridge",
  "thiserror 2.0.20",
  "wasm-bindgen",
- "waterkit-build 0.1.1",
+ "waterkit-build",
  "waterkit-core",
  "waterkit-permission",
  "web-sys",
@@ -12509,7 +12408,7 @@ dependencies = [
  "swift-bridge",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "waterkit-build 0.1.1",
+ "waterkit-build",
  "waterkit-core",
  "web-sys",
  "windows 0.62.2",
@@ -12532,7 +12431,7 @@ dependencies = [
  "swift-bridge",
  "thiserror 2.0.20",
  "tracing",
- "waterkit-build 0.1.1",
+ "waterkit-build",
  "waterkit-core",
  "wayland-sys",
  "wgpu",
@@ -12542,10 +12441,9 @@ dependencies = [
 [[package]]
 name = "waterkit-video"
 version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
 dependencies = [
  "waterkit-video-container",
- "waterkit-video-core 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-video-core",
  "waterkit-video-player",
  "waterkit-video-streaming",
 ]
@@ -12553,7 +12451,6 @@ dependencies = [
 [[package]]
 name = "waterkit-video-container"
 version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
 dependencies = [
  "broadcast-common",
  "byteorder",
@@ -12562,20 +12459,12 @@ dependencies = [
  "quick-xml 0.41.0",
  "subtp",
  "transmux",
- "waterkit-video-core 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-video-core",
 ]
 
 [[package]]
 name = "waterkit-video-core"
 version = "0.1.1"
-dependencies = [
- "thiserror 2.0.20",
-]
-
-[[package]]
-name = "waterkit-video-core"
-version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
 dependencies = [
  "thiserror 2.0.20",
 ]
@@ -12583,7 +12472,6 @@ dependencies = [
 [[package]]
 name = "waterkit-video-player"
 version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
 dependencies = [
  "aes",
  "async-channel",
@@ -12595,18 +12483,17 @@ dependencies = [
  "num-traits",
  "swift-bridge",
  "tracing",
- "waterkit-audio 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
- "waterkit-build 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
- "waterkit-codec 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-audio",
+ "waterkit-build",
+ "waterkit-codec",
  "waterkit-video-container",
- "waterkit-video-core 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-video-core",
  "waterkit-video-streaming",
 ]
 
 [[package]]
 name = "waterkit-video-streaming"
 version = "0.1.1"
-source = "git+https://github.com/water-rs/waterkit.git?branch=dev#8465221f3087b2403f92e1edc0c3ba384a2b3a83"
 dependencies = [
  "async-fs",
  "base64 0.22.1",
@@ -12620,9 +12507,9 @@ dependencies = [
  "quick-m3u8",
  "url",
  "uuid",
- "waterkit-video-core 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-video-core",
  "windows 0.62.2",
- "zenwave 0.6.1",
+ "zenwave 0.5.0",
 ]
 
 [[package]]
@@ -13001,7 +12888,7 @@ dependencies = [
  "tracing-oslog",
  "tracing-panic",
  "tracing-subscriber",
- "waterkit-audio 0.1.1",
+ "waterkit-audio",
  "waterui",
  "waterui-browser-cef",
  "waterui-chromium",
@@ -13220,7 +13107,7 @@ dependencies = [
  "mp4-atom",
  "num-traits",
  "peniko",
- "waterkit-codec 0.1.1",
+ "waterkit-codec",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
@@ -13455,9 +13342,9 @@ dependencies = [
  "hydrolysis-m3",
  "image",
  "tracing",
- "waterkit-codec 0.1.1",
+ "waterkit-codec",
  "waterkit-dialog",
- "waterkit-fs 0.1.1",
+ "waterkit-fs",
  "waterui",
  "waterui-controls",
  "waterui-core",
@@ -13684,8 +13571,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-video-gpu"
-version = "0.3.0"
-source = "git+https://github.com/water-rs/video-gpu?rev=6101fa9daa17aba022e270eb4a0b7c6a0d9e5a79#6101fa9daa17aba022e270eb4a0b7c6a0d9e5a79"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49e265d88476772a1197c05724c69c75bf2a9509619ed25c80406ecced6a8d5e"
 dependencies = [
  "async-channel",
  "executor-core",
@@ -13697,9 +13585,9 @@ dependencies = [
  "shaderloom",
  "tracing",
  "uuid",
- "waterkit-audio 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
- "waterkit-codec 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
- "waterkit-fs 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-audio",
+ "waterkit-codec",
+ "waterkit-fs",
  "waterkit-video",
  "waterui-controls",
  "waterui-core",
@@ -13724,7 +13612,7 @@ dependencies = [
  "peniko",
  "realfft",
  "tracing",
- "waterkit-audio 0.1.1",
+ "waterkit-audio",
  "waterui-core",
  "waterui-graphics",
 ]
@@ -15268,7 +15156,6 @@ dependencies = [
  "async-lock",
  "async-native-tls",
  "async-net",
- "async-tungstenite",
  "base64 0.22.1",
  "cfg_aliases 0.2.2",
  "dirs 6.0.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1208,7 +1208,7 @@ version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.21.3",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -2456,6 +2456,7 @@ dependencies = [
  "ident_case",
  "proc-macro2",
  "quote",
+ "strsim",
  "syn 2.0.119",
 ]
 
@@ -12191,17 +12192,25 @@ name = "waterkit-audio"
 version = "0.1.1"
 dependencies = [
  "async-channel",
+ "cpal 0.18.2",
  "futures",
  "jni 0.22.4",
  "js-sys",
+ "lofty",
  "mpris-server",
+ "ndk",
  "ndk-context",
+ "ndk-sys",
  "num-traits",
+ "rodio",
  "smallvec",
  "smol",
  "swift-bridge",
+ "symphonia-codec-aac",
+ "symphonia-core 0.6.1",
  "tempfile",
  "thiserror 2.0.20",
+ "timestretch",
  "tracing",
  "url",
  "wasm-bindgen",
@@ -12691,8 +12700,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-barcode"
-version = "0.1.0"
-source = "git+https://github.com/water-rs/barcode?rev=68e42866d455d0e2c865c06c1ff39dfc3f9253f4#68e42866d455d0e2c865c06c1ff39dfc3f9253f4"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8272778f774e70d79caf3f0617fa0d8eae5a924a5e409ae4c1a650adfe5845e8"
 dependencies = [
  "barcoders",
  "fast_qr",
@@ -12773,8 +12783,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-canvas"
-version = "0.1.1"
-source = "git+https://github.com/water-rs/canvas?rev=db68b844edba01f307d10021595f43a285ac4274#db68b844edba01f307d10021595f43a285ac4274"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88eed93e8209a01b99d9ea05afc3d526cfa5562530647d1d2f0f85ed88ea8384"
 dependencies = [
  "image",
  "kurbo 0.13.1",
@@ -12787,8 +12798,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-chart"
-version = "0.1.0"
-source = "git+https://github.com/water-rs/chart?rev=6a728447fcd1d7463556e30ef44b3bb3c43d02ca#6a728447fcd1d7463556e30ef44b3bb3c43d02ca"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57b74cdbb85869020a967b8dbb8aa830568bfd7c96a661d96a91aa8a15b2c953"
 dependencies = [
  "bytemuck",
  "nami",
@@ -13198,8 +13210,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-image"
-version = "0.3.0"
-source = "git+https://github.com/water-rs/image?rev=eeb6ca0e4ad159466e413964a16978908539553e#eeb6ca0e4ad159466e413964a16978908539553e"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23c6a200898c40d0f0e00844fa05df08364f6f5c2cbde8273840dba70b664638"
 dependencies = [
  "half",
  "image",
@@ -13207,7 +13220,7 @@ dependencies = [
  "mp4-atom",
  "num-traits",
  "peniko",
- "waterkit-codec 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-codec 0.1.1",
  "waterui-core",
  "waterui-graphics",
  "waterui-layout",
@@ -13366,8 +13379,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-map-gpu"
-version = "0.1.0"
-source = "git+https://github.com/water-rs/map-gpu?rev=4346d0fa542375a82a2b1c3fdabf43cbd20f39bb#4346d0fa542375a82a2b1c3fdabf43cbd20f39bb"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6ebe8918fb04ed8715e0e7d3cf5f8f2e3c339f23868c46204084e8ae01f37e"
 dependencies = [
  "blocking",
  "bytemuck",
@@ -13500,8 +13514,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-particle"
-version = "0.1.0"
-source = "git+https://github.com/water-rs/particle?rev=5e8454d617576ec440af26d26dbb9e9b0da1dba7#5e8454d617576ec440af26d26dbb9e9b0da1dba7"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd8a7ef80baba259509310ecfe1dc74f295b77b91b21f3988af85ed804ce8f29"
 dependencies = [
  "bytemuck",
  "encase",
@@ -13697,8 +13712,9 @@ dependencies = [
 
 [[package]]
 name = "waterui-visualizer"
-version = "0.3.0"
-source = "git+https://github.com/water-rs/visualizer?rev=cfd147e7f5614b2066ba2362f183e6dc333452c3#cfd147e7f5614b2066ba2362f183e6dc333452c3"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7793023c48ec9e8c8f4571989de29343b6af95f1c6c54efaca70d5f0b97b8963"
 dependencies = [
  "async-channel",
  "blocking",
@@ -13708,7 +13724,7 @@ dependencies = [
  "peniko",
  "realfft",
  "tracing",
- "waterkit-audio 0.1.1 (git+https://github.com/water-rs/waterkit.git?branch=dev)",
+ "waterkit-audio 0.1.1",
  "waterui-core",
  "waterui-graphics",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,14 +124,14 @@ waterui-url = { version = "0.3.0", path = "utils/url" }
 waterui-watcher-set = { version = "0.1.0", path = "utils/watcher-set" }
 waterui-text = { version = "0.4.0", path = "components/foundation/text" }
 waterui-media = { version = "0.3.1", path = "components/multimedia/media" }
-waterui-image = "0.3.0"
+waterui-image = "0.4.0"
 waterui-video = { version = "0.3.1", path = "components/multimedia/video" }
 waterui-video-gpu = "0.3.0"
-waterui-visualizer = "0.3.0"
+waterui-visualizer = "0.4.0"
 waterui-form = { version = "0.3.1", path = "components/foundation/form" }
 waterui-controls = { version = "0.3.1", path = "components/foundation/controls"}
 waterui-graphics = { version = "0.4.0", path = "components/visual/graphics", default-features = false }
-waterui-canvas = "0.1.1"
+waterui-canvas = "0.1.2"
 waterui-mermaid = { version = "0.1.0", path = "components/data/mermaid" }
 # Mermaid parsing, semantic model and diagram layout. Consumed from our fork
 # while `typed-layout-projection` is unreleased upstream: `merman-render`'s only
@@ -179,10 +179,10 @@ waterui-backend-core = { version = "0.1.1", path = "backends/core", default-feat
 filtrate = "0.2.0"
 filtrate-core = "0.2.0"
 filtrate-derive = "0.1.0"
-waterui-barcode = "0.1.0"
-waterui-particle = "0.1.0"
-waterui-chart = "0.1.0"
-waterui-map-gpu = "0.1.0"
+waterui-barcode = "0.2.0"
+waterui-particle = "0.1.1"
+waterui-chart = "0.2.0"
+waterui-map-gpu = "0.2.0"
 waterui-assets = { version = "0.1.1", path = "components/assets/runtime" }
 waterui-assets-planner = { version = "0.1.1", path = "components/assets/planner" }
 waterui-assets-macros = { version = "0.1.1", path = "components/assets/macros" }
@@ -452,18 +452,14 @@ waterui-map = { path = "components/data/map" }
 waterui-url = { path = "utils/url" }
 waterui-controls = { path = "components/foundation/controls" }
 waterui-video = { path = "components/multimedia/video" }
-# The eight extracted crates below still require the 0.3 foundation on
-# crates.io. Until they re-release against graphics/text 0.4 (#533) they
-# resolve from the commits on their `dev` branches that carry exactly that
-# bump (the `chore/foundation-0.4` PRs); the entries go away with the version bumps that follow those releases.
-waterui-barcode = { git = "https://github.com/water-rs/barcode", rev = "68e42866d455d0e2c865c06c1ff39dfc3f9253f4" }
-waterui-canvas = { git = "https://github.com/water-rs/canvas", rev = "db68b844edba01f307d10021595f43a285ac4274" }
-waterui-chart = { git = "https://github.com/water-rs/chart", rev = "6a728447fcd1d7463556e30ef44b3bb3c43d02ca" }
-waterui-image = { git = "https://github.com/water-rs/image", rev = "eeb6ca0e4ad159466e413964a16978908539553e" }
-waterui-map-gpu = { git = "https://github.com/water-rs/map-gpu", rev = "4346d0fa542375a82a2b1c3fdabf43cbd20f39bb" }
-waterui-particle = { git = "https://github.com/water-rs/particle", rev = "5e8454d617576ec440af26d26dbb9e9b0da1dba7" }
+# The extracted image, visualizer and video-gpu crates depend on the registry
+# waterkit codec/audio crates; resolve those to the kit copies for the same reason.
+waterkit-audio = { path = "kit/multimedia/audio" }
+waterkit-codec = { path = "kit/multimedia/codec" }
+# `waterui-video-gpu` on crates.io still requires the 0.3 foundation; until it
+# re-releases against graphics/text 0.4 (#533) it resolves from the commit on
+# its `dev` branch that carries exactly that bump.
 waterui-video-gpu = { git = "https://github.com/water-rs/video-gpu", rev = "6101fa9daa17aba022e270eb4a0b7c6a0d9e5a79" }
-waterui-visualizer = { git = "https://github.com/water-rs/visualizer", rev = "cfd147e7f5614b2066ba2362f183e6dc333452c3" }
 xcb = { git = "https://github.com/rust-x-bindings/rust-xcb", rev = "ae3b2cd080e78173223038ccbebdc644eaf4a9ad" }
 # `block` 0.1.6 declares the Blocks ABI symbol as an uninhabited extern
 # static. This pinned fork changes only that declaration to the symbol's byte

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ waterui-text = { version = "0.4.0", path = "components/foundation/text" }
 waterui-media = { version = "0.3.1", path = "components/multimedia/media" }
 waterui-image = "0.4.0"
 waterui-video = { version = "0.3.1", path = "components/multimedia/video" }
-waterui-video-gpu = "0.3.0"
+waterui-video-gpu = "0.3.1"
 waterui-visualizer = "0.4.0"
 waterui-form = { version = "0.3.1", path = "components/foundation/form" }
 waterui-controls = { version = "0.3.1", path = "components/foundation/controls"}
@@ -453,13 +453,16 @@ waterui-url = { path = "utils/url" }
 waterui-controls = { path = "components/foundation/controls" }
 waterui-video = { path = "components/multimedia/video" }
 # The extracted image, visualizer and video-gpu crates depend on the registry
-# waterkit codec/audio crates; resolve those to the kit copies for the same reason.
+# waterkit crates; resolve those to the kit copies for the same reason.
 waterkit-audio = { path = "kit/multimedia/audio" }
+waterkit-build = { path = "kit/utils/build" }
+waterkit-fs = { path = "kit/platform/fs" }
 waterkit-codec = { path = "kit/multimedia/codec" }
-# `waterui-video-gpu` on crates.io still requires the 0.3 foundation; until it
-# re-releases against graphics/text 0.4 (#533) it resolves from the commit on
-# its `dev` branch that carries exactly that bump.
-waterui-video-gpu = { git = "https://github.com/water-rs/video-gpu", rev = "6101fa9daa17aba022e270eb4a0b7c6a0d9e5a79" }
+waterkit-video = { path = "kit/multimedia/video" }
+waterkit-video-container = { path = "kit/multimedia/video/container" }
+waterkit-video-core = { path = "kit/multimedia/video/core" }
+waterkit-video-player = { path = "kit/multimedia/video/player" }
+waterkit-video-streaming = { path = "kit/multimedia/video/streaming" }
 xcb = { git = "https://github.com/rust-x-bindings/rust-xcb", rev = "ae3b2cd080e78173223038ccbebdc644eaf4a9ad" }
 # `block` 0.1.6 declares the Blocks ABI symbol as an uninhabited extern
 # static. This pinned fork changes only that declaration to the symbol's byte

--- a/components/data/mermaid/Cargo.toml
+++ b/components/data/mermaid/Cargo.toml
@@ -9,6 +9,11 @@ repository.workspace = true
 description = "Mermaid diagram component for WaterUI, drawn through Scene2D"
 keywords = ["mermaid", "diagram", "flowchart", "waterui"]
 categories = ["gui", "visualization"]
+# `merman-core` / `merman-render` are consumed from the water-rs/merman fork
+# (git, see the root manifest) until upstream releases the typed layout
+# projection; crates.io refuses git-only dependencies, so this crate cannot be
+# published and must not abort the release run for the crates behind it (#533).
+publish = false
 
 [dependencies]
 waterui-core.workspace = true


### PR DESCRIPTION
The eight extracted crates were re-released against graphics/text 0.4 (#533): barcode 0.2.0, canvas 0.1.2, chart 0.2.0, image 0.4.0, map-gpu 0.2.0, particle 0.1.1, visualizer 0.4.0. This bumps their requirements and removes the temporary git patch entries. The registry image and visualizer crates depend on the registry waterkit codec/audio crates, so those two are patched to the kit copies to keep one copy of each in the graph (`cargo check -p waterui` passes locally).

`waterui-mermaid` is marked `publish = false`: crates.io refuses its git-only merman dependencies, and the release run aborting there left cli/dew/gtk/ffi/browsers/icons/inspector/preview unpublished. Only the markdown example depends on it.

video-gpu 0.3.1 is published too (water-rs/video-gpu#3 fixed the Linux segfault that had kept its release workflow from running), so all eight come from the registry. The registry copies pull the registry waterkit crates, so the patch table resolves the whole waterkit set to the kit copies; `cargo tree` then carries exactly one copy of every framework crate.

barcode 0.2.0 carries the Scene2D renderer and the intrinsic scene size, which is what #433 asked this workspace to take.

Fixes #533
Fixes #433