### PR TITLE
Merge dev: CLI release binaries, avatar cover-crop, CI gate documentation

### DIFF
--- a/.github/actions/refresh-apt-index/action.yml
+++ b/.github/actions/refresh-apt-index/action.yml
@@ -13,9 +13,21 @@ runs:
   steps:
     - name: Refresh the Ubuntu package index
       shell: bash
-      # Ubuntu 24.04 declares its archive in deb822 form at this path; apt
-      # picks the parser from the `.sources` extension.
-      run: >
-        sudo apt-get update
-        -o Dir::Etc::SourceList=/etc/apt/sources.list.d/ubuntu.sources
-        -o Dir::Etc::SourceParts=/dev/null
+      # Ubuntu 24.04 declares its archive in deb822 form at
+      # `sources.list.d/ubuntu.sources`; 22.04 still uses the one-line
+      # `sources.list`, and the runners here are both. Naming the file that is
+      # not there resolves an empty index instead of failing, so apt then
+      # reports every package as unlocatable and the install step aborts —
+      # which is how the WPE runtime legs of the CLI release died.
+      run: |
+        if [ -f /etc/apt/sources.list.d/ubuntu.sources ]; then
+          list=/etc/apt/sources.list.d/ubuntu.sources
+        elif [ -s /etc/apt/sources.list ]; then
+          list=/etc/apt/sources.list
+        else
+          echo "::error::no Ubuntu archive source file on this runner"
+          exit 1
+        fi
+        sudo apt-get update \
+          -o Dir::Etc::SourceList="$list" \
+          -o Dir::Etc::SourceParts=/dev/null

--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -59,7 +59,7 @@ jobs:
           - target: x86_64-unknown-linux-gnu
             os: ubuntu-latest
           - target: aarch64-unknown-linux-gnu
-            os: ubuntu-latest
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
             os: macos-latest
           - target: aarch64-apple-darwin
@@ -78,15 +78,17 @@ jobs:
       - name: Install Rust toolchain
         uses: dtolnay/rust-toolchain@stable
 
-      - name: Install zig (for linux aarch64)
-        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: goto-bus-stop/setup-zig@v2
+      # The CLI links the framework, so a Linux build needs the same native
+      # libraries every other Linux job installs: without VA-API's headers
+      # `cros-libva`'s build script stops the build outright.
+      - uses: ./.github/actions/setup-linux-deps
+        if: runner.os == 'Linux'
 
-      - name: Install cargo-zigbuild (for linux aarch64)
-        if: runner.os == 'Linux' && matrix.target == 'aarch64-unknown-linux-gnu'
-        uses: taiki-e/install-action@v2
-        with:
-          tool: cargo-zigbuild
+      # `shaderloom` compiles WGSL to DXIL through `dxc`, which the Windows
+      # image does not ship.
+      - name: Install DirectX Shader Compiler
+        if: runner.os == 'Windows'
+        uses: tracel-ai/github-actions/install-dxc@295f2fdbae5271f4f8ad56d634e4ff6a95daafc8
 
       - uses: Swatinem/rust-cache@v2
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,12 +7,19 @@ permissions:
   pull-requests: read
 
 # The pull-request gate (#379); dev pushes use the lint-only dev.yml (#458).
-# It is deliberately the default-features shape on Linux plus the checks a
-# change can break, chosen per change by the `changes` job below. The full
-# matrix — every clippy shape, macOS and Windows, the all-features runs, the
-# macOS suites, coverage, the `cargo hack` sweep — is `nightly.yml`, once a
-# day against `dev`. Nothing is checked less often than daily; nothing a
-# change cannot break waits in front of it.
+# It is a compile-check gate, not a test-certifying one: format and
+# default-features clippy on Linux, plus the checks a change can break, chosen
+# per change by the `changes` job below. Running anything is `test.yml` with
+# `full: false`, and every job in that workflow except `lint` is gated on
+# `full`, so no test executes here — that is the #458 decision, "dev is the
+# compile-checked, not test-certified channel". The tests themselves, every
+# other clippy shape, macOS and Windows, the all-features runs, the macOS
+# suites, the examples, coverage and the `cargo hack` sweep are `nightly.yml`,
+# once a day against `dev`. Nothing is checked less often than daily.
+#
+# So a green gate here says the change compiles and lints, and says nothing
+# about whether it works. A change whose correctness matters is run locally by
+# whoever writes it, and the nightly is what certifies `dev`.
 on:
   # Integration branches only: a branch that also has a PR would otherwise run
   # the whole gate twice for one commit.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -230,9 +230,9 @@ jobs:
       matrix:
         # Windows is kept in its own workflow because it needs platform-
         # specific exclusions and compile-only CEF coverage; `nightly.yml`
