### PR TITLE
docs(ci): say that the pull-request gate runs no tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,19 @@ permissions:
   pull-requests: read
 
 # The pull-request gate (#379); dev pushes use the lint-only dev.yml (#458).
-# It is deliberately the default-features shape on Linux plus the checks a
-# change can break, chosen per change by the `changes` job below. The full
-# matrix — every clippy shape, macOS and Windows, the all-features runs, the
-# macOS suites, coverage, the `cargo hack` sweep — is `nightly.yml`, once a
-# day against `dev`. Nothing is checked less often than daily; nothing a
-# change cannot break waits in front of it.
+# It is a compile-check gate, not a test-certifying one: format and
+# default-features clippy on Linux, plus the checks a change can break, chosen
+# per change by the `changes` job below. Running anything is `test.yml` with
+# `full: false`, and every job in that workflow except `lint` is gated on
+# `full`, so no test executes here — that is the #458 decision, "dev is the
+# compile-checked, not test-certified channel". The tests themselves, every
+# other clippy shape, macOS and Windows, the all-features runs, the macOS
+# suites, the examples, coverage and the `cargo hack` sweep are `nightly.yml`,
+# once a day against `dev`. Nothing is checked less often than daily.
+#
+# So a green gate here says the change compiles and lints, and says nothing
+# about whether it works. A change whose correctness matters is run locally by
+# whoever writes it, and the nightly is what certifies `dev`.
 on:
   # Integration branches only: a branch that also has a PR would otherwise run
   # the whole gate twice for one commit.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,9 +230,9 @@ jobs:
       matrix:
         # Windows is kept in its own workflow because it needs platform-
         # specific exclusions and compile-only CEF coverage; `nightly.yml`
-        # calls it beside this one. macOS is a nightly platform too: the
-        # default-features gate a pull request runs is Linux only.
-        os: ${{ fromJSON(inputs.full && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]') }}
+        # calls it beside this one. This job runs only when `full` is set, so
+        # both platforms are always in the matrix.
+        os: ["ubuntu-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -478,7 +478,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(inputs.full && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]') }}
+        # Gated on `full` like `test` above, so both platforms always run.
+        os: ["ubuntu-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
`ci.yml` and `test.yml` still described the #379 arrangement, in which a
pull request ran the default-features test and example passes on Linux.
The #458 decision moved every test leg to the nightly: in `test.yml`
every job except `lint` is gated on `full`, which only `nightly.yml`
sets. So a pull request has been running format and clippy alone since
then, and the comments said the opposite of what the workflows do.

That is not a theoretical problem. Reading those comments while checking
a pull request of mine today, I took a green gate as evidence that the
Linux test leg had run against the change. It had not, and nothing in the
run said so.

Pre-existing, and no behaviour changes here: the gate keeps doing exactly
what it does now, and this writes it down where the next reader looks,
including the consequence — a green gate says the change compiles and
lints, and the nightly is what certifies `dev`.

The matrix expressions in `test` and `examples` also still chose between
a `full` and a non-`full` platform list underneath a job-level
`if: inputs.full` that makes the second branch unreachable. Both now name
the platforms they actually run on.

`actionlint` is clean on both files.