### PR TITLE
fix(dew): place chrome-carved children at f64, not through an f32 frame

### DIFF
--- a/backends/dew/src/dispatch.rs
+++ b/backends/dew/src/dispatch.rs
@@ -85,6 +85,10 @@ impl RenderContext {
     }
 
     /// A child context placed at `frame` inside this context.
+    ///
+    /// This is the layout path: `frame` is what a measurement pass produced, in
+    /// `f32`, and the child gets its own origin. Chrome that already knows the
+    /// exact region a child must cover uses [`Self::child_in`] instead.
     #[must_use]
     pub fn child(self, frame: LayoutRect) -> Self {
         Self {
@@ -96,6 +100,26 @@ impl RenderContext {
                 f64::from(frame.width()),
                 f64::from(frame.height()),
             ),
+        }
+    }
+
+    /// A child context covering `rect` of this context, at `f64` throughout.
+    ///
+    /// A child is placed by its origin and its extent, so the far edge it
+    /// reaches is the two added back together and the extent has to be exact
+    /// for that to be the edge the caller named. At `f32` it is not: the
+    /// distance between two edges a bar's height apart needs more significant
+    /// bits than an `f32` carries, so a frame rounds it and moves the far edge
+    /// by up to half an ULP — a hairline of page under a bar, or of window
+    /// background between them. At `f64` the same distance is exact with
+    /// twenty-odd bits to spare, which is why chrome that carves its window
+    /// into regions hands them over here rather than rounding them through
+    /// [`Self::child`].
+    #[must_use]
+    pub fn child_in(self, rect: Rect) -> Self {
+        Self {
+            transform: self.transform * Affine::translate((rect.x0, rect.y0)),
+            bounds: Rect::new(0.0, 0.0, rect.width(), rect.height()),
         }
     }
 
@@ -1329,4 +1353,40 @@ const fn placement_rect(bounds: Rect) -> LayoutRect {
 )]
 fn max_width_from_bounds(bounds: Rect) -> Option<f32> {
     (bounds.width() > 0.0).then(|| bounds.width() as f32)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A child reaches the far edge of the region it was given.
+    ///
+    /// The pair is the one the tab bar and its page disagreed over: a bar
+    /// bottom and a seam, both on the `f32` grid. Their distance does not fit
+    /// in an `f32`, so a frame placed the page a hairline short of the bar;
+    /// it fits in an `f64` with room to spare.
+    #[test]
+    fn a_child_reaches_the_far_edge_of_its_region() {
+        const NEAR: f64 = 62.964_000_701_904_3;
+        const FAR: f64 = 207.100_006_103_515_62;
+
+        #[expect(
+            clippy::cast_possible_truncation,
+            reason = "the frame path this replaced is exactly this cast"
+        )]
+        let framed = NEAR + f64::from((FAR - NEAR) as f32);
+        assert_ne!(
+            framed.to_bits(),
+            FAR.to_bits(),
+            "an `f32` extent reaches this edge after all"
+        );
+
+        let painted = RenderContext::root(320.0, 480.0)
+            .child_in(Rect::new(NEAR, NEAR, FAR, FAR))
+            .window_bounds();
+        assert_eq!(painted.x0.to_bits(), NEAR.to_bits());
+        assert_eq!(painted.y0.to_bits(), NEAR.to_bits());
+        assert_eq!(painted.x1.to_bits(), FAR.to_bits());
+        assert_eq!(painted.y1.to_bits(), FAR.to_bits());
+    }
 }

--- a/backends/dew/src/views/mod.rs
+++ b/backends/dew/src/views/mod.rs
@@ -217,16 +217,6 @@ pub fn emit_styled_text(
     crate::text::emit_text_commands(renderer.list_mut(), &layout, transform);
 }
 
