### PR TITLE
fix(ci): stop gating the CLI binaries on a WPE build that has never worked

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -117,6 +117,12 @@ jobs:
             target/distrib/*${{ matrix.target }}*.zip*
             target/distrib/*${{ matrix.target }}*-dist-manifest.json
 
+  # Not on the CLI release's critical path. This build has never once
+  # succeeded (#155) and is allowed up to six hours to fail, so gating the
+  # binaries on it means no `water` binary ever reaches a release page: run
+  # 34631973105 built all six CLI targets and still skipped the upload. The
+  # runtime is an optional add-on for one browser backend, and it publishes
+  # from its own job below once it works.
   browser-runtime-wpe:
     name: Build WPE runtime ${{ matrix.architecture }}
     needs: check
@@ -177,7 +183,7 @@ jobs:
 
   release:
     name: Upload Release Assets
-    needs: [check, build, browser-runtime-wpe]
+    needs: [check, build]
     if: needs.check.outputs.should_build == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -198,25 +204,6 @@ jobs:
           path: target/distrib
           merge-multiple: true
 
-      - name: Download browser runtime artifacts
-        uses: actions/download-artifact@v4
-        with:
-          pattern: browser-runtime-wpe-*
-          path: target/distrib
-          merge-multiple: true
-
-      - name: Generate browser runtime manifest
-        shell: bash
-        env:
-          RELEASE_TAG: ${{ needs.check.outputs.tag }}
-        run: |
-          BASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
-          python3 components/platform/browser-wpe/runtime/generate-manifest.py \
-            --base-url "$BASE_URL" \
-            --output target/distrib/browser-runtime-manifest.json \
-            target/distrib/*.artifact.json
-          find target/distrib -maxdepth 1 -name '*.artifact.json' -delete
-
       - name: Build global release artifacts
         run: dist build --tag "${{ needs.check.outputs.tag }}" --artifacts=global
 
@@ -229,7 +216,6 @@ jobs:
             target/distrib/*.zip
             target/distrib/*.sha256
             target/distrib/sha256.sum
-            target/distrib/browser-runtime-manifest.json
 
       - name: Checkout Homebrew tap
         uses: actions/checkout@v4
@@ -257,3 +243,50 @@ jobs:
           fi
           git commit -m "water ${VERSION}"
           git push
+
+  # The runtime zips and the manifest the CLI resolves them through, appended
+  # to the release the job above already published. Separate because the WPE
+  # build is hours long and has never finished: a release's binaries must not
+  # wait on it, and its absence means only that this CLI version offers no
+  # prebuilt WPE runtime, which `cli/src/browser_runtime.rs` already reports
+  # as a missing manifest.
+  release-browser-runtime:
+    name: Upload WPE runtime assets
+    # `release` is in here for ordering, not for content: both jobs upload to
+    # the same tag, and only one of them may be the one that creates it.
+    needs: [check, browser-runtime-wpe, release]
+    if: needs.check.outputs.should_build == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.check.outputs.tag }}
+          submodules: recursive
+
+      - name: Download browser runtime artifacts
+        uses: actions/download-artifact@v4
+        with:
+          pattern: browser-runtime-wpe-*
+          path: target/distrib
+          merge-multiple: true
+
+      - name: Generate browser runtime manifest
+        shell: bash
+        env:
+          RELEASE_TAG: ${{ needs.check.outputs.tag }}
+        run: |
+          set -euo pipefail
+          BASE_URL="https://github.com/${GITHUB_REPOSITORY}/releases/download/${RELEASE_TAG}"
+          python3 components/platform/browser-wpe/runtime/generate-manifest.py \
+            --base-url "$BASE_URL" \
+            --output target/distrib/browser-runtime-manifest.json \
+            target/distrib/*.artifact.json
+          find target/distrib -maxdepth 1 -name '*.artifact.json' -delete
+
+      - name: Upload assets to release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.check.outputs.tag }}
+          files: |
+            target/distrib/*.zip
+            target/distrib/browser-runtime-manifest.json


### PR DESCRIPTION
`Upload Release Assets` listed `browser-runtime-wpe` in its `needs`, so the
`water` binaries reach a release page only if WebKit's WPE port compiles first.
It never has — #155 catalogues four blockers and the job is still turning up
new ones — and it is allowed 360 minutes to arrive at that answer.

[Run 34631973105](https://github.com/water-rs/waterui/actions/runs/34631973105)
is the demonstration, dispatched for `waterui-cli-v0.2.1`:

| job | result |
| --- | --- |
| Build x86_64/aarch64-unknown-linux-gnu | success |
| Build x86_64/aarch64-apple-darwin | success |
| Build x86_64/aarch64-pc-windows-msvc | success |
| Build WPE runtime x86_64/aarch64 | failure |
| **Upload Release Assets** | **skipped** |

Every binary existed. None of them reached the release. This is the third and
last cause behind "the CLI release ships no binaries" — #540 fixed the build
legs themselves, #556 fixed the tag detection that skipped the workflow
outright, and this is the edge that discards the result.

## The dependency was wrong in both directions

The WPE runtime is an optional add-on for one browser backend. The CLI resolves
it at runtime from a manifest on the release page, and
`cli/src/browser_runtime.rs` already reads a missing manifest as "this CLI
version offers no prebuilt WPE runtime" — which is precisely what every release
to date has in fact said. Meanwhile the CLI's own binaries are the point of the
release and have nothing to do with WebKit.

## Two jobs

- **`release`** needs only `check` and the six build legs. It publishes the
  binaries, the checksums and the Homebrew formula as soon as they are ready.
- **`release-browser-runtime`** waits on the WPE legs and appends the runtime
  zips and their manifest to the same tag if and when that build succeeds. It
  also waits on `release`, because two jobs uploading to one tag must not both
  race to create it.

No coverage is dropped: the WPE legs still run on every CLI release and still
report red until #155 is resolved.
