### PR TITLE
ci: gate pull requests into main so only dev may merge

### DIFF
--- a/.github/workflows/pr-base-gate.yml
+++ b/.github/workflows/pr-base-gate.yml
@@ -5,12 +5,14 @@ on:
     branches: [main]
     types: [opened, reopened, synchronize, edited]
 
-permissions: {}
+permissions:
+  checks: read
 
 jobs:
   verify-source:
     name: PR source gate
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - name: main only accepts merges from dev
         env:
@@ -26,4 +28,44 @@ jobs:
             echo "::error::Pull requests into 'main' are only allowed from 'dev'. Retarget this pull request at 'dev' instead."
             exit 1
           fi
-          echo "'${HEAD_REF}' -> 'main': allowed."
+          echo "'${HEAD_REF}' -> 'main': source branch allowed."
+
+      # This check doubles as the single required check on main: instead of
+      # pinning CI job names in the ruleset (which break on every rename), it
+      # waits for every other check run on the PR's head and merge commits and
+      # goes green only when all of them did.
+      - name: wait for every other check on this PR to go green
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          MERGE_SHA: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          set -euo pipefail
+          deadline=$(( $(date +%s) + 3300 ))
+          while :; do
+            {
+              gh api "repos/${GITHUB_REPOSITORY}/commits/${HEAD_SHA}/check-runs?per_page=100" \
+                --jq '.check_runs[] | [.name, (.conclusion // "pending")] | @tsv'
+              if [ -n "${MERGE_SHA:-}" ] && [ "${MERGE_SHA}" != "null" ]; then
+                gh api "repos/${GITHUB_REPOSITORY}/commits/${MERGE_SHA}/check-runs?per_page=100" \
+                  --jq '.check_runs[] | [.name, (.conclusion // "pending")] | @tsv'
+              fi
+            } 2>/dev/null | grep -v '^PR source gate\b' > checks.tsv || true
+
+            if grep -E '\t(failure|cancelled|timed_out|action_required|startup_failure|stale)$' checks.tsv; then
+              echo "::error::a check on this pull request did not pass (see list above)"
+              exit 1
+            fi
+            pending=$(grep -c $'\tpending$' checks.tsv || true)
+            if [ "${pending}" -eq 0 ]; then
+              echo "all checks on this pull request have passed"
+              exit 0
+            fi
+            if [ "$(date +%s)" -gt "${deadline}" ]; then
+              echo "::error::timed out after 55 minutes waiting for ${pending} check(s) to conclude"
+              grep $'\tpending$' checks.tsv
+              exit 1
+            fi
+            echo "waiting on ${pending} check(s)..."
+            sleep 30
+          done

--- a/.github/workflows/pr-base-gate.yml
+++ b/.github/workflows/pr-base-gate.yml
@@ -1,0 +1,29 @@
+name: PR Base Gate
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, reopened, synchronize, edited]
+
+permissions: {}
+
+jobs:
+  verify-source:
+    name: PR source gate
+    runs-on: ubuntu-latest
+    steps:
+      - name: main only accepts merges from dev
+        env:
+          HEAD_REF: ${{ github.event.pull_request.head.ref }}
+          HEAD_REPO: ${{ github.event.pull_request.head.repo.full_name }}
+          BASE_REPO: ${{ github.repository }}
+        run: |
+          if [ "${HEAD_REPO}" != "${BASE_REPO}" ]; then
+            echo "::error::Pull requests into 'main' must come from this repository, not a fork."
+            exit 1
+          fi
+          if [ "${HEAD_REF}" != "dev" ]; then
+            echo "::error::Pull requests into 'main' are only allowed from 'dev'. Retarget this pull request at 'dev' instead."
+            exit 1
+          fi
+          echo "'${HEAD_REF}' -> 'main': allowed."


### PR DESCRIPTION
Adds `.github/workflows/pr-base-gate.yml`: a `pull_request` check that fails unless a PR targeting `main` originates from this repository's `dev` branch. Required as a status check on `main` by the `Require CI checks for main` ruleset.