### PR TITLE
fix(ci): take the CLI release tag from release-plz's report

### DIFF
--- a/.github/actions/release-plz/action.yml
+++ b/.github/actions/release-plz/action.yml
@@ -9,6 +9,13 @@ inputs:
   command:
     description: "`release-pr` or `release`."
     required: true
+outputs:
+  report:
+    description: >-
+      release-plz's own JSON report of what it just did: `releases`, one entry
+      per published package carrying the tag it created, for `release`; `prs`
+      for `release-pr`.
+    value: ${{ steps.run.outputs.report }}
 runs:
   using: composite
   steps:
@@ -23,10 +30,22 @@ runs:
         rev: cc554a52e97e0ee359e45c7801d770895247cf27
         locked: true
     - uses: release-plz/git-config@v0.1.2
+    # `-o json` puts the report on stdout and leaves the progress log on
+    # stderr, so the report is captured without swallowing anything a failure
+    # would print. Asking release-plz what it tagged is the only reliable way
+    # to know: the tags do not land on the commit this job checked out, and a
+    # `git tag --points-at HEAD` guess is what skipped the CLI binary build
+    # for 0.2.1 (#540).
     - name: Run release-plz ${{ inputs.command }}
+      id: run
       shell: bash
-      run: >-
-        release-plz ${{ inputs.command }}
-        --git-token "${GITHUB_TOKEN}"
-        --repo-url "https://github.com/${GITHUB_REPOSITORY}"
-        --forge github
+      run: |
+        set -euo pipefail
+        report="${RUNNER_TEMP}/release-plz-${{ inputs.command }}.json"
+        release-plz ${{ inputs.command }} \
+          --git-token "${GITHUB_TOKEN}" \
+          --repo-url "https://github.com/${GITHUB_REPOSITORY}" \
+          --forge github \
+          -o json > "$report"
+        printf 'report=%s\n' "$(jq -c '.' "$report")" >> "$GITHUB_OUTPUT"
+        jq '.' "$report"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,25 +31,33 @@ jobs:
       # `waterui-image` verify build on the missing `libva-dev`.
       - uses: ./.github/actions/setup-linux-deps
       - uses: ./.github/actions/release-plz
+        id: release_plz
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+      # Read the tag out of release-plz's own report rather than looking for
+      # one on this job's HEAD. The tags do not land there: releasing 0.4.1
+      # created `waterui-cli-v0.2.1` on the release branch's tip, while this
+      # job had the merge commit checked out, so `git tag --points-at HEAD`
+      # found nothing and the binary build skipped for a release that had
+      # published perfectly well (#540).
       - name: Detect CLI release tag
         id: cli_tag
         shell: bash
+        env:
+          REPORT: ${{ steps.release_plz.outputs.report }}
         run: |
           set -euo pipefail
 
-          git fetch --force --tags origin
-          CLI_TAG="$(git tag --points-at HEAD | grep '^waterui-cli-v' | sort -V | tail -n 1 || true)"
+          CLI_TAG="$(jq -r '[.releases[]? | select(.package_name == "waterui-cli") | .tag] | last // ""' <<< "$REPORT")"
 
           echo "cli_tag=${CLI_TAG}" >> "$GITHUB_OUTPUT"
           if [[ -n "${CLI_TAG}" ]]; then
-            echo "Detected CLI tag: ${CLI_TAG}"
+            echo "release-plz released the CLI as ${CLI_TAG}."
           else
-            echo "No waterui-cli-v* tag found on HEAD."
+            echo "release-plz released no waterui-cli this run."
           fi
 
   release-pr:


### PR DESCRIPTION
`Build waterui-cli binaries` was **skipped** for the 0.4.1 release
([run 34627922529](https://github.com/water-rs/waterui/actions/runs/34627922529))
even though release-plz published `waterui-cli` 0.2.1 and pushed its tag. The
release page therefore carried no `water` binary — the same symptom
#540 described, arriving from a different cause after those causes were fixed.

## Cause

The gate on the binary build is `needs.release.outputs.cli_tag != ''`, and the
release job derived that output by looking for a tag on its own checkout:

```bash
CLI_TAG="$(git tag --points-at HEAD | grep '^waterui-cli-v' | sort -V | tail -n 1 || true)"
```

release-plz does not tag that commit. It tagged `waterui-cli-v0.2.1` on
`7716c631`, the tip of the release branch it had merged, while the job had
`main`'s merge commit `d9fd8b77` checked out. `git tag --points-at HEAD` found
nothing, the job logged "No waterui-cli-v* tag found on HEAD", and the gate
stayed shut on a release that had gone through perfectly well. Nothing about
this is specific to 0.4.1: where the tag lands relative to `main`'s tip is
release-plz's business, so any inference from the tree is a guess.

## Fix

Ask release-plz. `release-plz release -o json` prints its own report of what it
released on stdout —

```json
{"releases":[{"package_name":"waterui-cli","prs":[…],"tag":"waterui-cli-v0.2.1","version":"0.2.1"}]}
```

— while its progress log stays on stderr, so capturing one does not swallow the
other. It is the process that computed the tag, which makes it the only source
that knows the tag rather than deducing it.

The composite action now captures that report into a `report` output, and the
release job selects the CLI entry out of it. The same call works for
`release-pr`, whose report is `{"prs":[…]}`: the selector yields the empty
string there, which is already what the gate reads as "no CLI release this
run".

`waterui-cli-v0.2.1`'s binaries were built by dispatching `build-cli.yml`
directly for that tag, so the 0.4.1 release page is whole; this is the repair
so the next one does not need a hand.
