### PR TITLE
fix(ci): update the Homebrew formula through a pull request, signed

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -227,22 +227,44 @@ jobs:
       - name: Stage dist-generated Homebrew formula
         run: cp target/distrib/water.rb homebrew-water/Formula/water.rb
 
-      - name: Push Homebrew formula update
+      # The tap's `dev` is ruled like every other branch in the organisation:
+      # changes arrive through a pull request and commits carry a verified
+      # signature. A plain `git push` of a locally made commit satisfies
+      # neither and was rejected with GH013 for `waterui-cli-v0.2.1`, failing
+      # the job after the release assets had already gone up. Both rules are
+      # met by going through GitHub rather than around it: this action commits
+      # through the API, which signs, and opens the pull request; the merge
+      # below is an API merge, which signs too.
+      - name: Open the Homebrew formula update
+        id: homebrew
+        uses: peter-evans/create-pull-request@v7
+        with:
+          path: homebrew-water
+          token: ${{ secrets.HOMEBREW_PAT }}
+          sign-commits: true
+          branch: water-${{ needs.check.outputs.version }}
+          delete-branch: true
+          add-paths: Formula/water.rb
+          commit-message: "water ${{ needs.check.outputs.version }}"
+          title: "water ${{ needs.check.outputs.version }}"
+          body: |
+            The formula `dist` generated for
+            [`${{ needs.check.outputs.tag }}`](https://github.com/${{ github.repository }}/releases/tag/${{ needs.check.outputs.tag }}).
+
+      # The formula is generated, so there is nothing here for a human to
+      # review; the pull request exists because the branch rule asks for one.
+      - name: Merge the Homebrew formula update
+        if: steps.homebrew.outputs.pull-request-number
         shell: bash
         env:
-          VERSION: ${{ needs.check.outputs.version }}
+          GH_TOKEN: ${{ secrets.HOMEBREW_PAT }}
+          PR: ${{ steps.homebrew.outputs.pull-request-number }}
         run: |
           set -euo pipefail
-          cd homebrew-water
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git config user.name "github-actions[bot]"
-          git add Formula/water.rb
-          if git diff --cached --quiet; then
-            echo "No Homebrew changes to publish."
-            exit 0
-          fi
-          git commit -m "water ${VERSION}"
-          git push
+          gh pr merge "$PR" \
+            --repo water-rs/homebrew-water \
+            --squash \
+            --delete-branch
 
   # The runtime zips and the manifest the CLI resolves them through, appended
   # to the release the job above already published. Separate because the WPE


### PR DESCRIPTION
With the binaries no longer gated on the WPE build (#558), `Upload Release
Assets` reached its last step for the first time —
[run 34634893231](https://github.com/water-rs/waterui/actions/runs/34634893231),
dispatched for `waterui-cli-v0.2.1` — and was rejected there:

```
remote: error: GH013: Repository rule violations found for refs/heads/dev.
remote: - Changes must be made through a pull request.
remote: - Commits must have verified signatures.
remote:   Found 1 violation:
remote:   f657de911670ad1c3f8347651adad97cb05cfd62
```

`water-rs/homebrew-water`'s `dev` carries the same rulesets as every other
branch in the organisation, and the step did a plain `git push` of a commit
made on the runner, which satisfies neither. The fifteen release assets had
already uploaded by then, so the job failed after its real work was done and
left the tap's formula pointing at an older release — `brew` reads that
branch.

## Fix

Go through GitHub rather than around it.
`peter-evans/create-pull-request` commits through the Contents API, which is
what makes the commit verified, and opens the pull request the branch rule
asks for. The merge is an API merge, signed for the same reason.

The formula is generated by `dist` and contains nothing a human would review,
so the job merges its own pull request rather than leaving one standing open
on a tap users install from. An unchanged formula produces no pull request and
the merge step is skipped — the same no-op the old script spelled out by hand.

`required_approving_review_count` on that ruleset is 0, so the merge needs no
reviewer; what it needed was for the change to be a pull request at all.

This is the last link in the chain that ends at a release page with binaries
on it: #540 fixed the build legs, #556 fixed the tag detection that skipped
the workflow, #558 removed the WPE gate, and this makes the formula follow
them.
