### PR TITLE
fix(ci): stop naming every checksum asset twice in the release upload

### DIFF
--- a/.github/workflows/build-cli.yml
+++ b/.github/workflows/build-cli.yml
@@ -207,12 +207,21 @@ jobs:
       - name: Build global release artifacts
         run: dist build --tag "${{ needs.check.outputs.tag }}" --artifacts=global
 
+      # The patterns must not overlap. `*.tar.*` also matched every
+      # `…tar.xz.sha256`, which `*.sha256` matched again, so each checksum
+      # beside a tarball was listed twice; the action then issued two deletes
+      # for the one existing asset of that name and the second answered
+      # `Not Found`, failing the step. Invisible on a first release, where
+      # there is nothing to delete — and fatal on the re-run that recovers
+      # one. `.tar.xz`, `.tar.gz`, `.zip`, `.sha256` and `sha256.sum` are
+      # disjoint suffixes, so each file is named once.
       - name: Upload assets to release
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ needs.check.outputs.tag }}
           files: |
-            target/distrib/*.tar.*
+            target/distrib/*.tar.xz
+            target/distrib/*.tar.gz
             target/distrib/*.zip
             target/distrib/*.sha256
             target/distrib/sha256.sum


### PR DESCRIPTION
`Upload Release Assets` failed on a re-run for `waterui-cli-v0.2.1`
([run 34637646837](https://github.com/water-rs/waterui/actions/runs/34637646837))
*after* all fifteen assets had uploaded successfully:

```
##[error]Not Found - https://docs.github.com/rest/releases/assets#delete-a-release-asset
```

The cause is our glob list, not the action:

```yaml
target/distrib/*.tar.*     # matches waterui-cli-…tar.xz  AND  …tar.xz.sha256
target/distrib/*.zip
target/distrib/*.sha256    # matches …tar.xz.sha256 a second time
target/distrib/sha256.sum
```

Every checksum sitting beside a tarball was named twice. The action clears an
existing asset before writing the new one, so it issued two deletes for the one
asset of that name; the second found nothing and failed the step. The uploads
that followed all succeeded, which is why the release page is correct and the
job is red.

A first release never sees this — there is nothing to delete. It bites only the
re-run that recovers one, which is precisely when the job has to work. It also
took the Homebrew steps down with it, since they follow in the same job.

`.tar.xz`, `.tar.gz`, `.zip`, `.sha256` and `sha256.sum` are disjoint suffixes
(`sha256.sum` does not end in `.sha256`), so each file is named exactly once
and the `source.tar.gz` pair that `*.tar.*` used to pick up stays covered.