-        # calls it beside this one. macOS is a nightly platform too: the
-        # default-features gate a pull request runs is Linux only.
-        os: ${{ fromJSON(inputs.full && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]') }}
+        # calls it beside this one. This job runs only when `full` is set, so
+        # both platforms are always in the matrix.
+        os: ["ubuntu-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:
@@ -478,7 +478,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJSON(inputs.full && '["ubuntu-latest", "macos-latest"]' || '["ubuntu-latest"]') }}
+        # Gated on `full` like `test` above, so both platforms always run.
+        os: ["ubuntu-latest", "macos-latest"]
     steps:
       - uses: actions/checkout@v4
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12162,19 +12162,6 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
-dependencies = [
- "futures-util",
- "js-sys",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
-name = "wasm-streams"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d1ec4f6517c9e11ae630e200b2b65d193279042e28edd4a2cda233e46670bbb"
@@ -12218,7 +12205,7 @@ dependencies = [
  "web-sys",
  "windows 0.62.2",
  "zbus",
- "zenwave 0.5.0",
+ "zenwave",
 ]
 
 [[package]]
@@ -12509,7 +12496,7 @@ dependencies = [
  "uuid",
  "waterkit-video-core",
  "windows 0.62.2",
- "zenwave 0.5.0",
+ "zenwave",
 ]
 
 [[package]]
@@ -12784,7 +12771,7 @@ dependencies = [
  "waterui-preview-protocol",
  "which 8.0.6",
  "whoami",
- "zenwave 0.6.1",
+ "zenwave",
  "zip 8.6.0",
 ]
 
@@ -13300,7 +13287,7 @@ dependencies = [
  "waterui-map",
  "waterui-url",
  "wgpu",
- "zenwave 0.6.1",
+ "zenwave",
 ]
 
 [[package]]
@@ -13355,7 +13342,7 @@ dependencies = [
  "waterui-text",
  "waterui-url",
  "waterui-video",
- "zenwave 0.6.1",
+ "zenwave",
 ]
 
 [[package]]
@@ -13555,7 +13542,7 @@ dependencies = [
  "sha2",
  "tracing",
  "waterui-str",
- "zenwave 0.6.1",
+ "zenwave",
 ]
 
 [[package]]
@@ -15098,54 +15085,6 @@ dependencies = [
 
 [[package]]
 name = "zenwave"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "317f927428f5b87778df87834ecf7543b837733ebd1fa981210153247d9047c1"
-dependencies = [
- "anyhow",
- "async-fs",
- "async-io",
- "async-lock",
- "async-native-tls",
- "async-net",
- "async-tungstenite",
- "base64 0.22.1",
- "block",
- "dirs 6.0.0",
- "dns-lookup",
- "executor-core",
- "futures-channel",
- "futures-io",
- "futures-rustls",
- "futures-util",
- "gloo-timers 0.3.0",
- "http",
- "http-body-util",
- "http-kit",
- "httpdate",
- "hyper",
- "js-sys",
- "native-tls",
- "objc",
- "once_cell",
- "rustls",
- "rustls-native-certs",
- "serde",
- "serde_json",
- "thiserror 2.0.20",
- "time",
- "tower-service",
- "tracing",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "wasm-streams 0.4.2",
- "web-sys",
- "webpki-roots 1.0.9",
-]
-
-[[package]]
-name = "zenwave"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dcebfb9dc75f253b47fa02ca3116d90c9fde75487e21586133a5d017c645081e"
@@ -15156,6 +15095,7 @@ dependencies = [
  "async-lock",
  "async-native-tls",
  "async-net",
+ "async-tungstenite",
  "base64 0.22.1",
  "cfg_aliases 0.2.2",
  "dirs 6.0.0",
@@ -15187,7 +15127,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams 0.5.0",
+ "wasm-streams",
  "web-sys",
 ]
 

--- a/components/multimedia/media/src/photo.rs
+++ b/components/multimedia/media/src/photo.rs
@@ -28,7 +28,7 @@ use waterkit_fs::WaterFs;
 use waterui_core::event::{LifeCycle, LifeCycleHook};
 use waterui_core::reactive::signal::IntoComputed;
 use waterui_core::{AnyView, Computed, Environment, Metadata, Retain, Signal, View};
-use waterui_image::{Image, ReactiveImage, ReactiveImageHandle, reactive_image};
+use waterui_image::{ContentMode, Image, ReactiveImage, ReactiveImageHandle, reactive_image};
 use zenwave::{Client, Method};
 
 /// A photo component that displays an image from a URL.
@@ -104,6 +104,16 @@ impl Photo {
     #[must_use]
     pub fn resizable(mut self) -> Self {
         self.content = self.content.resizable();
+        self
+    }
+
+    /// Preserves the decoded picture's aspect ratio inside the bounds the
+    /// parent proposes: [`ContentMode::Fit`] letterboxes, [`ContentMode::Fill`]
+    /// covers the bounds and crops the overflow. Without it a resizable photo
+    /// stretches on both axes independently.
+    #[must_use]
+    pub fn content_mode(mut self, mode: ContentMode) -> Self {
+        self.content = self.content.content_mode(mode);
         self
     }
 

--- a/src/widget/avatar.rs
+++ b/src/widget/avatar.rs
@@ -17,6 +17,8 @@ use unicode_segmentation::UnicodeSegmentation as _;
 use waterui_controls::{IntoLabel, Label};
 use waterui_core::accessibility::{AccessibilityChildren, AccessibilityRole};
 use waterui_core::handler::{AnyViewBuilder, ViewBuilder};
+#[cfg(feature = "media")]
+use waterui_layout::ContentMode;
 use waterui_layout::stack::zstack;
 use waterui_shape::{Circle, PathCommand, Shape, ShapeExt, ShapeKind};
 use waterui_text::Text;
@@ -287,7 +289,13 @@ impl View for Avatar {
         );
 
         #[cfg(feature = "media")]
-        let picture = image.map(|source| AnyView::new(Photo::new(source).resizable()));
+        let picture = image.map(|source| {
+            AnyView::new(
+                Photo::new(source)
+                    .resizable()
+                    .content_mode(ContentMode::Fill),
+            )
+        });
         #[cfg(not(feature = "media"))]
         let picture: Option<AnyView> = None;
 

--- a/tests/avatar.rs
+++ b/tests/avatar.rs
@@ -27,16 +27,29 @@ use waterui_testing::{OffscreenApp, Role, UiBuilder};
 /// the page — which reads in both colour schemes, unlike a light or dark
 /// border, either of which disappears into one of the two backgrounds and
 /// makes a circular clip look like an octagon.
+///
+/// The portrait is wider than it is tall and carries a white disc at its
+/// centre: an avatar that stretched the picture would show that disc as an
+/// ellipse, one that covers and crops keeps it round. Quadrants alone could
+/// not tell the two apart, since both leave their boundaries at the centre.
 fn write_test_portrait(dir: &Path) -> PathBuf {
-    const SIDE: u32 = 240;
+    const WIDTH: u32 = 320;
+    const HEIGHT: u32 = 200;
+    const DISC_RADIUS: f32 = 60.0;
     let path = dir.join("portrait.png");
-    let mut pixels = image::RgbaImage::new(SIDE, SIDE);
+    let mut pixels = image::RgbaImage::new(WIDTH, HEIGHT);
+    let (centre_x, centre_y) = (WIDTH as f32 / 2.0, HEIGHT as f32 / 2.0);
     for (x, y, pixel) in pixels.enumerate_pixels_mut() {
-        *pixel = match (x < SIDE / 2, y < SIDE / 2) {
-            (true, true) => image::Rgba([220, 40, 40, 255]),
-            (false, true) => image::Rgba([40, 160, 60, 255]),
-            (true, false) => image::Rgba([40, 80, 220, 255]),
-            (false, false) => image::Rgba([230, 190, 40, 255]),
+        let (dx, dy) = (x as f32 + 0.5 - centre_x, y as f32 + 0.5 - centre_y);
+        *pixel = if dx.hypot(dy) <= DISC_RADIUS {
+            image::Rgba([255, 255, 255, 255])
+        } else {
+            match (x < WIDTH / 2, y < HEIGHT / 2) {
+                (true, true) => image::Rgba([220, 40, 40, 255]),
+                (false, true) => image::Rgba([40, 160, 60, 255]),
+                (true, false) => image::Rgba([40, 80, 220, 255]),
+                (false, false) => image::Rgba([230, 190, 40, 255]),
+            }
         };
     }
     std::fs::create_dir_all(dir).expect("test portrait directory");
@@ -173,6 +186,7 @@ fn row(url: Url, side: f32, observed: Option<Rc<Cell<bool>>>) -> impl View {
                 let observed = Rc::clone(&observed);
                 Photo::new(watched.clone())
                     .resizable()
+                    .content_mode(ContentMode::Fill)
                     .on_event(move |event: PhotoEvent| {
                         if matches!(event, PhotoEvent::Loaded) {
                             observed.set(true);


### PR DESCRIPTION
Three changes, one of which the next release depends on.

* **#541** repairs `build-cli.yml`. The 0.2.0 release built one binary of
  eight and skipped `Upload Release Assets`: the Linux legs installed no
  native libraries, aarch64 Linux cross-compiled with a `pkg-config` that
  cannot cross, the Windows legs had no `dxc`, and `refresh-apt-index`
  named a source file that does not exist on 22.04, which resolved an
  empty index and took both WPE legs with it. The `kit` submodule also
  moves onto water-rs/waterkit#52, which is what makes the codec kit
  compile for x86_64 macOS. Fixes #540.
* **#542** gives `Photo` a content mode and has `Avatar` ask for
  `ContentMode::Fill`, so a non-square picture is cover-cropped instead
  of stretched. Fixes #427.
* **#543** corrects what `ci.yml` and `test.yml` say about themselves:
  since #458 the pull-request gate runs format and clippy only, and both
  files still described the older arrangement in which it ran tests.

Merging this is what lets the next release actually produce `water`
binaries: the CLI build workflow only runs behind a `waterui-cli-v*` tag,
so the fix has to be on `main` before the release run tags one.