### PR TITLE
fix(cli): say which preview app answered instead of blaming the TCP server

### DIFF
--- a/cli/src/preview/app_client.rs
+++ b/cli/src/preview/app_client.rs
@@ -30,105 +30,67 @@ pub struct PreviewAppClient {
     present_dylibs: HashSet<DylibId>,
 }
 
+/// What probing one or more candidate preview apps produced.
+///
+/// The three-way split is the whole point. "Nothing answered" and "something
+/// answered and is the wrong build" are different failures with different
+/// remedies, and collapsing them into one `None` is what let a stale `water`
+/// binary present itself as a dead TCP server.
+#[derive(Debug)]
+pub enum PreviewProbe {
+    /// An app answered the handshake and is a build this CLI can drive.
+    Connected(PreviewAppClient),
+    /// An app answered and was turned away. The string is the explanation to
+    /// put in front of whoever ran `water preview`.
+    Rejected(String),
+    /// Nothing answered on any candidate address.
+    Silent,
+}
+
+/// Why an app that answered is not one this CLI can drive.
+///
+/// Both halves are reported, because either alone is a half-diagnosis: the
+/// protocol id says the support app and the CLI were built from different
+/// checkouts of the protocol crate, and the runtime fingerprint says they link
+/// different `waterui_core` builds.
+fn describe_incompatible_app(
+    addr: SocketAddr,
+    app: &PreviewProtocolInfo,
+    expected_core: &str,
+) -> String {
+    let mut reasons = Vec::new();
+    if app.build_commit != PREVIEW_PROTOCOL_COMMIT {
+        reasons.push(format!(
+            "  preview protocol: app {}, this CLI {PREVIEW_PROTOCOL_COMMIT}",
+            app.build_commit
+        ));
+    }
+    if app.waterui_core_fingerprint != expected_core {
+        reasons.push(format!(
+            "  runtime: app {}, expected {expected_core}",
+            app.waterui_core_fingerprint
+        ));
+    }
+    format!(
+        "A preview app is listening on {addr} and answering, but it is not a build this `water` \
+         can drive:\n{}\nRebuild whichever of the two is older, so the CLI and the support app \
+         come from one checkout.",
+        reasons.join("\n")
+    )
+}
+
 impl PreviewAppClient {
-    /// Try to connect directly to a known preview app socket address.
-    ///
-    /// # Errors
-    /// Returns an error if the address is unreachable or the preview handshake fails.
-    pub async fn connect_addr(
+    /// Probe a known preview app socket address.
+    pub async fn probe_addr(
         addr: SocketAddr,
         expected_waterui_core_fingerprint: &str,
         expected_platform: PreviewRuntimePlatform,
-    ) -> Result<Self> {
-        Self::connect_to_addr(addr, expected_waterui_core_fingerprint, expected_platform)
-            .await
-            .ok_or_else(|| {
-                color_eyre::eyre::eyre!(
-                    "Could not connect to preview app at {addr} for runtime {expected_waterui_core_fingerprint} on {expected_platform:?}"
-                )
-            })
-    }
-
-    /// Try to connect to a registered local preview app instance.
-    ///
-    /// # Errors
-    /// Returns an error if no matching live registered preview app is found.
-    pub async fn connect_registered(
-        expected_waterui_core_fingerprint: &str,
-        expected_platform: PreviewRuntimePlatform,
-    ) -> Result<Self> {
-        let expected = expected_waterui_core_fingerprint.to_string();
-        let instances = smol::unblock(move || load_registered_instances_sync(&expected)).await?;
-        tracing::info!(
-            instance_count = instances.len(),
-            "Preview loaded matching registered app instances"
-        );
-
-        for instance in instances {
-            tracing::info!(pid = instance.pid, host = %instance.host, port = instance.port, "Preview trying registered app instance");
-            let addr = SocketAddr::new(instance.host, instance.port);
-            if let Some(client) =
-                Self::connect_to_addr(addr, expected_waterui_core_fingerprint, expected_platform)
-                    .await
-            {
-                return Ok(client);
-            }
-        }
-
-        bail!(
-            "Could not connect to a matching registered preview app. Launch a new preview support app for the current runtime."
-        );
-    }
-
-    /// Try to connect to a running preview app.
-    ///
-    /// # Errors
-    /// Returns an error if no preview app is found.
-    pub async fn connect(
-        config: PreviewTcpConfig,
-        expected_waterui_core_fingerprint: &str,
-        expected_platform: PreviewRuntimePlatform,
-    ) -> Result<Self> {
-        for port in config.ports() {
-            if let Some(client) = Self::connect_on_port(
-                config,
-                port,
-                expected_waterui_core_fingerprint,
-                expected_platform,
-            )
-            .await
-            {
-                return Ok(client);
-            }
-        }
-
-        bail!(
-            "Could not connect to preview app. Make sure it is running.\nThe preview app listens on ports {}..={}.",
-            config.port_start,
-            config.ports().end()
-        );
-    }
-
-    async fn connect_on_port(
-        config: PreviewTcpConfig,
-        port: u16,
-        expected_waterui_core_fingerprint: &str,
-        expected_platform: PreviewRuntimePlatform,
-    ) -> Option<Self> {
-        let addr = SocketAddr::new(config.host, port);
-        Self::connect_to_addr(addr, expected_waterui_core_fingerprint, expected_platform).await
-    }
-
-    async fn connect_to_addr(
-        addr: SocketAddr,
-        expected_waterui_core_fingerprint: &str,
-        expected_platform: PreviewRuntimePlatform,
-    ) -> Option<Self> {
+    ) -> PreviewProbe {
         let stream = match connect_with_timeout(addr, connect_timeout()).await {
             Ok(stream) => stream,
             Err(error) => {
                 tracing::warn!("Preview TCP connect failed on {addr}: {error}");
-                return None;
+                return PreviewProbe::Silent;
             }
         };
 
@@ -155,7 +117,7 @@ impl PreviewAppClient {
                     expected_waterui_core_fingerprint,
                     expected_platform,
                 ) {
-                    return Some(client);
+                    return PreviewProbe::Connected(client);
                 }
 
                 tracing::warn!(
@@ -167,6 +129,11 @@ impl PreviewAppClient {
                     expected_platform,
                     PREVIEW_PROTOCOL_COMMIT,
                 );
+                return PreviewProbe::Rejected(describe_incompatible_app(
+                    addr,
+                    &protocol,
+                    expected_waterui_core_fingerprint,
+                ));
             }
             Ok(other) => {
                 tracing::warn!("Preview handshake got unexpected response from {addr}: {other:?}");
@@ -176,7 +143,67 @@ impl PreviewAppClient {
             }
         }
 
-        None
+        PreviewProbe::Silent
+    }
+
+    /// Probe every live registered local preview app instance.
+    ///
+    /// # Errors
+    /// Returns an error if the instance registry cannot be read.
+    pub async fn probe_registered(
+        expected_waterui_core_fingerprint: &str,
+        expected_platform: PreviewRuntimePlatform,
+    ) -> Result<PreviewProbe> {
+        let expected = expected_waterui_core_fingerprint.to_string();
+        let instances = smol::unblock(move || load_registered_instances_sync(&expected)).await?;
+        tracing::info!(
+            instance_count = instances.len(),
+            "Preview loaded matching registered app instances"
+        );
+
+        // An app that answered and was turned away is the one worth reporting:
+        // "nothing is listening" sends a reader to the network, and this is
+        // never the network.
+        let mut rejection = None;
+        for instance in instances {
+            tracing::info!(pid = instance.pid, host = %instance.host, port = instance.port, "Preview trying registered app instance");
+            let addr = SocketAddr::new(instance.host, instance.port);
+            match Self::probe_addr(addr, expected_waterui_core_fingerprint, expected_platform).await
+            {
+                PreviewProbe::Connected(client) => return Ok(PreviewProbe::Connected(client)),
+                PreviewProbe::Rejected(reason) => {
+                    rejection.get_or_insert(reason);
+                }
+                PreviewProbe::Silent => {}
+            }
+        }
+
+        Ok(rejection.map_or(PreviewProbe::Silent, PreviewProbe::Rejected))
+    }
+
+    /// Probe the configured port range for a running preview app.
+    pub async fn probe_ports(
+        config: PreviewTcpConfig,
+        expected_waterui_core_fingerprint: &str,
+        expected_platform: PreviewRuntimePlatform,
+    ) -> PreviewProbe {
+        // Same reasoning as `probe_registered`: an app that answered and was
+        // turned away outranks every silent port, because silence is the
+        // expected state of a port and an answer is the finding.
+        let mut rejection = None;
+        for port in config.ports() {
+            let addr = SocketAddr::new(config.host, port);
+            match Self::probe_addr(addr, expected_waterui_core_fingerprint, expected_platform).await
+            {
+                PreviewProbe::Connected(client) => return PreviewProbe::Connected(client),
+                PreviewProbe::Rejected(reason) => {
+                    rejection.get_or_insert(reason);
+                }
+                PreviewProbe::Silent => {}
+            }
+        }
+
+        rejection.map_or(PreviewProbe::Silent, PreviewProbe::Rejected)
     }
 
     /// Render a view symbol to PNG bytes.
@@ -640,5 +667,44 @@ mod tests {
             "runtime-fingerprint",
             PreviewRuntimePlatform::Macos
         ));
+    }
+
+    #[test]
+    fn rejection_names_both_halves_of_the_mismatch() {
+        let addr: SocketAddr = "127.0.0.1:9123".parse().unwrap();
+        let app = PreviewProtocolInfo {
+            build_commit: "app-protocol-build".to_string(),
+            waterui_core_fingerprint: "app-runtime".to_string(),
+            platform: PreviewRuntimePlatform::Macos,
+        };
+
+        let explanation = describe_incompatible_app(addr, &app, "cli-runtime");
+
+        assert!(explanation.contains("127.0.0.1:9123"), "{explanation}");
+        assert!(explanation.contains("app-protocol-build"), "{explanation}");
+        assert!(
+            explanation.contains(PREVIEW_PROTOCOL_COMMIT),
+            "{explanation}"
+        );
+        assert!(explanation.contains("app-runtime"), "{explanation}");
+        assert!(explanation.contains("cli-runtime"), "{explanation}");
+    }
+
+    #[test]
+    fn rejection_reports_only_the_half_that_differs() {
+        let addr: SocketAddr = "127.0.0.1:9123".parse().unwrap();
+        let app = PreviewProtocolInfo {
+            build_commit: PREVIEW_PROTOCOL_COMMIT.to_string(),
+            waterui_core_fingerprint: "app-runtime".to_string(),
+            platform: PreviewRuntimePlatform::Macos,
+        };
+
+        let explanation = describe_incompatible_app(addr, &app, "cli-runtime");
+
+        assert!(!explanation.contains("preview protocol:"), "{explanation}");
+        assert!(
+            explanation.contains("runtime: app app-runtime"),
+            "{explanation}"
+        );
     }
 }

