### PR TITLE
feat(media): let a photo preserve its aspect ratio inside the frame it is given

### DIFF
--- a/components/multimedia/media/src/photo.rs
+++ b/components/multimedia/media/src/photo.rs
@@ -28,7 +28,7 @@ use waterkit_fs::WaterFs;
 use waterui_core::event::{LifeCycle, LifeCycleHook};
 use waterui_core::reactive::signal::IntoComputed;
 use waterui_core::{AnyView, Computed, Environment, Metadata, Retain, Signal, View};
-use waterui_image::{Image, ReactiveImage, ReactiveImageHandle, reactive_image};
+use waterui_image::{ContentMode, Image, ReactiveImage, ReactiveImageHandle, reactive_image};
 use zenwave::{Client, Method};
 
 /// A photo component that displays an image from a URL.
@@ -104,6 +104,16 @@ impl Photo {
     #[must_use]
     pub fn resizable(mut self) -> Self {
         self.content = self.content.resizable();
+        self
+    }
+
+    /// Preserves the decoded picture's aspect ratio inside the bounds the
+    /// parent proposes: [`ContentMode::Fit`] letterboxes, [`ContentMode::Fill`]
+    /// covers the bounds and crops the overflow. Without it a resizable photo
+    /// stretches on both axes independently.
+    #[must_use]
+    pub fn content_mode(mut self, mode: ContentMode) -> Self {
+        self.content = self.content.content_mode(mode);
         self
     }
 

--- a/src/widget/avatar.rs
+++ b/src/widget/avatar.rs
@@ -17,6 +17,8 @@ use unicode_segmentation::UnicodeSegmentation as _;
 use waterui_controls::{IntoLabel, Label};
 use waterui_core::accessibility::{AccessibilityChildren, AccessibilityRole};
 use waterui_core::handler::{AnyViewBuilder, ViewBuilder};
+#[cfg(feature = "media")]
+use waterui_layout::ContentMode;
 use waterui_layout::stack::zstack;
 use waterui_shape::{Circle, PathCommand, Shape, ShapeExt, ShapeKind};
 use waterui_text::Text;
@@ -287,7 +289,13 @@ impl View for Avatar {
         );
 
         #[cfg(feature = "media")]
-        let picture = image.map(|source| AnyView::new(Photo::new(source).resizable()));
+        let picture = image.map(|source| {
+            AnyView::new(
+                Photo::new(source)
+                    .resizable()
+                    .content_mode(ContentMode::Fill),
+            )
+        });
         #[cfg(not(feature = "media"))]
         let picture: Option<AnyView> = None;
 

--- a/tests/avatar.rs
+++ b/tests/avatar.rs
@@ -27,16 +27,29 @@ use waterui_testing::{OffscreenApp, Role, UiBuilder};
 /// the page — which reads in both colour schemes, unlike a light or dark
 /// border, either of which disappears into one of the two backgrounds and
 /// makes a circular clip look like an octagon.
+///
+/// The portrait is wider than it is tall and carries a white disc at its
+/// centre: an avatar that stretched the picture would show that disc as an
+/// ellipse, one that covers and crops keeps it round. Quadrants alone could
+/// not tell the two apart, since both leave their boundaries at the centre.
 fn write_test_portrait(dir: &Path) -> PathBuf {
-    const SIDE: u32 = 240;
+    const WIDTH: u32 = 320;
+    const HEIGHT: u32 = 200;
+    const DISC_RADIUS: f32 = 60.0;
     let path = dir.join("portrait.png");
-    let mut pixels = image::RgbaImage::new(SIDE, SIDE);
+    let mut pixels = image::RgbaImage::new(WIDTH, HEIGHT);
+    let (centre_x, centre_y) = (WIDTH as f32 / 2.0, HEIGHT as f32 / 2.0);
     for (x, y, pixel) in pixels.enumerate_pixels_mut() {
-        *pixel = match (x < SIDE / 2, y < SIDE / 2) {
-            (true, true) => image::Rgba([220, 40, 40, 255]),
-            (false, true) => image::Rgba([40, 160, 60, 255]),
-            (true, false) => image::Rgba([40, 80, 220, 255]),
-            (false, false) => image::Rgba([230, 190, 40, 255]),
+        let (dx, dy) = (x as f32 + 0.5 - centre_x, y as f32 + 0.5 - centre_y);
+        *pixel = if dx.hypot(dy) <= DISC_RADIUS {
+            image::Rgba([255, 255, 255, 255])
+        } else {
+            match (x < WIDTH / 2, y < HEIGHT / 2) {
+                (true, true) => image::Rgba([220, 40, 40, 255]),
+                (false, true) => image::Rgba([40, 160, 60, 255]),
+                (true, false) => image::Rgba([40, 80, 220, 255]),
+                (false, false) => image::Rgba([230, 190, 40, 255]),
+            }
         };
     }
     std::fs::create_dir_all(dir).expect("test portrait directory");
@@ -173,6 +186,7 @@ fn row(url: Url, side: f32, observed: Option<Rc<Cell<bool>>>) -> impl View {
                 let observed = Rc::clone(&observed);
                 Photo::new(watched.clone())
                     .resizable()
+                    .content_mode(ContentMode::Fill)
                     .on_event(move |event: PhotoEvent| {
                         if matches!(event, PhotoEvent::Loaded) {
                             observed.set(true);


### PR DESCRIPTION
`waterui-image` 0.4.0 shipped the content mode this issue asked for, so the
gap left in this tree is that nothing exposes it: `Photo` had no way to pass
one down, and `Avatar` drew every picture with a bare `resizable()`, which
scales both axes independently and stretches a non-square portrait into the
circle.

* `Photo::content_mode` forwards to `ReactiveImage::content_mode`, so any
  component that puts a photo in a fixed frame can ask for fit or fill.
* `Avatar` asks for `ContentMode::Fill`: the picture covers the circle and
  the overflow is cropped, which is what the shape implies.
* The acceptance portrait is now 320x200 with a centred white disc. A
  stretched picture draws that disc as an ellipse and a cover-cropped one
  keeps it round; the four saturated quadrants alone could not tell the two
  apart, because both leave their boundaries at the centre.

Reviewed by eye in both colour schemes from `avatar_gallery_light` and
`avatar_gallery_dark`: the disc is circular at 40 px and at 128 px, the
quadrant boundaries stay centred and axis-aligned, and the circular clip is
clean against both backgrounds.

Fixes #427