-/// A child render context covering the window-coordinate-free local `rect`
-/// within the current widget's bounds.
-pub fn child_in_rect(ctx: RenderContext, rect: Rect) -> RenderContext {
-    use waterui_core::layout::{Point, Rect as LayoutRect};
-    ctx.child(LayoutRect::new(
-        Point::new(to_f32(rect.x0), to_f32(rect.y0)),
-        Size::new(to_f32(rect.width()), to_f32(rect.height())),
-    ))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/backends/dew/src/views/navigation.rs
+++ b/backends/dew/src/views/navigation.rs
@@ -732,20 +732,16 @@ fn render_destination(
     });
     let bottom = entry.chrome.bottom_layout(renderer.state_cell());
 
-    // Where the chrome stops and the content starts is one edge, so it is
-    // computed once — on layout's `f32` grid, the coarser of the two the
-    // backend works in. Painting the bar to its `f64` height and starting the
-    // content at that height narrowed to `f32` describes two edges up to half
-    // an ULP apart, which is a hairline of window background under the bar or a
-    // hairline of content painted beneath it, depending on which way the height
-    // rounds. Invisible while every bar measured to a round number; a title
-    // whose font puts the height off that grid shows it immediately.
-    let top_seam = f64::from(to_f32(
-        bounds.y0 + bar.as_ref().map_or(0.0, |layout| layout.height),
-    ));
-    let bottom_seam = f64::from(to_f32(
-        bounds.y1 - bottom.as_ref().map_or(0.0, |(height, _)| *height),
-    ));
+    // Where the chrome stops and the content starts is one edge, so it is one
+    // number, and the content is placed by its two edges rather than by a frame
+    // — see `RenderContext::child_in`. Painting the bar to its own height and
+    // framing the content from that height describes two edges up to half an
+    // `f32` ULP apart, which is a hairline of window background under the bar
+    // or a hairline of content painted beneath it, depending on which way the
+    // size rounds. Invisible while every bar measured to a round number; a
+    // title whose font puts the height off that grid shows it immediately.
+    let top_seam = bounds.y0 + bar.as_ref().map_or(0.0, |layout| layout.height);
+    let bottom_seam = bounds.y1 - bottom.as_ref().map_or(0.0, |(height, _)| *height);
     if let Some(layout) = &bar {
         let rect = Rect::new(bounds.x0, bounds.y0, bounds.x1, top_seam);
         entry.chrome.render(renderer, ctx, rect, layout);
@@ -754,14 +750,8 @@ fn render_destination(
         let rect = Rect::new(bounds.x0, bottom_seam, bounds.x1, bounds.y1);
         entry.chrome.render_bottom(renderer, ctx, rect, sizes);
     }
-    let content = LayoutRect::new(
-        Point::new(to_f32(bounds.x0), to_f32(top_seam)),
-        Size::new(
-            to_f32(bounds.width()),
-            to_f32((bottom_seam - top_seam).max(0.0)),
-        ),
-    );
-    entry.content.render(renderer, ctx.child(content));
+    let content = Rect::new(bounds.x0, top_seam, bounds.x1, bottom_seam.max(top_seam));
+    entry.content.render(renderer, ctx.child_in(content));
     if renderer.accessibility_enabled() {
         renderer.pop_accessibility_parent();
     }
@@ -1136,19 +1126,12 @@ fn render_split_destination(
         render_destination(
             Some(entry),
             renderer,
-            ctx.child(rect_frame(frame.bounds)),
+            ctx.child_in(frame.bounds),
             frame.show_back,
         );
     } else {
-        placeholder.render(renderer, ctx.child(rect_frame(frame.bounds)));
+        placeholder.render(renderer, ctx.child_in(frame.bounds));
     }
-}
-
-const fn rect_frame(rect: Rect) -> LayoutRect {
-    LayoutRect::new(
-        Point::new(to_f32(rect.x0), to_f32(rect.y0)),
-        Size::new(to_f32(rect.width()), to_f32(rect.height())),
-    )
 }
 
 impl DewNode for SplitNode {
@@ -1174,7 +1157,7 @@ impl DewNode for SplitNode {
 
         let mut dividers = Vec::new();
         if let Some(bounds) = presentation.primary {
-            self.primary.render(renderer, ctx.child(rect_frame(bounds)));
+            self.primary.render(renderer, ctx.child_in(bounds));
             if bounds.x1 < ctx.bounds.x1 {
                 dividers.push(bounds.x1);
             }

--- a/backends/dew/src/views/progress.rs
+++ b/backends/dew/src/views/progress.rs
@@ -11,7 +11,7 @@ use waterui_core::layout::{ProposalSize, Size, StretchAxis, ViewDimensions};
 
 use crate::dispatch::{DewNode, DewRenderer, RenderContext, WatchedSignal, build_node};
 use crate::text::DewState;
-use crate::views::{child_in_rect, to_f32};
+use crate::views::to_f32;
 
 const BAR_HEIGHT: f64 = 4.0;
 const BAR_SPACING: f64 = 6.0;
@@ -102,7 +102,7 @@ impl DewNode for ProgressNode {
                 bounds.x1,
                 (bounds.y0 + label_height).min(bounds.y1),
             );
-            self.label.render(renderer, child_in_rect(ctx, rect));
+            self.label.render(renderer, ctx.child_in(rect));
         }
         let bar_top = bounds.y0 + label_height + if label_height > 0.0 { BAR_SPACING } else { 0.0 };
         let track = Rect::new(bounds.x0, bar_top, bounds.x1, bar_top + BAR_HEIGHT);
@@ -141,7 +141,7 @@ impl DewNode for ProgressNode {
                 bounds.y1,
             );
             if rect.height() > 0.0 {
-                self.value_label.render(renderer, child_in_rect(ctx, rect));
+                self.value_label.render(renderer, ctx.child_in(rect));
             }
         }
     }