--- a/cli/src/preview/launcher.rs
+++ b/cli/src/preview/launcher.rs
@@ -16,7 +16,7 @@ use sha2::Digest as _;
 use smol::stream::StreamExt;
 use tracing::{error, info};
 
-use super::app_client::PreviewAppClient;
+use super::app_client::{PreviewAppClient, PreviewProbe};
 use super::inputs::{ProjectInputsFingerprint, project_inputs_fingerprint};
 use super::protocol::DylibId;
 use super::protocol::PreviewPlatform;
@@ -583,20 +583,30 @@ async fn try_connect_existing_preview_app(
     platform: PreviewPlatform,
     sccache_path: Option<PathBuf>,
 ) -> Result<Option<PreviewSession>> {
-    let client = match platform {
-        PreviewPlatform::Macos => connect_existing_macos_preview_app(expected_fingerprint).await?,
+    let probe = match platform {
+        PreviewPlatform::Macos => {
+            PreviewAppClient::probe_registered(expected_fingerprint, PreviewRuntimePlatform::Macos)
+                .await?
+        }
         PreviewPlatform::IosSimulator | PreviewPlatform::Ios | PreviewPlatform::Android => {
-            PreviewAppClient::connect(
+            PreviewAppClient::probe_ports(
                 tcp_config,
                 expected_fingerprint,
                 preview_runtime_platform(platform),
             )
             .await
-            .ok()
         }
     };
-    let Some(client) = client else {
-        return Ok(None);
+    let client = match probe {
+        PreviewProbe::Connected(client) => client,
+        // Not an error here: a support app from another checkout is exactly the
+        // case this function exists to decline, and the caller goes on to launch
+        // one that matches. Saying so keeps the launch from looking unexplained.
+        PreviewProbe::Rejected(reason) => {
+            info!("Not reusing the running preview app: {reason}");
+            return Ok(None);
+        }
+        PreviewProbe::Silent => return Ok(None),
     };
 
     info!("Connected to existing preview app");
@@ -609,16 +619,6 @@ async fn try_connect_existing_preview_app(
         sccache_path,
         runtime_fingerprint: expected_fingerprint.to_string(),
     }))
-}
-
-async fn connect_existing_macos_preview_app(
-    expected_fingerprint: &str,
-) -> Result<Option<PreviewAppClient>> {
-    Ok(
-        PreviewAppClient::connect_registered(expected_fingerprint, PreviewRuntimePlatform::Macos)
-            .await
-            .ok(),
-    )
 }
 
 const fn preview_runtime_platform(platform: PreviewPlatform) -> PreviewRuntimePlatform {
@@ -779,7 +779,17 @@ async fn build_preview_session_from_launch(
 Check the app logs for more information."
             );
         }
-        ConnectionWaitResult::Timeout => {
+        // An app that answered and was turned away is not a connection problem,
+        // and listing connection problems in front of it is how this timeout
+        // once sent two debugging sessions at the network.
+        ConnectionWaitResult::Timeout(Some(rejection)) => {
+            bail!(
+                "Preview app started but no compatible app ever answered within {} seconds.
+{rejection}",
+                STARTUP_DEADLINE.as_secs()
+            );
+        }
+        ConnectionWaitResult::Timeout(None) => {
             bail!(
                 "Preview app is still running after {} seconds but never accepted a connection.
 Possible causes:
@@ -805,7 +815,11 @@ enum ConnectionWaitResult {
     /// App exited without crash.
     Exited,
     /// The app stayed alive but never became reachable before the hang backstop.
-    Timeout,
+    ///
+    /// Carries the explanation of an app that answered and was turned away, when
+    /// one did: that is a different failure from silence and has to be reported
+    /// as itself.
+    Timeout(Option<String>),
 }
 
 /// How long a launched preview app may stay alive without ever becoming reachable.
@@ -857,7 +871,9 @@ async fn wait_for_connection_or_crash(
     };
 
     match ready {
-        ConnectionWaitResult::Timeout => drain_terminal_preview_event(running).await,
+        ConnectionWaitResult::Timeout(rejection) => {
+            drain_terminal_preview_event(running, rejection).await
+        }
         other => other,
     }
 }
@@ -870,17 +886,21 @@ async fn wait_for_registered_preview_ready(
 ) -> ConnectionWaitResult {
     const POLL_INTERVAL: Duration = Duration::from_millis(100);
 
-    if let Some(client) =
-        try_connect_registered_preview(expected_fingerprint, PreviewRuntimePlatform::Macos, start)
-            .await
+    // The one app that answered and was turned away outlives every silent poll:
+    // on timeout it is the only thing here that explains anything.
+    let mut rejection = None;
+
+    match probe_registered_preview(expected_fingerprint, PreviewRuntimePlatform::Macos, start).await
     {
-        return ConnectionWaitResult::Ready(client);
+        PreviewProbe::Connected(client) => return ConnectionWaitResult::Ready(client),
+        PreviewProbe::Rejected(reason) => rejection = Some(reason),
+        PreviewProbe::Silent => {}
     }
 
     let registry_dir = preview_instance_registry_dir();
     if let Err(error) = smol::fs::create_dir_all(&registry_dir).await {
         error!(path = %registry_dir.display(), "Failed to create preview registry dir: {error}");
-        return ConnectionWaitResult::Timeout;
+        return ConnectionWaitResult::Timeout(rejection);
     }
 
     let (event_tx, event_rx) = async_channel::unbounded();
@@ -891,28 +911,26 @@ async fn wait_for_registered_preview_ready(
         Ok(watcher) => watcher,
         Err(error) => {
             error!(path = %registry_dir.display(), "Failed to create preview registry watcher: {error}");
-            return ConnectionWaitResult::Timeout;
+            return ConnectionWaitResult::Timeout(rejection);
         }
     };
     if let Err(error) = watcher.watch(&registry_dir, RecursiveMode::NonRecursive) {
         error!(path = %registry_dir.display(), "Failed to watch preview registry dir: {error}");
-        return ConnectionWaitResult::Timeout;
+        return ConnectionWaitResult::Timeout(rejection);
     }
 
     loop {
-        if let Some(client) = try_connect_registered_preview(
-            expected_fingerprint,
-            PreviewRuntimePlatform::Macos,
-            start,
-        )
-        .await
+        match probe_registered_preview(expected_fingerprint, PreviewRuntimePlatform::Macos, start)
+            .await
         {
-            return ConnectionWaitResult::Ready(client);
+            PreviewProbe::Connected(client) => return ConnectionWaitResult::Ready(client),
+            PreviewProbe::Rejected(reason) => rejection = Some(reason),
+            PreviewProbe::Silent => {}
         }
 
         let remaining = timeout.saturating_sub(start.elapsed());
         if remaining.is_zero() {
-            return ConnectionWaitResult::Timeout;
+            return ConnectionWaitResult::Timeout(rejection);
         }
 
         let sleep = futures::FutureExt::fuse(smol::Timer::after(POLL_INTERVAL.min(remaining)));
@@ -929,6 +947,7 @@ async fn wait_for_registered_preview_ready(
                     expected_fingerprint,
                     PreviewRuntimePlatform::Macos,
                     start,
+                    &mut rejection,
                 )
                 .await
                 {
@@ -941,7 +960,7 @@ async fn wait_for_registered_preview_ready(
                     Ok(Err(error)) => {
                         error!(path = %registry_dir.display(), "Preview registry watcher error: {error}");
                     }
-                    Err(_) => return ConnectionWaitResult::Timeout,
+                    Err(_) => return ConnectionWaitResult::Timeout(rejection),
                 }
             },
             _ = sleep => {}
@@ -958,17 +977,19 @@ async fn wait_for_polled_preview_ready(
     timeout: Duration,
     poll_interval: Duration,
 ) -> ConnectionWaitResult {
+    let mut rejection = None;
+
     loop {
-        if let Some(client) =
-            try_connect_polled_preview(tcp_config, expected_fingerprint, expected_platform, start)
-                .await
+        match probe_polled_preview(tcp_config, expected_fingerprint, expected_platform, start).await
         {
-            return ConnectionWaitResult::Ready(client);
+            PreviewProbe::Connected(client) => return ConnectionWaitResult::Ready(client),
+            PreviewProbe::Rejected(reason) => rejection = Some(reason),
+            PreviewProbe::Silent => {}
         }
 
         let remaining = timeout.saturating_sub(start.elapsed());
         if remaining.is_zero() {
-            return ConnectionWaitResult::Timeout;
+            return ConnectionWaitResult::Timeout(rejection);
         }
 
         let sleep = futures::FutureExt::fuse(smol::Timer::after(poll_interval.min(remaining)));
@@ -983,6 +1004,7 @@ async fn wait_for_polled_preview_ready(
                     expected_fingerprint,
                     expected_platform,
                     start,
+                    &mut rejection,
                 )
                 .await
                 {
@@ -999,36 +1021,43 @@ async fn wait_for_polled_preview_ready(
 /// The probe completes a full protocol handshake, so discarding the client and
 /// reconnecting afterwards would pay for that handshake twice and reopen the window
 /// for the app to go away in between.
-async fn try_connect_registered_preview(
+async fn probe_registered_preview(
     expected_fingerprint: &str,
     expected_platform: PreviewRuntimePlatform,
     start: Instant,
-) -> Option<PreviewAppClient> {
-    let client = PreviewAppClient::connect_registered(expected_fingerprint, expected_platform)
-        .await
-        .ok()?;
-    info!(
-        "Connected to preview app after {}ms",
-        start.elapsed().as_millis()
-    );
-    Some(client)
+) -> PreviewProbe {
+    match PreviewAppClient::probe_registered(expected_fingerprint, expected_platform).await {
+        Ok(PreviewProbe::Connected(client)) => {
+            info!(
+                "Connected to preview app after {}ms",
+                start.elapsed().as_millis()
+            );
+            PreviewProbe::Connected(client)
+        }
+        Ok(other) => other,
+        Err(error) => {
+            error!("Failed to read the preview instance registry: {error}");
+            PreviewProbe::Silent
+        }
+    }
 }
 
 /// Probe the configured port range for a ready preview app, keeping the connection.
-async fn try_connect_polled_preview(
+async fn probe_polled_preview(
     tcp_config: PreviewTcpConfig,
     expected_fingerprint: &str,
     expected_platform: PreviewRuntimePlatform,
     start: Instant,
-) -> Option<PreviewAppClient> {
-    let client = PreviewAppClient::connect(tcp_config, expected_fingerprint, expected_platform)
-        .await
-        .ok()?;
-    info!(
-        "Connected to preview app after {}ms",
-        start.elapsed().as_millis()
-    );
-    Some(client)
+) -> PreviewProbe {
+    let probe =
+        PreviewAppClient::probe_ports(tcp_config, expected_fingerprint, expected_platform).await;
+    if matches!(probe, PreviewProbe::Connected(_)) {
+        info!(
+            "Connected to preview app after {}ms",
+            start.elapsed().as_millis()
+        );
+    }
+    probe
 }
 
 async fn preview_connection_result_from_device_event(
@@ -1036,6 +1065,7 @@ async fn preview_connection_result_from_device_event(
     expected_fingerprint: &str,
     expected_platform: PreviewRuntimePlatform,
     start: Instant,
+    rejection: &mut Option<String>,
 ) -> Option<ConnectionWaitResult> {
     match event? {
         DeviceEvent::Crashed(message) => {
@@ -1051,16 +1081,23 @@ async fn preview_connection_result_from_device_event(
             if level == tracing::Level::ERROR {
                 error!("{message}");
             }
-            if let Some(addr) = parse_preview_listening_addr(&message)
-                && let Ok(client) =
-                    PreviewAppClient::connect_addr(addr, expected_fingerprint, expected_platform)
-                        .await
-            {
-                info!(
-                    "Connected to preview app after {}ms",
-                    start.elapsed().as_millis()
-                );
-                return Some(ConnectionWaitResult::Ready(client));
+            if let Some(addr) = parse_preview_listening_addr(&message) {
+                match PreviewAppClient::probe_addr(addr, expected_fingerprint, expected_platform)
+                    .await
+                {
+                    PreviewProbe::Connected(client) => {
+                        info!(
+                            "Connected to preview app after {}ms",
+                            start.elapsed().as_millis()
+                        );
+                        return Some(ConnectionWaitResult::Ready(client));
+                    }
+                    // The app this launch just started announced its own port and
+                    // is the wrong build: that is the finding, and the wait keeps
+                    // it so the deadline can report it instead of guessing.
+                    PreviewProbe::Rejected(reason) => *rejection = Some(reason),
+                    PreviewProbe::Silent => {}
+                }
             }
             None
         }
@@ -1075,7 +1112,10 @@ fn parse_preview_listening_addr(message: &str) -> Option<SocketAddr> {
     Some(SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port))
 }
 
-async fn drain_terminal_preview_event(running: &mut Pin<Box<Running>>) -> ConnectionWaitResult {
+async fn drain_terminal_preview_event(
+    running: &mut Pin<Box<Running>>,
+    rejection: Option<String>,
+) -> ConnectionWaitResult {
     while let Some(event) = futures_lite::future::poll_once(running.as_mut().next())
         .await
         .flatten()
@@ -1087,7 +1127,7 @@ async fn drain_terminal_preview_event(running: &mut Pin<Box<Running>>) -> Connec
         }
     }
 
-    ConnectionWaitResult::Timeout
+    ConnectionWaitResult::Timeout(rejection)
 }
 
 /// Get the path to the preview support app.

--- a/cli/src/preview/mod.rs
+++ b/cli/src/preview/mod.rs
@@ -13,7 +13,7 @@ mod inputs;
 mod launcher;
 pub mod protocol;
 
-pub use app_client::PreviewAppClient;
+pub use app_client::{PreviewAppClient, PreviewProbe};
 pub use hydrolysis::{
     HydrolysisPreviewEventKind, HydrolysisPreviewPointerButton, HydrolysisPreviewRequest,
     HydrolysisPreviewScenario, HydrolysisPreviewScenarioEvent, HydrolysisPreviewSource,

--- a/components/devtools/preview/protocol/build.rs
+++ b/components/devtools/preview/protocol/build.rs
@@ -32,8 +32,27 @@ fn track_git_commit_inputs(crate_dir: &Path) {
     }
 }
 
+/// The last commit that changed this crate, not the last commit in the tree.
+///
+/// This value is a *protocol* version: the CLI refuses to talk to a support app
+/// whose value differs, because the two would be speaking different wire
+/// formats. Taking the workspace `HEAD` instead made every commit anywhere
+/// declare a new protocol, so a `water` binary built before your last commit
+/// could never preview anything again — the handshake rejected the app it had
+/// just built, retried until the startup backstop, and reported the failure as
+/// a TCP server that would not start.
+///
+/// Runtime compatibility is a separate question and already has an answer:
+/// `waterui_core_fingerprint` carries the package version, the feature set, the
+/// dependency-graph hash and the profile, and the CLI computes what it expects
+/// from the tree at run time rather than baking it in. That is what catches an
+/// app built against a different runtime. This value only has to change when
+/// the protocol does.
 fn resolve_git_commit(crate_dir: &Path) -> Option<String> {
-    git_output(crate_dir, &["rev-parse", "--short=12", "HEAD"])
+    git_output(
+        crate_dir,
+        &["log", "-1", "--format=%h", "--abbrev=12", "--", "."],
+    )
 }
 
 fn resolve_git_path(crate_dir: &Path, name: &str) -> Option<std::path::PathBuf> {


### PR DESCRIPTION
Two defects that together turned a one-line backend bug into two sessions spent inside the launch chain.

**The protocol id churned on every commit.** `PREVIEW_PROTOCOL_COMMIT` was `git rev-parse --short=12 HEAD` of the workspace, so any commit anywhere declared a new preview protocol and an installed `water` could no longer drive a support app built after it. It now comes from the last commit that touched the protocol crate. Runtime compatibility is unaffected — `waterui_core_fingerprint` does that work, computed from the resolved graph at run time.

**The timeout reported a failure that had already been ruled out.** Every probe collapsed into `Option<PreviewAppClient>`, so an app that answered, completed the `Ping` handshake and declared the wrong build was indistinguishable from a silent port. The deadline then printed "the TCP server failed to start / the port range may be blocked / the app is stuck during initialization" about an app that had answered minutes earlier; the real reason lived only in a `tracing::warn!`.

Probing now answers with `PreviewProbe` — `Connected`, `Rejected(String)`, `Silent`. A rejection outranks silence across the whole wait, in the registry walk, the port sweep and the app's own listening-address log line, because silence is a port's expected state and an answer is the finding. The deadline reports it verbatim, naming the address and both halves of the mismatch:

```
Preview app started but no compatible app ever answered within 180 seconds.
A preview app is listening on 127.0.0.1:8730 and answering, but it is not a build this `water` can drive:
  preview protocol: app 3f1c9a2b4d5e, this CLI f09a565b17c5
  runtime: app 9d2e…, expected 41ab…
Rebuild whichever of the two is older, so the CLI and the support app come from one checkout.
```

`connect_addr` / `connect_registered` / `connect` are gone rather than kept beside the probes: every call site ended in `.ok()`, so the eyre wrappers only existed to throw the reason away.

Verified: `cargo clippy -p waterui-cli --all-targets --all-features` clean, and three unit tests over the rejection text (both halves differ, one half differs).

Fixes #564
