### PR TITLE
fix(tests): keep the avatar portrait's geometry off lossy casts

### DIFF
--- a/tests/avatar.rs
+++ b/tests/avatar.rs
@@ -35,12 +35,12 @@ use waterui_testing::{OffscreenApp, Role, UiBuilder};
 fn write_test_portrait(dir: &Path) -> PathBuf {
     const WIDTH: u32 = 320;
     const HEIGHT: u32 = 200;
-    const DISC_RADIUS: f32 = 60.0;
+    const DISC_RADIUS: f64 = 60.0;
     let path = dir.join("portrait.png");
     let mut pixels = image::RgbaImage::new(WIDTH, HEIGHT);
-    let (centre_x, centre_y) = (WIDTH as f32 / 2.0, HEIGHT as f32 / 2.0);
+    let (centre_x, centre_y) = (f64::from(WIDTH) / 2.0, f64::from(HEIGHT) / 2.0);
     for (x, y, pixel) in pixels.enumerate_pixels_mut() {
-        let (dx, dy) = (x as f32 + 0.5 - centre_x, y as f32 + 0.5 - centre_y);
+        let (dx, dy) = (f64::from(x) + 0.5 - centre_x, f64::from(y) + 0.5 - centre_y);
         *pixel = if dx.hypot(dy) <= DISC_RADIUS {
             image::Rgba([255, 255, 255, 255])
         } else {


### PR DESCRIPTION
The avatar visual acceptance added in #427 builds its test portrait with four `u32 as f32` casts. `cast_precision_loss` is denied across the workspace, so `cargo clippy --all-targets` fails on `tests/avatar.rs`.

It landed green because the per-change gate lints `--lib --bins`; a test target's lints are only reached by the nightly `--all-targets` sweep.

Pixel coordinates and image dimensions are `u32`, which converts into `f64` losslessly, so the disc geometry moves to `f64` and `From` replaces every cast. The portrait it writes is byte-identical.

Verified with `cargo clippy --profile ci-check --workspace --exclude '*-example' --all-targets -- -D warnings`, where these four were the only errors in the workspace.