### PR TITLE
ci: publish to crates.io via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ on:
 permissions:
   contents: write
   pull-requests: write
+  id-token: write
 
 jobs:
   release:
@@ -30,13 +31,18 @@ jobs:
       # `cros-libva` build script, reached through `waterkit-codec`, fails the
       # `waterui-image` verify build on the missing `libva-dev`.
       - uses: ./.github/actions/setup-linux-deps
+      # Mint a short-lived crates.io token from the GitHub OIDC identity
+      # instead of a stored CARGO_REGISTRY_TOKEN (trusted publishing is
+      # configured per crate on crates.io).
+      - uses: rust-lang/crates-io-auth-action@v1
+        id: crates-io-auth
       - uses: ./.github/actions/release-plz
         id: release_plz
         with:
           command: release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.crates-io-auth.outputs.token }}
       # Read the tag out of release-plz's own report rather than looking for
       # one on this job's HEAD. The tags do not land there: releasing 0.4.1
       # created `waterui-cli-v0.2.1` on the release branch's tip, while this
@@ -82,7 +88,6 @@ jobs:
           command: release-pr
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
 
   build-cli:
     name: Build waterui-cli binaries
@@ -93,3 +98,4 @@ jobs:
       tag: ${{ needs.release.outputs.cli_tag }}
     secrets:
       HOMEBREW_PAT: ${{ secrets.HOMEBREW_PAT }}
+


### PR DESCRIPTION
Publish to crates.io via [OIDC trusted publishing](https://crates.io/docs/trusted-publishing) instead of the stored `CARGO_REGISTRY_TOKEN` secret.

- adds `id-token: write` plus a `rust-lang/crates-io-auth-action@v1` step that mints a short-lived publish token from the GitHub OIDC identity
- `release-pr` steps no longer receive the registry token (they never needed it)
- trusted publisher entries for this repository + workflow are already configured on crates.io for every crate this repo publishes

After the next release run verifies, the old `CARGO_REGISTRY_TOKEN` secret can be deleted.