--- a/backends/dew/src/views/slider.rs
+++ b/backends/dew/src/views/slider.rs
@@ -16,7 +16,7 @@ use crate::accessibility::ActionTarget;
 use crate::dispatch::{DewNode, DewRenderer, RenderContext, WatchedSignal, build_node};
 use crate::pointer::{PointerHandler, PointerTargetHandle};
 use crate::text::DewState;
-use crate::views::{LabelText, child_in_rect, to_f32};
+use crate::views::{LabelText, to_f32};
 
 const TRACK_HEIGHT: f64 = 4.0;
 const THUMB_RADIUS: f64 = 10.0;
@@ -195,8 +195,7 @@ impl DewNode for SliderNode {
                 bounds.x0 + f64::from(min_size.width),
                 control_bottom,
             );
-            self.min_value_label
-                .render(renderer, child_in_rect(ctx, rect));
+            self.min_value_label.render(renderer, ctx.child_in(rect));
             track_left += f64::from(min_size.width) + LABEL_SPACING;
         }
         if max_size.width > 0.0 {
@@ -206,8 +205,7 @@ impl DewNode for SliderNode {
                 bounds.x1,
                 control_bottom,
             );
-            self.max_value_label
-                .render(renderer, child_in_rect(ctx, rect));
+            self.max_value_label.render(renderer, ctx.child_in(rect));
             track_right -= f64::from(max_size.width) + LABEL_SPACING;
         }
         assert!(

--- a/backends/dew/src/views/tabs.rs
+++ b/backends/dew/src/views/tabs.rs
@@ -478,7 +478,7 @@ impl TabsNode {
         let Page::Open(page) = &mut self.items[selected].page else {
             panic!("the selected dew tab must be opened during the patch phase")
         };
-        page.render(renderer, ctx.child(rect_frame(bounds)));
+        page.render(renderer, ctx.child_in(bounds));
     }
 
     fn render_tab_bar(
@@ -494,20 +494,11 @@ impl TabsNode {
             .fold(0.0_f64, f64::max);
         let desired_height = ITEM_PADDING_Y.mul_add(2.0, tallest).max(MIN_BAR_HEIGHT) + HAIRLINE;
         let bar_height = desired_height.min(bounds.height() / 2.0);
-        // Where the bar stops and the page starts is one edge, so it is decided
-        // once, on layout's `f32` grid — the same contract `navigation.rs`
-        // keeps for its own chrome. The bar is painted in kurbo's `f64` and the
-        // page is framed in `f32`, so an edge left at `f64` and narrowed only on
-        // the page's side describes two positions up to half an ULP apart: a
-        // hairline of page painted under the bar, or a hairline of window
-        // background between them. The bar's height comes from the tallest tab
-        // label, so whether it lands on the `f32` grid is a property of the font.
-        let bar = kurbo::Rect::new(
-            bounds.x0,
-            f64::from(to_f32(bounds.y1 - bar_height)),
-            bounds.x1,
-            bounds.y1,
-        );
+        // Where the bar stops and the page starts is one edge, so it is one
+        // number: the page is placed by its two edges rather than by a frame,
+        // which is what lets both sides name the same position (see
+        // `RenderContext::child_in`).
+        let bar = kurbo::Rect::new(bounds.x0, bounds.y1 - bar_height, bounds.x1, bounds.y1);
         self.render_selected_page(
             renderer,
             ctx,
@@ -598,13 +589,6 @@ impl TabsNode {
             renderer.pop_accessibility_parent();
         }
     }
-}
-
-const fn rect_frame(rect: kurbo::Rect) -> LayoutRect {
-    LayoutRect::new(
-        Point::new(to_f32(rect.x0), to_f32(rect.y0)),
-        Size::new(to_f32(rect.width()), to_f32(rect.height())),
-    )
 }
 
 impl DewNode for TabsNode {


### PR DESCRIPTION
Part of #539: two of the nightly's failing tests are dew's bit-exact seam guards.

```
the page  Rect { y0: 62.9640007019043, y1: 207.10000228881836 }
and the bar Rect { y0: 207.10000610351563, y1: 240.1 }
disagree about the seam
```

## What the seam actually is

Both containers already computed the seam once. What they did with it was describe it twice: the bar was painted to the seam, and the page was handed a frame — an `f32` origin and an `f32` size — carved from the same number.

A child reaches its origin plus its extent, so the extent has to be exact for that to be the edge the caller named. Above, `207.10000610351563 - 62.9640007019043` is `144.13600540161133`; the nearest `f32` is `144.13600158691406`, and added back to the origin it stops `3.8e-6` short. That is a hairline of window background between page and bar, and rounding the other way paints a hairline of page underneath. The distance between two edges a bar's height apart simply needs more significant bits than an `f32` carries.

Snapping the seam to the `f32` grid — what both containers did, with a comment each explaining why — does not close that gap. It only makes whether the gap appears a property of the installed font, which is exactly what the tests observed: both are bit-exact, both pass on macOS, and both fail on Linux. #528 moved the label metrics far enough for the Linux nightly to start failing.

## The fix

`RenderContext::child_in` places a child from the `f64` region itself, where the same distance is exact with twenty-odd bits to spare. Chrome that carves its window into regions has both edges in hand and no longer rounds them into a frame on the way to the child; `RenderContext::child` stays for the layout path, where the frame is what a measurement pass produced.

The two identical copies of `rect_frame` (tabs and navigation) and the `child_in_rect` helper that rounded regions this way go with it.

## Verification

`cargo nextest run -p waterui-dew`: 117 passed, including both seam guards and the new `a_child_reaches_the_far_edge_of_its_region`, which pins the real pair — the `f32` extent misses it, the `f64` extent lands on it. `cargo clippy -p waterui-dew --all-targets -- -D warnings` clean.

The tabs and navigation visual-review exports were read: the title bar, the content and the tab bar meet with no hairline, and content starts below its bar on the root, pushed and tabs screens.
