### PR TITLE
ci(release): give the CLI binary legs the tools they build with

### DIFF
--- a/.github/actions/refresh-apt-index/action.yml
+++ b/.github/actions/refresh-apt-index/action.yml
@@ -13,9 +13,21 @@ runs:
   steps:
     - name: Refresh the Ubuntu package index
       shell: bash
-      # Ubuntu 24.04 declares its archive in deb822 form at this path; apt
-      # picks the parser from the `.sources` extension.
-      run: >
-        sudo apt-get update
-        -o Dir::Etc::SourceList=/etc/apt/sources.list.d/ubuntu.sources
-        -o Dir::Etc::SourceParts=/dev/null
+      # Ubuntu 24.04 declares its archive in deb822 form at
+      # `sources.list.d/ubuntu.sources`; 22.04 still uses the one-line
+      # `sources.list`, and the runners here are both. Naming the file that is
+      # not there resolves an empty index instead of failing, so apt then
+      # reports every package as unlocatable and the install step aborts —
+      # which is how the WPE runtime legs of the CLI release died.
+      run: |
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+          list=/etc/apt/sources.list.d/ubuntu.sources
+        elif [ -s /etc/apt/sources.list ]; then
+          list=/etc/apt/sources.list
+        else
+          echo "::error::no Ubuntu archive source file on this runner"
+          exit 1
+        fi
+        sudo apt-get update \
+          -o Dir::Etc::SourceList="$list" \
+          -o Dir::Etc::SourceParts=/dev/null

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -59,7 +59,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
@@ -78,15 +78,17 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install zig (for linux aarch64)
-        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: goto-bus-stop/setup-zig@v2
+      # The CLI links the framework, so a Linux build needs the same native
+      # libraries every other Linux job installs: without VA-API's headers
+      # `cros-libva`'s build script stops the build outright.
+      - uses: ./.github/actions/setup-linux-deps
+        if: runner.os == 'Linux'
 
-      - name: Install cargo-zigbuild (for linux aarch64)
-        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-zigbuild
+      # `shaderloom` compiles WGSL to DXIL through `dxc`, which the Windows
+      # image does not ship.
+      - name: Install DirectX Shader Compiler
+        if: runner.os == 'Windows'
+        uses: tracel-ai/github-actions/install-dxc@295f2fdbae5271f4f8ad56d634e4ff6a95daafc8
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12162,19 +12162,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -12218,7 +12205,7 @@ dependencies = [
  "web-sys",
  "windows 0.62.2",
  "zbus",
- "zenwave 0.5.0",
+ "zenwave",
 ]
 
 [[package]]
@@ -12509,7 +12496,7 @@ dependencies = [
  "uuid",
  "waterkit-video-core",
  "windows 0.62.2",
- "zenwave 0.5.0",
+ "zenwave",
 ]
 
 [[package]]
@@ -12784,7 +12771,7 @@ dependencies = [
  "waterui-preview-protocol",
  "which 8.0.6",
  "whoami",
- "zenwave 0.6.1",
+ "zenwave",
  "zip 8.6.0",
 ]
 
@@ -13300,7 +13287,7 @@ dependencies = [
  "waterui-map",
  "waterui-url",
  "wgpu",
- "zenwave 0.6.1",
+ "zenwave",
 ]
 
 [[package]]
@@ -13355,7 +13342,7 @@ dependencies = [
  "waterui-text",
  "waterui-url",
  "waterui-video",
- "zenwave 0.6.1",
+ "zenwave",
 ]
 
 [[package]]
@@ -13555,7 +13542,7 @@ dependencies = [
  "sha2",
  "tracing",
  "waterui-str",
- "zenwave 0.6.1",
+ "zenwave",
 ]
 
 [[package]]
@@ -15098,54 +15085,6 @@ dependencies = [
 
 [[package]]
 name = "zenwave"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f927428f5b87778df87834ecf7543b837733ebd1fa981210153247d9047c1"
-dependencies = [
- "anyhow",
- "async-fs",
- "async-io",
- "async-lock",
- "async-native-tls",
- "async-net",
- "async-tungstenite",
- "base64 0.22.1",
- "block",
- "dirs 6.0.0",
- "dns-lookup",
- "executor-core",
- "futures-channel",
- "futures-io",
- "futures-rustls",
- "futures-util",
- "gloo-timers 0.3.0",
- "http",
- "http-body-util",
- "http-kit",
- "httpdate",
- "hyper",
- "js-sys",
- "native-tls",
- "objc",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "serde",
- "serde_json",
- "thiserror 2.0.20",
- "time",
- "tower-service",
- "tracing",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "zenwave"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcebfb9dc75f253b47fa02ca3116d90c9fde75487e21586133a5d017c645081e"
@@ -15156,6 +15095,7 @@ dependencies = [
  "async-lock",
  "async-native-tls",
  "async-net",
+ "async-tungstenite",
  "base64 0.22.1",
  "cfg_aliases 0.2.2",
  "dirs 6.0.0",
@@ -15187,7 +15127,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 


### PR DESCRIPTION
The 0.2.0 CLI release built one binary out of eight and skipped
`Upload Release Assets`, so the tag carries no download. Each failure is a
tool the job never installed; all three gaps are pre-existing.

* **Linux legs** now run `.github/actions/setup-linux-deps`, the same action
  every other Linux job uses, so `cros-libva` finds VA-API's headers.
* **aarch64-linux** builds natively on `ubuntu-24.04-arm` instead of
  cross-compiling from x86_64, where `pkg-config` refuses to resolve anything.
  The WPE legs of this workflow already run on arm runners.
* **Windows legs** install `dxc` from the same pinned
  `tracel-ai/github-actions/install-dxc` that `windows.yml` and `bench.yml`
  use, so `filtrate` can compile its shaders to DXIL.
* **`refresh-apt-index`** picks the source file the runner actually has:
  24.04's deb822 `ubuntu.sources` when it exists, 22.04's one-line
  `sources.list` otherwise, and an explicit error when neither does. Naming
  the missing file resolved an empty index, which is why both WPE runtime
  legs reported every package as unlocatable.

The remaining leg, `x86_64-apple-darwin`, fails on `Float16` in the codec
kit's Swift sources; water-rs/waterkit#52 fixes that and lands through the
`kit` submodule pin.

Fixes #540
