### PR TITLE
build(cli): scaffold against the Apple backend commit the tree pins

### DIFF
--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -28,7 +28,7 @@ waterui-preview-version = "0.1.1"
 waterui-preview-protocol-version = "0.1.0"
 android-kotlin-version = "2.3.21"
 apple-backend-url = "https://github.com/water-rs/apple-backend.git"
-apple-backend-commit = "ceb9c75c147fba2686bf56ab36ad4f1017130657"
+apple-backend-commit = "aa4b418f392b667c7926095e9530d3febd8bb9ae"
 android-backend-url = "https://github.com/water-rs/android-backend.git"
 android-backend-commit = "7153c408ea7b115fc655213d6be57c75741ff3c0"
 

--- a/cli/src/preview/launcher.rs
+++ b/cli/src/preview/launcher.rs
@@ -1150,7 +1150,14 @@ async fn preview_support_ffi_crate_path() -> Result<PathBuf> {
     smol::fs::create_dir_all(&support_path)
         .await
         .wrap_err("Failed to create the preview support application directory")?;
-    Ok(crate::water_dir::project_build_cache_dir(&support_path)
+    // The cache is brought into shape here, where the path into it is first
+    // handed out, and not left to whoever opens the support project later. A
+    // managed cache built by a different CLI is emptied when its shape is
+    // checked, and the check used to land *after* the preview module had been
+    // written into it: the module was deleted out from under the `cargo
+    // metadata` that reads it, and the first preview after any change to the
+    // CLI failed with a manifest path that does not exist.
+    Ok(crate::water_dir::ensure_project_build_cache(&support_path)
         .await?
         .join("ffi"))
 }


### PR DESCRIPTION
#563 moved `backends/apple` to `aa4b418f` — the commit carrying the offscreen-filter occlusion fix — but left `package.metadata.waterui-scaffold.apple-backend-commit` on `ceb9c75c`. `cli/build.rs`'s pin guard has been saying so on every build since:

```
warning: waterui-cli@0.2.0: cli/Cargo.toml `apple-backend-commit` is stale: pinned ceb9c75c…, submodule is at aa4b418f…. A released CLI would scaffold against the pinned commit.
```

That is not cosmetic: a released `water` scaffolds projects against the *pinned* commit, so every user who installs the CLI rather than building it from this tree would have kept the preview hang the submodule bump just fixed. The guard is quiet again with the pin moved.