### PR TITLE
fix(cli): shape the support app's build cache before writing into it

### DIFF
--- a/cli/src/preview/launcher.rs
+++ b/cli/src/preview/launcher.rs
@@ -1150,7 +1150,14 @@ async fn preview_support_ffi_crate_path() -> Result<PathBuf> {
     smol::fs::create_dir_all(&support_path)
         .await
         .wrap_err("Failed to create the preview support application directory")?;
-    Ok(crate::water_dir::project_build_cache_dir(&support_path)
+    // The cache is brought into shape here, where the path into it is first
+    // handed out, and not left to whoever opens the support project later. A
+    // managed cache built by a different CLI is emptied when its shape is
+    // checked, and the check used to land *after* the preview module had been
+    // written into it: the module was deleted out from under the `cargo
+    // metadata` that reads it, and the first preview after any change to the
+    // CLI failed with a manifest path that does not exist.
+    Ok(crate::water_dir::ensure_project_build_cache(&support_path)
         .await?
         .join("ffi"))
 }


### PR DESCRIPTION
The first `water preview` after any new CLI commit failed:

```
Error:
   0: Failed to resolve user project Cargo metadata with its dev feature
   1: `cargo metadata` exited with an error: error: manifest path
      `…/preview_support/managed_backends/ffi/modules/filter-example-preview-ffi/Cargo.toml`
      does not exist
```

and the identical command succeeded on the second run, which is what made a deterministic ordering bug look flaky.

`scaffold_preview_module` writes the module into the support app's managed build cache at the path `preview_support_ffi_crate_path` hands out — a path that was only *derived*. The cache's shape is checked later, when the same function opens the support project, and a cache recorded against a different `cli_commit` is emptied there:

```
INFO Managed build cache changed shape, cleaning …/preview_support/managed_backends
```

So the order was: write the module, delete the directory holding it, read its manifest. `CLI_COMMIT` is `git rev-parse HEAD`, so this fires once after every commit while working on the CLI and once for every user after every upgrade.

The cache is now brought into shape where the path into it is handed out (`ensure_project_build_cache` rather than `project_build_cache_dir`); the later open finds it already in shape and touches nothing.

Verified by A/B on the real command, not by reasoning: `water preview nested_filter_preview --platform macos --path examples/filter` at the previous CLI commit failed exactly as above, and the first run after this commit — the same cache-shape change, since the commit moves `CLI_COMMIT` — rendered and wrote its PNG.

Fixes #568
